### PR TITLE
Add ticket status and comments feature

### DIFF
--- a/api/src/main/java/com/example/api/controller/TicketController.java
+++ b/api/src/main/java/com/example/api/controller/TicketController.java
@@ -1,11 +1,9 @@
 package com.example.api.controller;
 
 import com.example.api.models.Ticket;
-import com.example.api.repository.TicketRepository;
+import com.example.api.models.TicketComment;
 import com.example.api.service.TicketService;
-import org.apache.coyote.Response;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.typesense.model.SearchResult;
@@ -19,7 +17,7 @@ public class TicketController {
     private final TicketService ticketService;
 
     @Autowired
-    public TicketController(TicketService ticketService, TicketRepository ticketRepository) {
+    public TicketController(TicketService ticketService) {
         this.ticketService = ticketService;
     }
 
@@ -29,6 +27,13 @@ public class TicketController {
 //        return ticketService.getTickets();
     }
 
+    @GetMapping("/{id}")
+    public ResponseEntity<Ticket> getTicket(@PathVariable int id) {
+        Ticket t = ticketService.getTicket(id);
+        if (t == null) return ResponseEntity.notFound().build();
+        return ResponseEntity.ok(t);
+    }
+
     @PostMapping("/add")
     public ResponseEntity<Ticket> addTicket(@RequestBody Ticket ticket) {
         System.out.println("TicketController: addTicket - method");
@@ -36,6 +41,21 @@ public class TicketController {
         System.out.println("Ticket added with Id: " + addedTicket.getId());
         return ResponseEntity.ok(addedTicket);
 //        return ResponseEntity.ok("Ticket with Id " + addedTicket.getId() + " added successfully");
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Ticket> updateTicket(@PathVariable int id, @RequestBody Ticket ticket) {
+        return ResponseEntity.ok(ticketService.updateTicket(id, ticket));
+    }
+
+    @PostMapping("/{id}/comments")
+    public ResponseEntity<TicketComment> addComment(@PathVariable int id, @RequestBody String comment) {
+        return ResponseEntity.ok(ticketService.addComment(id, comment));
+    }
+
+    @GetMapping("/{id}/comments")
+    public ResponseEntity<List<TicketComment>> getComments(@PathVariable int id, @RequestParam(required = false) Integer count) {
+        return ResponseEntity.ok(ticketService.getComments(id, count));
     }
 
     @PostMapping

--- a/api/src/main/java/com/example/api/enums/TicketStatus.java
+++ b/api/src/main/java/com/example/api/enums/TicketStatus.java
@@ -1,0 +1,8 @@
+package com.example.api.enums;
+
+public enum TicketStatus {
+    Pending,
+    Closed,
+    OnHold,
+    Reopened
+}

--- a/api/src/main/java/com/example/api/models/Ticket.java
+++ b/api/src/main/java/com/example/api/models/Ticket.java
@@ -2,6 +2,7 @@ package com.example.api.models;
 
 import com.example.api.enums.Mode;
 import com.example.api.enums.Priority;
+import com.example.api.enums.TicketStatus;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.Data;
@@ -32,6 +33,8 @@ public class Ticket {
     private String subCategory;
     @Enumerated(EnumType.STRING)
     private Priority priority;
+    @Enumerated(EnumType.STRING)
+    private TicketStatus status;
     @Column(name="attachment_path")
     private String attachmentPath;
     @JsonProperty("isMaster")

--- a/api/src/main/java/com/example/api/models/TicketComment.java
+++ b/api/src/main/java/com/example/api/models/TicketComment.java
@@ -1,0 +1,24 @@
+package com.example.api.models;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "ticket_comments")
+@Data
+public class TicketComment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @ManyToOne
+    @JoinColumn(name = "ticket_id", referencedColumnName = "id")
+    private Ticket ticket;
+
+    private String comment;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+}

--- a/api/src/main/java/com/example/api/repository/TicketCommentRepository.java
+++ b/api/src/main/java/com/example/api/repository/TicketCommentRepository.java
@@ -1,0 +1,13 @@
+package com.example.api.repository;
+
+import com.example.api.models.Ticket;
+import com.example.api.models.TicketComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TicketCommentRepository extends JpaRepository<TicketComment, Integer> {
+    List<TicketComment> findByTicketOrderByCreatedAtDesc(Ticket ticket);
+}

--- a/api/src/main/java/com/example/api/service/TicketService.java
+++ b/api/src/main/java/com/example/api/service/TicketService.java
@@ -2,7 +2,9 @@ package com.example.api.service;
 
 import com.example.api.models.Employee;
 import com.example.api.models.Ticket;
+import com.example.api.models.TicketComment;
 import com.example.api.repository.EmployeeRepository;
+import com.example.api.repository.TicketCommentRepository;
 import com.example.api.repository.TicketRepository;
 import com.example.api.typesense.TypesenseClient;
 import org.springframework.stereotype.Service;
@@ -15,17 +17,24 @@ public class TicketService {
     private final TypesenseClient typesenseClient;
     private final TicketRepository ticketRepository;
     private final EmployeeRepository employeeRepository;
+    private final TicketCommentRepository commentRepository;
 
 
-    public TicketService(TypesenseClient typesenseClient, TicketRepository ticketRepository, EmployeeRepository employeeRepository) {
+    public TicketService(TypesenseClient typesenseClient, TicketRepository ticketRepository,
+                         EmployeeRepository employeeRepository, TicketCommentRepository commentRepository) {
         this.typesenseClient = typesenseClient;
         this.ticketRepository = ticketRepository;
         this.employeeRepository = employeeRepository;
+        this.commentRepository = commentRepository;
     }
 
     public List<Ticket> getTickets() throws Exception {
         System.out.println("Getting tickets...");
         return ticketRepository.findAll();
+    }
+
+    public Ticket getTicket(int id) {
+        return ticketRepository.findById(id).orElse(null);
     }
 
     public Ticket addTicket(Ticket ticket) {
@@ -40,6 +49,34 @@ public class TicketService {
 
     public SearchResult search(String query) throws Exception {
         return typesenseClient.searchTickets(query);
+    }
+
+    public Ticket updateTicket(int id, Ticket updated) {
+        Ticket existing = ticketRepository.findById(id).orElseThrow();
+        existing.setCategory(updated.getCategory());
+        existing.setSubCategory(updated.getSubCategory());
+        existing.setPriority(updated.getPriority());
+        existing.setDescription(updated.getDescription());
+        existing.setAttachmentPath(updated.getAttachmentPath());
+        return ticketRepository.save(existing);
+    }
+
+    public TicketComment addComment(int ticketId, String comment) {
+        Ticket ticket = ticketRepository.findById(ticketId).orElseThrow();
+        TicketComment tc = new TicketComment();
+        tc.setTicket(ticket);
+        tc.setComment(comment);
+        tc.setCreatedAt(java.time.LocalDateTime.now());
+        return commentRepository.save(tc);
+    }
+
+    public List<TicketComment> getComments(int ticketId, Integer count) {
+        Ticket ticket = ticketRepository.findById(ticketId).orElseThrow();
+        List<TicketComment> list = commentRepository.findByTicketOrderByCreatedAtDesc(ticket);
+        if (count == null || count >= list.size()) {
+            return list;
+        }
+        return list.subList(0, count);
     }
 
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -3,6 +3,7 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 import RaiseTicket from './pages/RaiseTicket';
 import AllTickets from './pages/AllTickets';
 import KnowledgeBase from './pages/KnowledgeBase';
+import TicketDetails from './pages/TicketDetails';
 import SidebarLayout from './components/Layout/SidebarLayout';
 
 function App() {
@@ -12,6 +13,7 @@ function App() {
         <Route index element={<Navigate to="/create-ticket" replace />} />
         <Route path="create-ticket" element={<RaiseTicket />} />
         <Route path="tickets" element={<AllTickets />} />
+        <Route path="tickets/:ticketId" element={<TicketDetails />} />
         <Route path="knowledge-base" element={<KnowledgeBase />} />
       </Route>
     </Routes>

--- a/ui/src/components/Title.tsx
+++ b/ui/src/components/Title.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+interface TitleProps {
+    text: string;
+}
+
+const Title: React.FC<TitleProps> = ({ text }) => (
+    <div className="d-flex justify-content-between align-items-center mb-3">
+        <h2 className="m-0">{text}</h2>
+        <div>
+            {/* Global icons placeholder */}
+        </div>
+    </div>
+);
+
+export default Title;

--- a/ui/src/pages/AllTickets.tsx
+++ b/ui/src/pages/AllTickets.tsx
@@ -4,6 +4,8 @@ import { Chip, ToggleButton, ToggleButtonGroup, Card, CardContent, Typography, T
 import { useApi } from "../hooks/useApi";
 import { useDebounce } from "../hooks/useDebounce";
 import { getTickets } from "../services/TicketService";
+import { useNavigate } from "react-router-dom";
+import Title from "../components/Title";
 
 interface Employee {
     name?: string;
@@ -24,6 +26,7 @@ interface Ticket {
 
 const AllTickets: React.FC = () => {
     const { data, pending, error, apiHandler } = useApi<Ticket[]>();
+    const navigate = useNavigate();
     const [search, setSearch] = useState("");
     const [viewMode, setViewMode] = useState<"grid" | "table">("table");
     const [filtered, setFiltered] = useState<Ticket[]>([]);
@@ -109,6 +112,7 @@ const AllTickets: React.FC = () => {
 
     return (
         <div className="container">
+            <Title text="My Tickets" />
             <div className="d-flex justify-content-between align-items-center mb-3">
                 <TextField
                     label="Search by Id or Subject"
@@ -134,13 +138,14 @@ const AllTickets: React.FC = () => {
                     columns={columns}
                     rowKey="id"
                     pagination={{ pageSize: 5 }}
+                    onRow={(record) => ({ onClick: () => navigate(`/tickets/${record.id}`) })}
                 />
             )}
             {!pending && viewMode === "grid" && (
                 <div className="row">
                     {filtered.map((t) => (
                         <div className="col-md-4 mb-3" key={t.id}>
-                            <Card>
+                            <Card onClick={() => navigate(`/tickets/${t.id}`)} style={{cursor:'pointer'}}>
                                 <CardContent>
                                     <Typography variant="h6">
                                         {t.subject}{" "}

--- a/ui/src/pages/KnowledgeBase.tsx
+++ b/ui/src/pages/KnowledgeBase.tsx
@@ -1,9 +1,10 @@
 import React from "react";
+import Title from "../components/Title";
 
 const KnowledgeBase: React.FC = () => {
     return (
         <div className="container mt-4">
-            <h2>Knowledge Base</h2>
+            <Title text="Knowledge Base" />
             {/* Content goes here */}
         </div>
     );

--- a/ui/src/pages/RaiseTicket.tsx
+++ b/ui/src/pages/RaiseTicket.tsx
@@ -4,6 +4,7 @@ import RequestorDetails from "../components/RaiseTicket/RequestorDetails";
 import TicketDetails from "../components/RaiseTicket/TicketDetails";
 import SuccessfulModal from "../components/RaiseTicket/SuccessfulModal";
 import { useState } from "react";
+import Title from "../components/Title";
 import LinkToMasterTicketModal from "../components/RaiseTicket/LinkToMasterTicketModal";
 import GenericButton from "../components/UI/Button";
 import { useApi } from "../hooks/useApi";
@@ -38,7 +39,7 @@ const RaiseTicket: React.FC<any> = () => {
 
     return (
         <div className="container pt-5 px-3">
-            {/* Title */}
+            <Title text="Raise Ticket" />
             <form onSubmit={handleSubmit(onSubmit)}>
                 {/* Request Details */}
                 <RequestDetails register={register} control={control} errors={errors} />

--- a/ui/src/pages/TicketDetails.tsx
+++ b/ui/src/pages/TicketDetails.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { getTicket, updateTicket, addComment, getComments } from "../services/TicketService";
+import { useApi } from "../hooks/useApi";
+import Title from "../components/Title";
+
+interface Ticket {
+    id: number;
+    subject: string;
+    description: string;
+    category: string;
+    subCategory: string;
+    priority: string;
+    status: string;
+}
+
+interface Comment {
+    id: number;
+    comment: string;
+    createdAt: string;
+}
+
+const TicketDetails: React.FC = () => {
+    const { ticketId } = useParams();
+    const { data: ticket, apiHandler } = useApi<Ticket>();
+    const [comments, setComments] = useState<Comment[]>([]);
+    const [commentText, setCommentText] = useState("");
+
+    useEffect(() => {
+        if (ticketId) {
+            apiHandler(() => getTicket(Number(ticketId)));
+            loadComments(5);
+        }
+    }, [ticketId]);
+
+    const loadComments = (count?: number) => {
+        apiHandler(() => getComments(Number(ticketId), count)).then((c: any) => setComments(c));
+    };
+
+    const postComment = () => {
+        if (!commentText) return;
+        apiHandler(() => addComment(Number(ticketId), commentText)).then(() => {
+            setCommentText("");
+            loadComments();
+        });
+    };
+
+    return (
+        <div className="container">
+            <Title text={`Ticket ${ticketId}`} />
+            {ticket && (
+                <div>
+                    <p>Status: {ticket.status}</p>
+                </div>
+            )}
+            <div className="border p-3 mb-3">
+                <textarea
+                    className="form-control mb-2"
+                    value={commentText}
+                    onChange={(e) => setCommentText(e.target.value)}
+                />
+                <button className="btn btn-primary" onClick={postComment}>Post</button>
+            </div>
+            <div>
+                {comments.length === 0 && <p>No comments</p>}
+                {comments.map((c) => (
+                    <div key={c.id} className="border p-2 mb-2">
+                        {c.comment}
+                    </div>
+                ))}
+                {comments.length > 0 && (
+                    <button className="btn btn-link" onClick={() => loadComments()}>Show more</button>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default TicketDetails;

--- a/ui/src/services/TicketService.ts
+++ b/ui/src/services/TicketService.ts
@@ -16,3 +16,22 @@ export function getTickets() {
     console.log("getTickets called");
     return axios.get(`${baseURL}/tickets`);
 }
+
+export function getTicket(id: number) {
+    return axios.get(`${baseURL}/tickets/${id}`);
+}
+
+export function updateTicket(id: number, payload: any) {
+    return axios.put(`${baseURL}/tickets/${id}`, payload);
+}
+
+export function addComment(id: number, comment: string) {
+    return axios.post(`${baseURL}/tickets/${id}/comments`, comment, {
+        headers: { 'Content-Type': 'text/plain' }
+    });
+}
+
+export function getComments(id: number, count?: number) {
+    const url = count ? `${baseURL}/tickets/${id}/comments?count=${count}` : `${baseURL}/tickets/${id}/comments`;
+    return axios.get(url);
+}


### PR DESCRIPTION
## Summary
- add TicketStatus enum and field on Ticket
- create TicketComment entity and repository
- add CRUD endpoints for tickets and comments
- add API methods for comments in the UI
- add Title component and use on pages
- allow navigating to ticket detail via table row or card
- add basic ticket detail page

## Testing
- `npm test` *(fails: Cannot find module 'react-router-dom')*
- `./gradlew test` *(fails: Cannot find a Java installation)*

------
https://chatgpt.com/codex/tasks/task_e_6845ded8f2b883328c6c9242a69dc7a7