### PR TITLE
Add editable ticket form

### DIFF
--- a/ui/src/components/RaiseTicket/RequestDetails.tsx
+++ b/ui/src/components/RaiseTicket/RequestDetails.tsx
@@ -4,13 +4,17 @@ import { FormProps } from "../../types";
 import GenericDropdownController from "../UI/Dropdown/GenericDropdownController";
 import CustomFormInput from "../UI/Input/CustomFormInput";
 
+interface RequestDetailsProps extends FormProps {
+    disableAll?: boolean;
+}
+
 const ticketLodgedThroughDropdownOptions: DropdownOption[] = [
     { label: "Self", value: "Self" },
     { label: "Call", value: "Call" },
     { label: "Mail", value: "Mail" }
 ];
 
-const RequestDetails: React.FC<FormProps> = ({ register, control, errors }) => (
+const RequestDetails: React.FC<RequestDetailsProps> = ({ register, control, errors, disableAll = false }) => (
     <div className={`${cardContainer1}`}>
         {/* title */}
         <p className={`${cardContainer1Header}`}>Request Details</p>
@@ -18,7 +22,14 @@ const RequestDetails: React.FC<FormProps> = ({ register, control, errors }) => (
         <div className="row g-3">
             {/* Ticket ID - Input - System Generated */}
             <div className="col-md-4">
-                <CustomFormInput name="ticketId" register={register} required errors={errors} label="Ticket ID" />
+                <CustomFormInput
+                    name="ticketId"
+                    register={register}
+                    required
+                    errors={errors}
+                    label="Ticket ID"
+                    disabled={disableAll}
+                />
             </div>
             {/* Reported Date - Input - System Generated */}
             <div className="col-md-4">
@@ -38,10 +49,10 @@ const RequestDetails: React.FC<FormProps> = ({ register, control, errors }) => (
                     name="mode"
                     control={control}
                     rules={{ required: true }}
-
                     label="Mode"
                     options={ticketLodgedThroughDropdownOptions}
                     className="form-select"
+                    disabled={disableAll}
                 />
             </div>
         </div>

--- a/ui/src/components/RaiseTicket/RequestorDetails.tsx
+++ b/ui/src/components/RaiseTicket/RequestorDetails.tsx
@@ -11,11 +11,14 @@ import ClearIcon from '@mui/icons-material/Clear';
 
 interface RequestorDetailsProps extends FormProps {
     formData: FieldValues;
+    disableAll?: boolean;
 }
 
-const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, setValue, formData }) => {
+const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, setValue, formData, disableAll = false }) => {
     const [verified, setVerified] = useState<boolean>(false);
     const [disabled, setDisabled] = useState<boolean>(false);
+
+    const isDisabled = disableAll || disabled;
 
     const { data, error, pending, success, apiHandler } = useApi<any>();
 
@@ -74,19 +77,22 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
                         slotProps={{
                             input: {
                                 endAdornment: <InputAdornment position="end">
-                                    {(verified || formData?.employeeId) && <IconButton onClick={clearForm}>
+                                    {(verified || formData?.employeeId) && <IconButton onClick={clearForm} disabled={disableAll}>
                                         <ClearIcon fontSize="small" />
                                     </IconButton>}
                                     <VerifyIconButton
                                         onClick={verifyEmployeeById}
                                         pending={pending}
-                                        verified={verified} />
+                                        verified={verified}
+                                        disabled={disableAll}
+                                    />
                                 </InputAdornment>
                             }
                         }}
                         register={register}
                         errors={errors}
                         required
+                        disabled={isDisabled}
                     />
                 </div>
                 <div className="col-md-4">
@@ -98,7 +104,7 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
                         name="name"
                         register={register}
                         errors={errors}
-                        disabled={disabled}
+                        disabled={isDisabled}
                         required
                     />
                 </div>
@@ -111,7 +117,7 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
                         name="emailId"
                         register={register}
                         errors={errors}
-                        disabled={disabled}
+                        disabled={isDisabled}
                         type="email"
                     />
                 </div>
@@ -124,7 +130,7 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
                         name="mobileNo"
                         register={register}
                         errors={errors}
-                        disabled={disabled}
+                        disabled={isDisabled}
                         type="tel"
                     />
                 </div>
@@ -137,7 +143,7 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
                         name="role"
                         register={register}
                         errors={errors}
-                        disabled={disabled}
+                        disabled={isDisabled}
                     />
                 </div>
                 <div className="col-md-4">
@@ -149,7 +155,7 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
                         name="office"
                         register={register}
                         errors={errors}
-                        disabled={disabled}
+                        disabled={isDisabled}
                     />
                 </div>
             </div>

--- a/ui/src/components/RaiseTicket/TicketDetails.tsx
+++ b/ui/src/components/RaiseTicket/TicketDetails.tsx
@@ -4,6 +4,11 @@ import { DropdownOption } from "../UI/Dropdown/GenericDropdown";
 import GenericDropdownController from "../UI/Dropdown/GenericDropdownController";
 import CustomFormInput from "../UI/Input/CustomFormInput";
 
+interface TicketDetailsProps extends FormProps {
+    disableAll?: boolean;
+    subjectDisabled?: boolean;
+}
+
 const categoryOptions: DropdownOption[] = [
     { label: "Hardware", value: "hardware" },
     { label: "Software", value: "software" },
@@ -22,7 +27,7 @@ const priorityOptions: DropdownOption[] = [
     { label: "High", value: "High" }
 ];
 
-const TicketDetails: React.FC<FormProps> = ({ register, control, errors }) => {
+const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, errors, disableAll = false, subjectDisabled = false }) => {
     return (
         <div className={`${cardContainer1}`}>
             {/* Title */}
@@ -35,6 +40,7 @@ const TicketDetails: React.FC<FormProps> = ({ register, control, errors }) => {
                         label="Category of Ticket"
                         options={categoryOptions}
                         className="form-select"
+                        disabled={disableAll}
                     />
                 </div>
                 <div className="col-md-4 mb-3">
@@ -44,6 +50,7 @@ const TicketDetails: React.FC<FormProps> = ({ register, control, errors }) => {
                         label="Sub-Category"
                         options={subCategoryOptions}
                         className="form-select"
+                        disabled={disableAll}
                     />
                 </div>
                 <div className="col-md-4 mb-3">
@@ -53,6 +60,7 @@ const TicketDetails: React.FC<FormProps> = ({ register, control, errors }) => {
                         label="Priority"
                         options={priorityOptions}
                         className="form-select"
+                        disabled={disableAll}
                     />
                 </div>
                 <div className="col-md-12 mb-3">
@@ -62,6 +70,7 @@ const TicketDetails: React.FC<FormProps> = ({ register, control, errors }) => {
                         register={register}
                         errors={errors}
                         type="text"
+                        disabled={disableAll || subjectDisabled}
                     />
                 </div>
                 <div className="col-md-12 mb-3">
@@ -72,6 +81,7 @@ const TicketDetails: React.FC<FormProps> = ({ register, control, errors }) => {
                         errors={errors}
                         multiline
                         rows={3}
+                        disabled={disableAll}
                     />
                 </div>
                 <div className="col-md-6 d-flex align-items-center">
@@ -86,6 +96,7 @@ const TicketDetails: React.FC<FormProps> = ({ register, control, errors }) => {
                         size="medium"
                         className="form-control"
                         inputProps={{ accept: ".jpg,.jpeg,.png,.pdf" }}
+                        disabled={disableAll}
                     />
                 </div>
             </div>

--- a/ui/src/components/UI/IconButton/VerifyIconButton.tsx
+++ b/ui/src/components/UI/IconButton/VerifyIconButton.tsx
@@ -11,6 +11,7 @@ type VerifyIconButtonProps = {
     onClick?: () => void;
     verified?: boolean;
     pending?: boolean;
+    disabled?: boolean;
 };
 
 const VerifyIconButton: React.FC<VerifyIconButtonProps> = ({
@@ -18,11 +19,12 @@ const VerifyIconButton: React.FC<VerifyIconButtonProps> = ({
     onClick,
     verified,
     pending,
+    disabled,
 }) => {
     return (
         <IconButton
             // onClick={onClick}
-            disabled={pending || verified}
+            disabled={disabled || pending || verified}
             color={verified ? 'success' : 'primary'}
             aria-label="verify"
             disableRipple


### PR DESCRIPTION
## Summary
- allow disabling fields in ticket-related form components
- reuse form components to edit a ticket
- extend VerifyIconButton with `disabled` prop
- make TicketDetails page show editable details and comments

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68467970f9cc83329e5951be0f1e1354