### PR TITLE
Implement document CRUD with soft delete

### DIFF
--- a/api/src/main/java/com/example/api/controller/DocumentController.java
+++ b/api/src/main/java/com/example/api/controller/DocumentController.java
@@ -1,0 +1,40 @@
+package com.example.api.controller;
+
+import com.example.api.models.Document;
+import com.example.api.service.DocumentService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/documents")
+@CrossOrigin(origins = "http://localhost:3000")
+public class DocumentController {
+    private final DocumentService documentService;
+
+    public DocumentController(DocumentService documentService) {
+        this.documentService = documentService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Document>> getDocuments() {
+        return ResponseEntity.ok(documentService.getDocuments());
+    }
+
+    @PostMapping
+    public ResponseEntity<Document> addDocument(@RequestBody Document doc) {
+        return ResponseEntity.ok(documentService.addDocument(doc));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Document> updateDocument(@PathVariable Integer id, @RequestBody Document doc) {
+        return ResponseEntity.ok(documentService.updateDocument(id, doc));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteDocument(@PathVariable Integer id) {
+        documentService.softDeleteDocument(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/api/src/main/java/com/example/api/models/Document.java
+++ b/api/src/main/java/com/example/api/models/Document.java
@@ -1,0 +1,21 @@
+package com.example.api.models;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Entity
+@Table(name = "documents")
+@Data
+public class Document {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private String title;
+    private String description;
+    private String type;
+    @Column(name = "attachment_path")
+    private String attachmentPath;
+    @Column(name = "is_deleted")
+    private boolean isDeleted = false;
+}

--- a/api/src/main/java/com/example/api/repository/DocumentRepository.java
+++ b/api/src/main/java/com/example/api/repository/DocumentRepository.java
@@ -1,0 +1,12 @@
+package com.example.api.repository;
+
+import com.example.api.models.Document;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface DocumentRepository extends JpaRepository<Document, Integer> {
+    List<Document> findByIsDeletedFalse();
+}

--- a/api/src/main/java/com/example/api/service/DocumentService.java
+++ b/api/src/main/java/com/example/api/service/DocumentService.java
@@ -1,0 +1,39 @@
+package com.example.api.service;
+
+import com.example.api.models.Document;
+import com.example.api.repository.DocumentRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class DocumentService {
+    private final DocumentRepository documentRepository;
+
+    public DocumentService(DocumentRepository documentRepository) {
+        this.documentRepository = documentRepository;
+    }
+
+    public List<Document> getDocuments() {
+        return documentRepository.findByIsDeletedFalse();
+    }
+
+    public Document addDocument(Document doc) {
+        return documentRepository.save(doc);
+    }
+
+    public Document updateDocument(Integer id, Document doc) {
+        Document existing = documentRepository.findById(id).orElseThrow();
+        existing.setTitle(doc.getTitle());
+        existing.setDescription(doc.getDescription());
+        existing.setType(doc.getType());
+        existing.setAttachmentPath(doc.getAttachmentPath());
+        return documentRepository.save(existing);
+    }
+
+    public void softDeleteDocument(Integer id) {
+        Document existing = documentRepository.findById(id).orElseThrow();
+        existing.setIsDeleted(true);
+        documentRepository.save(existing);
+    }
+}


### PR DESCRIPTION
## Summary
- add `Document` entity to map to new table `documents`
- implement repository/service/controller for basic CRUD
- support soft deletion via `isDeleted` field

## Testing
- `./gradlew test` *(fails: Could not resolve com.github.typesense:typesense-java:0.2.0)*

------
https://chatgpt.com/codex/tasks/task_e_6846c7a0ee0c8332b58b2556c7b6d6ee