### PR TITLE
Implement category management list and bulk delete

### DIFF
--- a/api/src/main/java/com/example/api/controller/CategoryController.java
+++ b/api/src/main/java/com/example/api/controller/CategoryController.java
@@ -25,6 +25,31 @@ public class CategoryController {
         return ResponseEntity.ok(categoryService.getAllCategories());
     }
 
+    @PostMapping
+    public ResponseEntity<Category> addCategory(@RequestBody Category category) {
+        return ResponseEntity.ok(categoryService.saveCategory(category));
+    }
+
+    @PutMapping("/{categoryId}")
+    public ResponseEntity<Category> updateCategory(@PathVariable Integer categoryId,
+                                                   @RequestBody Category category) {
+        return categoryService.updateCategory(categoryId, category)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{categoryId}")
+    public ResponseEntity<Void> deleteCategory(@PathVariable Integer categoryId) {
+        categoryService.deleteCategory(categoryId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteCategories(@RequestParam List<Integer> ids) {
+        categoryService.deleteCategories(ids);
+        return ResponseEntity.noContent().build();
+    }
+
     @GetMapping("/{categoryId}/sub-categories")
     public ResponseEntity<Set<SubCategoryDto>> getSubCategoriesByCategory(@PathVariable String categoryId) {
         Optional<Set<SubCategoryDto>> subCategoriesOptional = categoryService.getSubCategoriesByCategory(categoryId);

--- a/api/src/main/java/com/example/api/service/CategoryService.java
+++ b/api/src/main/java/com/example/api/service/CategoryService.java
@@ -4,6 +4,7 @@ import com.example.api.dto.SubCategoryDto;
 import com.example.api.models.Category;
 import com.example.api.models.SubCategory;
 import com.example.api.repository.CategoryRepository;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.stereotype.Service;
 
 import java.util.HashSet;
@@ -21,6 +22,27 @@ public class CategoryService {
 
     public List<Category> getAllCategories() {
         return categoryRepository.findAll();
+    }
+
+    public Category saveCategory(Category category) {
+        return categoryRepository.save(category);
+    }
+
+    public Optional<Category> updateCategory(Integer id, Category updated) {
+        return categoryRepository.findById(id)
+                .map(existing -> {
+                    existing.setCategory(updated.getCategory());
+                    return categoryRepository.save(existing);
+                });
+    }
+
+    public void deleteCategory(Integer id) {
+        categoryRepository.deleteById(id);
+    }
+
+    @Transactional
+    public void deleteCategories(List<Integer> ids) {
+        categoryRepository.deleteAllById(ids);
     }
 
     public Optional<Set<SubCategoryDto>> getSubCategoriesByCategory(String categoryId) {

--- a/ui/src/pages/CategoriesMaster.tsx
+++ b/ui/src/pages/CategoriesMaster.tsx
@@ -1,146 +1,87 @@
-import React, { useState } from 'react';
-import { TextField, Chip, IconButton, Stack, Button, Autocomplete, Box } from '@mui/material';
+import React, { useEffect, useState } from 'react';
+import { List, ListItem, Checkbox, IconButton, TextField, Button } from '@mui/material';
 import { Delete, Edit } from '@mui/icons-material';
 import Title from '../components/Title';
+import { useApi } from '../hooks/useApi';
+import { getCategories, addCategory, updateCategory, deleteCategory, deleteCategories } from '../services/CategoryService';
 
 interface Category {
-    name: string;
-    subCategories: string[];
+    categoryId: number;
+    category: string;
 }
 
 const CategoriesMaster: React.FC = () => {
+    const { apiHandler: listApi } = useApi<any>();
+    const { apiHandler: addApi } = useApi<any>();
+    const { apiHandler: updateApi } = useApi<any>();
+    const { apiHandler: deleteApi } = useApi<any>();
+    const { apiHandler: deleteManyApi } = useApi<any>();
+
     const [categories, setCategories] = useState<Category[]>([]);
-    const [selectedCategory, setSelectedCategory] = useState<Category | null>(null);
-    const [categoryInput, setCategoryInput] = useState('');
-    const [subCategoryInput, setSubCategoryInput] = useState('');
-    const [editCategoryName, setEditCategoryName] = useState<string | null>(null);
-    const [editSubCategoryName, setEditSubCategoryName] = useState<string | null>(null);
+    const [editId, setEditId] = useState<number | null>(null);
+    const [name, setName] = useState('');
+    const [selectedIds, setSelectedIds] = useState<number[]>([]);
 
-    const handleAddCategory = () => {
-        const name = categoryInput.trim();
-        if (!name) return;
-        if (editCategoryName) {
-            setCategories(categories.map(c => c.name === editCategoryName ? { ...c, name } : c));
-            setEditCategoryName(null);
-        } else if (!categories.find(c => c.name.toLowerCase() === name.toLowerCase())) {
-            setCategories([...categories, { name, subCategories: [] }]);
+    const load = () => {
+        listApi(getCategories).then((c: any) => setCategories(c));
+    };
+
+    useEffect(() => {
+        load();
+    }, []);
+
+    const handleSave = () => {
+        const value = name.trim();
+        if (!value) return;
+        if (editId !== null) {
+            updateApi(() => updateCategory(editId, { category: value })).then(load);
+            setEditId(null);
+        } else {
+            addApi(() => addCategory({ category: value })).then(load);
         }
-        setCategoryInput('');
+        setName('');
     };
 
-    const handleDeleteCategory = (name: string) => {
-        setCategories(categories.filter(c => c.name !== name));
-        if (selectedCategory?.name === name) setSelectedCategory(null);
+    const handleEdit = (cat: Category) => {
+        setEditId(cat.categoryId);
+        setName(cat.category);
     };
 
-    const handleEditCategory = (cat: Category) => {
-        setEditCategoryName(cat.name);
-        setCategoryInput(cat.name);
-        setSelectedCategory(cat);
+    const handleDelete = (id: number) => {
+        deleteApi(() => deleteCategory(id)).then(load);
     };
 
-    const handleAddSubCategory = () => {
-        if (!selectedCategory) return;
-        const name = subCategoryInput.trim();
-        if (!name) return;
-        setCategories(categories.map(c => {
-            if (c.name !== selectedCategory.name) return c;
-            const exists = c.subCategories.includes(name);
-            let subCategories = c.subCategories;
-            if (editSubCategoryName) {
-                subCategories = subCategories.map(s => s === editSubCategoryName ? name : s);
-            } else if (!exists) {
-                subCategories = [...subCategories, name];
-            }
-            return { ...c, subCategories };
-        }));
-        setSelectedCategory(prev => prev ? {
-            ...prev,
-            subCategories: editSubCategoryName ? prev.subCategories.map(s => s === editSubCategoryName ? name : s) : prev.subCategories.includes(name) ? prev.subCategories : [...prev.subCategories, name]
-        } : null);
-        setEditSubCategoryName(null);
-        setSubCategoryInput('');
+    const toggleSelect = (id: number) => {
+        setSelectedIds(prev => prev.includes(id) ? prev.filter(i => i !== id) : [...prev, id]);
     };
 
-    const handleDeleteSubCategory = (name: string) => {
-        if (!selectedCategory) return;
-        setCategories(categories.map(c => c.name === selectedCategory.name ? { ...c, subCategories: c.subCategories.filter(s => s !== name) } : c));
-        setSelectedCategory(prev => prev ? { ...prev, subCategories: prev.subCategories.filter(s => s !== name) } : null);
-    };
-
-    const handleEditSubCategory = (name: string) => {
-        setEditSubCategoryName(name);
-        setSubCategoryInput(name);
-    };
-
-    const handleSubmit = () => {
-        console.log(categories);
-        alert('Categories saved.');
+    const handleDeleteSelected = () => {
+        deleteManyApi(() => deleteCategories(selectedIds)).then(() => {
+            setSelectedIds([]);
+            load();
+        });
     };
 
     return (
         <div className="container">
             <Title text="Categories Master" />
-            <div className="row mb-4">
-                <div className="col-md-6 mb-3">
-                    <Autocomplete
-                        freeSolo
-                        options={categories.map(c => c.name)}
-                        value={selectedCategory?.name || null}
-                        inputValue={categoryInput}
-                        onInputChange={(_, newInput) => setCategoryInput(newInput)}
-                        onChange={(_, value) => {
-                            const cat = categories.find(c => c.name === value);
-                            setSelectedCategory(cat || null);
-                            if (cat) setCategoryInput(cat.name);
-                        }}
-                        renderInput={(params) => <TextField {...params} label="Category" size="small" />} />
-                    {categoryInput && !categories.find(c => c.name.toLowerCase() === categoryInput.toLowerCase()) && (
-                        <Button className="mt-2" size="small" variant="outlined" onClick={handleAddCategory}>Add as new category</Button>
-                    )}
-                    {/* Category chips below input */}
-                    <Stack direction="row" spacing={1} flexWrap="wrap" className="mt-3 mb-2">
-                        {categories.map(cat => (
-                            <Box key={cat.name} className="d-flex align-items-center me-2 mb-2">
-                                <Chip
-                                    label={cat.name}
-                                    color={selectedCategory?.name === cat.name ? 'primary' : 'default'}
-                                    onClick={() => setSelectedCategory(cat)}
-                                />
-                            </Box>
-                        ))}
-                    </Stack>
-                </div>
-                <div className="col-md-6 mb-3">
-                    <Autocomplete
-                        freeSolo
-                        disabled={!selectedCategory}
-                        options={selectedCategory ? selectedCategory.subCategories : []}
-                        value={null}
-                        inputValue={subCategoryInput}
-                        onInputChange={(_, newInput) => setSubCategoryInput(newInput)}
-                        onChange={(_, value) => {
-                            if (value) setSubCategoryInput(value);
-                        }}
-                        renderInput={(params) => <TextField {...params} label="Sub-Category" size="small" />} />
-                    {subCategoryInput && selectedCategory && !selectedCategory.subCategories.includes(subCategoryInput) && (
-                        <Button className="mt-2" size="small" variant="outlined" onClick={handleAddSubCategory}>Add as new sub-category</Button>
-                    )}
-                    {/* Sub-category chips below input */}
-                    {selectedCategory && (
-                        <Stack direction="row" spacing={1} flexWrap="wrap" className="mt-3 mb-2">
-                            {selectedCategory.subCategories.map(sc => (
-                                <Box key={sc} className="d-flex align-items-center me-2 mb-2">
-                                    <Chip label={sc} />
-                                    {/* <IconButton size="small" onClick={() => handleEditSubCategory(sc)}><Edit fontSize="small" /></IconButton>
-                                    <IconButton size="small" onClick={() => handleDeleteSubCategory(sc)}><Delete fontSize="small" /></IconButton> */}
-                                </Box>
-                            ))}
-                        </Stack>
-                    )}
-                </div>
+            <div className="mb-3">
+                <TextField size="small" label="Category" value={name} onChange={(e) => setName(e.target.value)} sx={{ mr: 2 }} />
+                <Button variant="contained" size="small" onClick={handleSave}>{editId !== null ? 'Update' : 'Add'}</Button>
             </div>
-            <Button variant="contained" onClick={handleSubmit}>Submit</Button>
+            <List>
+                {categories.map(cat => (
+                    <ListItem key={cat.categoryId} sx={{ display: 'flex', alignItems: 'center' }}>
+                        <Checkbox size="small" checked={selectedIds.includes(cat.categoryId)} onChange={() => toggleSelect(cat.categoryId)} />
+                        <span style={{ flexGrow: 1 }}>{cat.category}</span>
+                        <IconButton size="small" onClick={() => handleEdit(cat)}><Edit fontSize="small" /></IconButton>
+                        <IconButton size="small" onClick={() => handleDelete(cat.categoryId)} color="error"><Delete fontSize="small" /></IconButton>
+                    </ListItem>
+                ))}
+            </List>
+            {selectedIds.length > 0 && (
+                <Button variant="outlined" color="error" onClick={handleDeleteSelected}>Delete Selected</Button>
+            )}
         </div>
     );
 };

--- a/ui/src/services/CategoryService.ts
+++ b/ui/src/services/CategoryService.ts
@@ -9,3 +9,21 @@ export function getCategories() {
 export function getSubCategories(category: string) {
     return axios.get(`${baseURL}/categories/${category}/sub-categories`);
 }
+
+export function addCategory(category: any) {
+    return axios.post(`${baseURL}/categories`, category);
+}
+
+export function updateCategory(id: number, category: any) {
+    return axios.put(`${baseURL}/categories/${id}`, category);
+}
+
+export function deleteCategory(id: number) {
+    return axios.delete(`${baseURL}/categories/${id}`);
+}
+
+export function deleteCategories(ids: number[]) {
+    const params = new URLSearchParams();
+    ids.forEach(i => params.append('ids', i.toString()));
+    return axios.delete(`${baseURL}/categories`, { params });
+}


### PR DESCRIPTION
## Summary
- support CRUD operations for categories on the API
- list categories vertically in UI with edit and delete actions
- add checkbox-based multi delete using new API
- extend CategoryService in the frontend to call new endpoints

## Testing
- `./gradlew test --no-daemon` *(fails: Cannot find a Java installation for toolchain)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68491ab4f9888332839dad0d2cbb48fb