### PR TITLE
Add severity management

### DIFF
--- a/api/src/main/java/com/example/api/dto/TicketDto.java
+++ b/api/src/main/java/com/example/api/dto/TicketDto.java
@@ -2,6 +2,7 @@ package com.example.api.dto;
 
 import com.example.api.enums.Mode;
 import com.example.api.enums.Priority;
+import com.example.api.enums.Severity;
 import com.example.api.enums.TicketStatus;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
@@ -22,6 +23,10 @@ public class TicketDto {
     private String category;
     private String subCategory;
     private Priority priority;
+    private Severity severity;
+    private Severity recommendedSeverity;
+    private String impact;
+    private String severityRecommendedBy;
     private TicketStatus status;
     private String attachmentPath;
     private String assignToLevel;

--- a/api/src/main/java/com/example/api/enums/Severity.java
+++ b/api/src/main/java/com/example/api/enums/Severity.java
@@ -1,0 +1,5 @@
+package com.example.api.enums;
+
+public enum Severity {
+    CRITICAL, HIGH, MEDIUM, LOW
+}

--- a/api/src/main/java/com/example/api/mapper/DtoMapper.java
+++ b/api/src/main/java/com/example/api/mapper/DtoMapper.java
@@ -52,6 +52,10 @@ public class DtoMapper {
         dto.setCategory(ticket.getCategory());
         dto.setSubCategory(ticket.getSubCategory());
         dto.setPriority(ticket.getPriority());
+        dto.setSeverity(ticket.getSeverity());
+        dto.setRecommendedSeverity(ticket.getRecommendedSeverity());
+        dto.setImpact(ticket.getImpact());
+        dto.setSeverityRecommendedBy(ticket.getSeverityRecommendedBy());
         dto.setStatus(ticket.getStatus());
         dto.setAttachmentPath(ticket.getAttachmentPath());
         dto.setAssignedToLevel(ticket.getAssignedToLevel());

--- a/api/src/main/java/com/example/api/models/Ticket.java
+++ b/api/src/main/java/com/example/api/models/Ticket.java
@@ -2,6 +2,7 @@ package com.example.api.models;
 
 import com.example.api.enums.Mode;
 import com.example.api.enums.Priority;
+import com.example.api.enums.Severity;
 import com.example.api.enums.TicketStatus;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
@@ -33,6 +34,14 @@ public class Ticket {
     private String subCategory;
     @Enumerated(EnumType.STRING)
     private Priority priority;
+    @Enumerated(EnumType.STRING)
+    private Severity severity;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "recommended_severity")
+    private Severity recommendedSeverity;
+    private String impact;
+    @Column(name = "severity_recommended_by")
+    private String severityRecommendedBy;
     @Enumerated(EnumType.STRING)
     private TicketStatus status;
     @Column(name="attachment_path")

--- a/api/src/main/java/com/example/api/service/TicketService.java
+++ b/api/src/main/java/com/example/api/service/TicketService.java
@@ -74,6 +74,10 @@ public class TicketService {
         existing.setStatus(updated.getStatus());
         existing.setSubCategory(updated.getSubCategory());
         existing.setPriority(updated.getPriority());
+        existing.setSeverity(updated.getSeverity());
+        existing.setRecommendedSeverity(updated.getRecommendedSeverity());
+        existing.setImpact(updated.getImpact());
+        existing.setSeverityRecommendedBy(updated.getSeverityRecommendedBy());
         existing.setDescription(updated.getDescription());
         existing.setAttachmentPath(updated.getAttachmentPath());
         existing.setAssignedToLevel(updated.getAssignedToLevel());

--- a/ui/src/components/RaiseTicket/TicketDetails.tsx
+++ b/ui/src/components/RaiseTicket/TicketDetails.tsx
@@ -16,12 +16,20 @@ interface TicketDetailsProps extends FormProps {
     disableAll?: boolean;
     subjectDisabled?: boolean;
     actionElement?: React.ReactNode;
+    showSeverityFields?: boolean;
 }
 
 const priorityOptions: DropdownOption[] = [
     { label: "Low", value: "Low" },
     { label: "Medium", value: "Medium" },
     { label: "High", value: "High" }
+];
+
+const severityOptions: DropdownOption[] = [
+    { label: "CRITICAL", value: "CRITICAL" },
+    { label: "HIGH", value: "HIGH" },
+    { label: "MEDIUM", value: "MEDIUM" },
+    { label: "LOW", value: "LOW" }
 ];
 
 const statusOptions: DropdownOption[] = [
@@ -41,7 +49,7 @@ const getDropdownOptions = <T,>(arr: any, labelKey: keyof T, valueKey: keyof T):
         }))
         : [];
 
-const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, formData, errors, disableAll = false, subjectDisabled = false, actionElement }) => {
+const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, formData, errors, disableAll = false, subjectDisabled = false, actionElement, showSeverityFields = false }) => {
 
     const { data: allLevels, pending: isLevelsLoading, error: levelsError, apiHandler: getAllLevelApiHandler } = useApi();
     const { data: allEmployeesByLevel, pending, error, apiHandler: getAllEmployeesByLevelHandler } = useApi();
@@ -136,6 +144,38 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, formDa
                         disabled={disableAll}
                     />
                 </div>
+                {showSeverityFields && currentUserDetails?.role === 'RNO' && (
+                    <>
+                        <div className="col-md-4 mb-3 px-4">
+                            <CustomFormInput
+                                name="severity"
+                                label="Severity"
+                                register={register}
+                                errors={errors}
+                                disabled
+                            />
+                        </div>
+                        <div className="col-md-4 mb-3 px-4">
+                            <GenericDropdownController
+                                name="recommendedSeverity"
+                                control={control}
+                                label="Recommend Severity"
+                                options={severityOptions}
+                                className="form-select"
+                                disabled={disableAll}
+                            />
+                        </div>
+                        <div className="col-md-4 mb-3 px-4">
+                            <CustomFormInput
+                                name="impact"
+                                label="Impact"
+                                register={register}
+                                errors={errors}
+                                disabled={disableAll}
+                            />
+                        </div>
+                    </>
+                )}
                 <div className="col-md-4 mb-3 px-4 d-flex align-items-center">
                     <FormControlLabel
                         control={<Checkbox {...register('isMaster')} disabled={disableAll} />}

--- a/ui/src/config/envconfig.ts
+++ b/ui/src/config/envconfig.ts
@@ -1,5 +1,5 @@
 export const envConfig = {
-    Roles: ["L1", "L2", "L3", "ADMIN", "FCI_USER", "USER"],
+    Roles: ["L1", "L2", "L3", "ADMIN", "FCI_USER", "USER", "RNO"],
     CurrentUserDetails: {
         userId: localStorage.getItem('userId') || 'nimit.jain',
         role: localStorage.getItem('role') || 'L1',

--- a/ui/src/pages/TicketDetails.tsx
+++ b/ui/src/pages/TicketDetails.tsx
@@ -31,6 +31,10 @@ interface Ticket {
     category: string;
     subCategory: string;
     priority: string;
+    severity?: string;
+    recommendedSeverity?: string;
+    impact?: string;
+    severityRecommendedBy?: string;
     status: string;
     assignToLevel?: string;
     assignTo?: string;
@@ -62,6 +66,9 @@ const TicketDetails: React.FC = () => {
             setValue("category", ticket.category);
             setValue("subCategory", ticket.subCategory);
             setValue("priority", ticket.priority);
+            setValue("severity", ticket.severity);
+            setValue("impact", ticket.impact);
+            setValue("severityRecommendedBy", ticket.severityRecommendedBy);
             setValue("subject", ticket.subject);
             setValue("description", ticket.description);
             setValue("assignToLevel", ticket.assignToLevel);
@@ -90,6 +97,9 @@ const TicketDetails: React.FC = () => {
         setValue("category", ticket.category);
         setValue("subCategory", ticket.subCategory);
         setValue("priority", ticket.priority);
+        setValue("severity", ticket.severity);
+        setValue("impact", ticket.impact);
+        setValue("severityRecommendedBy", ticket.severityRecommendedBy);
         setValue("description", ticket.description);
         setValue("status", ticket.status);
         setValue("assignedToLevel", ticket.assignToLevel);
@@ -122,6 +132,7 @@ const TicketDetails: React.FC = () => {
                     formData={formData}
                     subjectDisabled
                     disableAll={!editing}
+                    showSeverityFields
                     actionElement={editing ? (
                         <>
                             <GenericButton variant="text" textKey="" type="button" onClick={() => { resetFields(); setEditing(false); }} style={{minWidth:0,padding:2}}>


### PR DESCRIPTION
## Summary
- add Severity enum in backend
- store severity fields in Ticket entity and DTO
- propagate severity fields when updating tickets
- allow RNO users to view/update severity fields in UI
- include RNO role in environment config

## Testing
- `./api/gradlew -p api test --no-daemon` *(fails: Cannot find a Java installation)*
- `npm test --silent --force -- -w 1` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab02ddc488332b8311b9ac61ffb8e