### PR TITLE
Add sidebar dev role selector

### DIFF
--- a/ui/src/components/Layout/Sidebar.tsx
+++ b/ui/src/components/Layout/Sidebar.tsx
@@ -1,15 +1,36 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { List, ListItemButton, ListItemIcon, ListItemText, IconButton } from '@mui/material';
+import { List, ListItemButton, ListItemIcon, ListItemText, IconButton, Button, Stack, TextField } from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ListAltIcon from '@mui/icons-material/ListAlt';
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 import LibraryBooksIcon from '@mui/icons-material/LibraryBooks';
 import CategoryIcon from '@mui/icons-material/Category';
+import { Roles, currentUserDetails, devMode } from '../../config/config';
 
 const Sidebar: React.FC = () => {
   const [collapsed, setCollapsed] = useState(false);
+  const [roleInput, setRoleInput] = useState('');
+  const [selectedRoles, setSelectedRoles] = useState<string[]>(Array.isArray(currentUserDetails.role) ? currentUserDetails.role : []);
+
+  const toggleRole = (role: string) => {
+    const exists = selectedRoles.includes(role);
+    const updated = exists ? selectedRoles.filter(r => r !== role) : [...selectedRoles, role];
+    setSelectedRoles(updated);
+    currentUserDetails.role = updated;
+    localStorage.setItem('role', JSON.stringify(updated));
+  };
+
+  const handleAddRole = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && roleInput.trim()) {
+      const newRole = roleInput.trim().toUpperCase();
+      setRoleInput('');
+      if (!selectedRoles.includes(newRole)) {
+        toggleRole(newRole);
+      }
+    }
+  };
 
   return (
     <div
@@ -17,6 +38,9 @@ const Sidebar: React.FC = () => {
       style={{
         width: collapsed ? '60px' : '200px',
         transition: 'width 0.3s',
+        height: '100vh',
+        display: 'flex',
+        flexDirection: 'column'
       }}
     >
       <div className="text-end mb-3">
@@ -50,6 +74,34 @@ const Sidebar: React.FC = () => {
           {!collapsed && <ListItemText primary="Categories Master" />}
         </ListItemButton>
       </List>
+      {devMode && (
+        <div style={{ marginTop: 'auto' }}>
+          {!collapsed && (
+            <TextField
+              value={roleInput}
+              onChange={e => setRoleInput(e.target.value.toUpperCase())}
+              onKeyDown={handleAddRole}
+              size="small"
+              label="Add Role"
+              fullWidth
+              className="mb-2"
+            />
+          )}
+          <Stack direction="row" flexWrap="wrap" spacing={0.5}>
+            {Array.from(new Set([...Roles, ...selectedRoles.filter(r => !Roles.includes(r))])).map(role => (
+              <Button
+                key={role}
+                variant={selectedRoles.includes(role) ? 'contained' : 'outlined'}
+                size="small"
+                onClick={() => toggleRole(role)}
+                sx={{ mb: 0.5 }}
+              >
+                {role}
+              </Button>
+            ))}
+          </Stack>
+        </div>
+      )}
     </div>
   );
 };

--- a/ui/src/config/config.ts
+++ b/ui/src/config/config.ts
@@ -2,3 +2,4 @@ import { envConfig } from './envconfig';
 
 export const Roles = envConfig.Roles;
 export const currentUserDetails = envConfig.CurrentUserDetails;
+export const devMode = envConfig.devMode;

--- a/ui/src/config/envconfig.ts
+++ b/ui/src/config/envconfig.ts
@@ -1,5 +1,6 @@
 export const envConfig = {
     Roles: ["L1", "L2", "L3", "ADMIN", "FCI_USER", "USER", "RNO"],
+    devMode: true,
     CurrentUserDetails: {
         userId: localStorage.getItem('userId') || 'nimit.jain',
         role: localStorage.getItem('role') || ["L1", "L2", "L3", "ADMIN", "FCI_USER", "RNO"],


### PR DESCRIPTION
## Summary
- expose a `devMode` flag in env config
- show new role management UI at the bottom of the sidebar when `devMode` is true
- allow adding custom roles via an input and toggling roles with buttons

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_684adb0444cc8332ac03bf94dc77f1da