### PR TITLE
Centralize UI theming

### DIFF
--- a/ui/src/components/UI/Button/index.tsx
+++ b/ui/src/components/UI/Button/index.tsx
@@ -6,8 +6,8 @@ interface GenericButtonProps extends ButtonProps {
     children?: ReactNode;
 }
 
-const GenericButton: React.FC<GenericButtonProps> = ({ textKey, children, ...props }) => (
-    <Button {...props}>
+const GenericButton: React.FC<GenericButtonProps> = ({ textKey, children, className, ...props }) => (
+    <Button {...props} className={`generic-button ${className ?? ''}`.trim()}>
         {textKey || children}
     </Button>
 );

--- a/ui/src/components/UI/Dropdown/GenericDropdown.tsx
+++ b/ui/src/components/UI/Dropdown/GenericDropdown.tsx
@@ -38,19 +38,19 @@ const GenericDropdown: React.FC<GenericDropdownProps> = ({
     className,
     style,
 }) => {
+    const classes = `generic-dropdown ${className ?? ''}`.trim();
     return (
-        <FormControl fullWidth={fullWidth} disabled={disabled} required={required} style={style} className={className} size='small'>
+        <FormControl fullWidth={fullWidth} disabled={disabled} required={required} style={style} className={classes} size='small'>
             {label && <InputLabel id={id ? `${id}-label` : undefined}>{label}</InputLabel>}
             <Select
                 labelId={id ? `${id}-label` : undefined}
                 id={id}
                 name={name}
-                value={value ?? ""}
+                value={value ?? ''}
                 label={label}
                 size='small'
                 onChange={onChange}
             >
-                {console.log({ options })}
                 {menuItemsList
                     ? menuItemsList
                     : options?.length

--- a/ui/src/components/UI/Input/CustomFormInput.tsx
+++ b/ui/src/components/UI/Input/CustomFormInput.tsx
@@ -1,7 +1,7 @@
 import { InputLabel, TextField, TextFieldProps } from "@mui/material";
 import { FormProps } from "../../../types";
 
-interface CustomFormInputProps extends Omit<TextFieldProps<"outlined">, "variant">, Omit<FormProps, "control"> {
+interface CustomFormInputProps extends Omit<TextFieldProps<'outlined'>, 'variant'>, Omit<FormProps, 'control'> {
     name: string;
     label?: string;
     required?: boolean;
@@ -29,8 +29,10 @@ const CustomFormInput: React.FC<CustomFormInputProps> = ({
     ...inputProps
 }) => {
     const hasError = !!(errors && errors[name]);
-    const errorMessage = errors && errors[name]?.message as string;
+    const errorMessage = (errors && errors[name]?.message) as string;
     validations = { ...validations, required: required ? `Please fill the ${label}` : false };
+
+    const classes = `generic-input ${className ?? ''}`.trim();
 
     return (
         <>
@@ -44,7 +46,7 @@ const CustomFormInput: React.FC<CustomFormInputProps> = ({
                 label={label}
                 fullWidth={fullWidth}
                 disabled={disabled}
-                className={className}
+                className={classes}
                 style={style}
                 size="small"
                 error={hasError}

--- a/ui/src/components/UI/Input/GenericInput.tsx
+++ b/ui/src/components/UI/Input/GenericInput.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import TextField, { TextFieldProps } from '@mui/material/TextField';
 
-interface GenericInputProps extends Omit<TextFieldProps<"outlined">, "variant"> {
+interface GenericInputProps extends Omit<TextFieldProps<'outlined'>, 'variant'> {
     label?: string;
     fullWidth?: boolean;
     required?: boolean;
     disabled?: boolean;
     className?: string;
     style?: React.CSSProperties;
-    variant?: "outlined" | "filled" | "standard";
+    variant?: 'outlined' | 'filled' | 'standard';
 }
 
 const GenericInput: React.FC<GenericInputProps> = ({
@@ -16,29 +16,22 @@ const GenericInput: React.FC<GenericInputProps> = ({
     fullWidth = false,
     required = false,
     disabled = false,
-    className = 'form-control',
+    className,
     style,
     ...props
 }) => {
+    const classes = `generic-input ${className ?? ''}`.trim();
     return (
-        <>
-            {/* {label && (
-                <label style={{ display: 'block', marginBottom: 4 }}>
-                    {label}
-                    {required && <span style={{ color: 'red', marginLeft: 2 }}>*</span>}
-                </label>
-            )} */}
-            <TextField
-                label={label}
-                fullWidth={fullWidth}
-                required={required}
-                disabled={disabled}
-                className={className}
-                style={style}
-                size='small'
-                {...props}
-            />
-        </>
+        <TextField
+            label={label}
+            fullWidth={fullWidth}
+            required={required}
+            disabled={disabled}
+            className={classes}
+            style={style}
+            size='small'
+            {...props}
+        />
     );
 };
 

--- a/ui/src/index.scss
+++ b/ui/src/index.scss
@@ -1,3 +1,26 @@
+:root {
+  --primary-color: #1976d2;
+  --secondary-color: #dc004e;
+  --success-color: #388e3c;
+  --danger-color: #d32f2f;
+  --warning-color: #f57c00;
+  --info-color: #0288d1;
+}
+
+.generic-button {
+  background-color: var(--primary-color) !important;
+  color: #fff !important;
+  text-transform: none;
+}
+
+.generic-input .MuiInputBase-root {
+  border-radius: 4px;
+}
+
+.generic-dropdown .MuiInputBase-root {
+  border-radius: 4px;
+}
+
 .modal-box {
     position: absolute;
     top: 50%;


### PR DESCRIPTION
## Summary
- create base theme variables and common styles in `index.scss`
- apply `generic-button` style in `GenericButton`
- apply `generic-input` style in input components
- apply `generic-dropdown` style in dropdowns

## Testing
- `npm test --silent --yes` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684bc46a2d74833288a2c6d9fa43bb99