### PR TITLE
Refactor tickets view and add dark theme

### DIFF
--- a/api/src/main/java/com/example/api/controller/TicketStatusController.java
+++ b/api/src/main/java/com/example/api/controller/TicketStatusController.java
@@ -1,0 +1,26 @@
+package com.example.api.controller;
+
+import com.example.api.enums.TicketStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/ticket-statuses")
+@CrossOrigin(origins = "http://localhost:3000")
+public class TicketStatusController {
+
+    @GetMapping
+    public ResponseEntity<List<String>> getStatuses() {
+        List<String> statuses = Arrays.stream(TicketStatus.values())
+                .map(Enum::name)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(statuses);
+    }
+}

--- a/ui/src/components/AllTickets/TicketCard.tsx
+++ b/ui/src/components/AllTickets/TicketCard.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Card, CardContent, Typography, Box, Tooltip } from '@mui/material';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import MasterIcon from '../UI/Icons/MasterIcon';
+
+interface Employee {
+    name?: string;
+}
+
+export interface TicketCardData {
+    id: number;
+    subject: string;
+    category: string;
+    subCategory: string;
+    priority: string;
+    isMaster: boolean;
+    employee?: Employee;
+}
+
+interface PriorityConfig { color: string; count: number; }
+
+interface TicketCardProps {
+    ticket: TicketCardData;
+    priorityConfig: Record<string, PriorityConfig>;
+    onClick?: () => void;
+}
+
+const TicketCard: React.FC<TicketCardProps> = ({ ticket, priorityConfig, onClick }) => {
+    const p = priorityConfig[ticket.priority as keyof typeof priorityConfig] || { color: 'grey.400', count: 1 };
+    return (
+        <Card onClick={onClick} sx={{ cursor: 'pointer', border: '2px solid', borderColor: (theme: any) => `${theme.palette[p.color.split('.')[0]]?.[p.color.split('.')[1]]}40`, boxShadow: 'none', height: '100%', position: 'relative', transition: 'background-color 0.2s, transform 0.2s', '&:hover': { backgroundColor: 'rgba(0,0,0,0.04)', transform: 'scale(1.02)' } }}>
+            <CardContent sx={{ pb: 4 }}>
+                <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center' }}>
+                    <span style={{ maxWidth: 200, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }} title={ticket.subject}>{ticket.subject}</span>
+                    {ticket.isMaster && <MasterIcon />}
+                </Typography>
+                <Typography variant="body2">Id: {ticket.id}</Typography>
+                <Typography variant="body2">Requestor: {ticket.employee?.name || '-'}</Typography>
+                <Typography variant="body2">Category: {ticket.category}</Typography>
+                <Typography variant="body2">Sub-Category: {ticket.subCategory}</Typography>
+            </CardContent>
+            <Box sx={{ position: 'absolute', bottom: 4, right: 4, color: p.color }}>
+                <Tooltip title={ticket.priority}>
+                    <Box sx={{ position: 'relative', width: 24, height: 24 + (p.count - 1) * 10 }}>
+                        {Array.from({ length: p.count }).map((_, i) => (
+                            <KeyboardArrowUpIcon
+                                key={i}
+                                fontSize="small"
+                                sx={{ position: 'absolute', left: 0, top: `${i * 10}px`, zIndex: p.count - i }}
+                            />
+                        ))}
+                    </Box>
+                </Tooltip>
+            </Box>
+        </Card>
+    );
+};
+
+export default TicketCard;

--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -1,0 +1,81 @@
+import React, { useMemo } from 'react';
+import { Table } from 'antd';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import MasterIcon from '../UI/Icons/MasterIcon';
+
+interface Employee {
+    name?: string;
+    emailId?: string;
+    mobileNo?: string;
+}
+
+export interface TicketRow {
+    id: number;
+    subject: string;
+    category: string;
+    subCategory: string;
+    priority: string;
+    isMaster: boolean;
+    employee?: Employee;
+    status?: string;
+}
+
+interface TicketsTableProps {
+    tickets: TicketRow[];
+    onRowClick: (id: number) => void;
+}
+
+const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onRowClick }) => {
+    const columns = useMemo(
+        () => [
+            {
+                title: 'Ticket Id',
+                dataIndex: 'id',
+                key: 'id',
+                render: (_: any, record: TicketRow) => (
+                    <div className="d-flex align-items-center">
+                        {record.id}
+                        {record.isMaster && <MasterIcon />}
+                    </div>
+                ),
+            },
+            {
+                title: 'Requestor Name',
+                key: 'name',
+                render: (_: any, record: TicketRow) => record.employee?.name || '-',
+            },
+            {
+                title: 'Email',
+                key: 'email',
+                render: (_: any, record: TicketRow) => record.employee?.emailId || '-',
+            },
+            {
+                title: 'Mobile',
+                key: 'mobile',
+                render: (_: any, record: TicketRow) => record.employee?.mobileNo || '-',
+            },
+            { title: 'Category', dataIndex: 'category', key: 'category' },
+            { title: 'Sub-Category', dataIndex: 'subCategory', key: 'subCategory' },
+            { title: 'Priority', dataIndex: 'priority', key: 'priority' },
+            { title: 'Status', dataIndex: 'status', key: 'status', render: (v: any) => v || '-' },
+            {
+                title: 'Action',
+                key: 'action',
+                render: () => <VisibilityIcon fontSize="small" sx={{ color: 'grey.600', cursor: 'pointer' }} />,
+            },
+        ],
+        []
+    );
+
+    return (
+        <Table
+            dataSource={tickets}
+            columns={columns as any}
+            rowKey="id"
+            pagination={false}
+            onRow={(record) => ({ onClick: () => onRowClick(record.id) })}
+        />
+    );
+};
+
+export default TicketsTable;

--- a/ui/src/components/AllTickets/ViewToggle.tsx
+++ b/ui/src/components/AllTickets/ViewToggle.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { ToggleButton, ToggleButtonGroup } from '@mui/material';
+
+interface ToggleOption {
+    icon: React.ElementType;
+    value: string;
+}
+
+interface ViewToggleProps {
+    value: string;
+    onChange: (val: string) => void;
+    options: ToggleOption[];
+}
+
+const ViewToggle: React.FC<ViewToggleProps> = ({ value, onChange, options }) => (
+    <ToggleButtonGroup
+        value={value}
+        exclusive
+        onChange={(_, val) => val && onChange(val)}
+        size="small"
+    >
+        {options.map((o, i) => {
+            const Icon = o.icon;
+            return (
+                <ToggleButton key={i} value={o.value}>
+                    <Icon fontSize="small" />
+                </ToggleButton>
+            );
+        })}
+    </ToggleButtonGroup>
+);
+
+export default ViewToggle;

--- a/ui/src/components/Comments/CommentsSection.tsx
+++ b/ui/src/components/Comments/CommentsSection.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { IconButton } from '@mui/material';
+import CustomIconButton from '../UI/IconButton/CustomIconButton';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { useApi } from '../../hooks/useApi';
@@ -114,12 +114,8 @@ const CommentsSection: React.FC<CommentsSectionProps> = ({ ticketId }) => {
                                     <small className="text-muted">{timeSince(c.createdAt)}</small>
                                 </div>
                                 <div className="ms-2">
-                                    <IconButton size="small" onClick={() => startEdit(c)}>
-                                        <EditIcon fontSize="small" />
-                                    </IconButton>
-                                    <IconButton size="small" onClick={() => removeComment(c.id)} color="error">
-                                        <DeleteIcon fontSize="small" />
-                                    </IconButton>
+                                    <CustomIconButton icon="Edit" size="small" onClick={() => startEdit(c)} />
+                                    <CustomIconButton icon="Delete" size="small" onClick={() => removeComment(c.id)} color="error" />
                                 </div>
                             </div>
                         )}

--- a/ui/src/components/Layout/Header.tsx
+++ b/ui/src/components/Layout/Header.tsx
@@ -1,0 +1,14 @@
+import React, { useContext } from 'react';
+import { ThemeModeContext } from '../../context/ThemeContext';
+import CustomIconButton from '../UI/IconButton/CustomIconButton';
+
+const Header: React.FC = () => {
+    const { toggle, mode } = useContext(ThemeModeContext);
+    return (
+        <header style={{ backgroundColor: 'green', color: 'white', width: '100%', padding: '10px', display: 'flex', justifyContent: 'flex-end' }}>
+            <CustomIconButton icon={mode === 'light' ? 'DarkMode' : 'LightMode'} onClick={toggle} />
+        </header>
+    );
+};
+
+export default Header;

--- a/ui/src/components/Layout/Sidebar.tsx
+++ b/ui/src/components/Layout/Sidebar.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { List, ListItemButton, ListItemIcon, ListItemText, IconButton, Button, Stack, TextField } from '@mui/material';
+import { List, ListItemButton, ListItemIcon, ListItemText, Button, Stack, TextField } from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ListAltIcon from '@mui/icons-material/ListAlt';
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 import LibraryBooksIcon from '@mui/icons-material/LibraryBooks';
 import CategoryIcon from '@mui/icons-material/Category';
+import CustomIconButton from '../UI/IconButton/CustomIconButton';
 import { Roles, currentUserDetails, devMode } from '../../config/config';
 
 const Sidebar: React.FC = () => {
@@ -34,9 +35,10 @@ const Sidebar: React.FC = () => {
 
   return (
     <div
-      className="bg-light p-2"
+      className="p-2"
       style={{
-        width: collapsed ? '60px' : '200px',
+        backgroundColor: 'orange',
+        width: collapsed ? '80px' : '220px',
         transition: 'width 0.3s',
         height: '100vh',
         display: 'flex',
@@ -44,9 +46,7 @@ const Sidebar: React.FC = () => {
       }}
     >
       <div className="text-end mb-3">
-        <IconButton size="small" onClick={() => setCollapsed(!collapsed)}>
-          {collapsed ? <MenuIcon /> : <ChevronLeftIcon />}
-        </IconButton>
+        <CustomIconButton icon={collapsed ? 'Menu' : 'ChevronLeft'} size="small" onClick={() => setCollapsed(!collapsed)} />
       </div>
       <List component="nav">
         <ListItemButton component={Link} to="/tickets">

--- a/ui/src/components/Layout/SidebarLayout.tsx
+++ b/ui/src/components/Layout/SidebarLayout.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
 import Sidebar from './Sidebar';
+import Header from './Header';
+import CustomThemeProvider from '../../context/ThemeContext';
 
 const SidebarLayout: React.FC = () => (
-  <div className="d-flex" style={{ minHeight: '100vh' }}>
-    <Sidebar />
-    <div className="flex-grow-1 p-3">
-      <Outlet />
+  <CustomThemeProvider>
+    <Header />
+    <div className="d-flex" style={{ minHeight: 'calc(100vh - 50px)' }}>
+      <Sidebar />
+      <div className="flex-grow-1 p-3" style={{ marginTop: '0' }}>
+        <Outlet />
+      </div>
     </div>
-  </div>
+  </CustomThemeProvider>
 );
 
 export default SidebarLayout;

--- a/ui/src/components/RaiseTicket/LinkToMasterTicketModal.tsx
+++ b/ui/src/components/RaiseTicket/LinkToMasterTicketModal.tsx
@@ -1,7 +1,8 @@
-import { Box, Modal, IconButton, Tooltip } from "@mui/material";
+import { Box, Modal, Tooltip } from "@mui/material";
 import React, { useEffect, useState } from "react";
 import GenericButton from "../UI/Button";
 import LinkIcon from '@mui/icons-material/Link';
+import CustomIconButton from "../UI/IconButton/CustomIconButton";
 import CustomFieldset from "../CustomFieldset";
 import { useDebounce } from "../../hooks/useDebounce";
 import { searchTickets, getTicket, linkTicketToMaster } from "../../services/TicketService";
@@ -100,11 +101,13 @@ const LinkToMasterTicketModal: React.FC<LinkToMasterTicketModalProps> = ({ open,
                         </CustomFieldset>
                         <div className='d-flex align-items-center justify-content-center position-absolute w-100' style={{ top: '35%' }}>
                             <Tooltip title={`Link ${currentTicket.id} to Master ${selected.id}`} placement="top">
-                                <IconButton color={linked ? 'success' : 'primary'} onClick={() => {
-                                    linkTicketToMaster(currentTicket.id, selected.id).then(() => setLinked(true));
-                                }}>
-                                    <LinkIcon />
-                                </IconButton>
+                                <CustomIconButton
+                                    icon="Link"
+                                    color={linked ? 'success' : 'primary'}
+                                    onClick={() => {
+                                        linkTicketToMaster(currentTicket.id, selected.id).then(() => setLinked(true));
+                                    }}
+                                />
                             </Tooltip>
                         </div>
                         <CustomFieldset

--- a/ui/src/components/RaiseTicket/RequestorDetails.tsx
+++ b/ui/src/components/RaiseTicket/RequestorDetails.tsx
@@ -1,4 +1,4 @@
-import { IconButton, InputAdornment, ToggleButton, ToggleButtonGroup } from "@mui/material";
+import { InputAdornment, ToggleButton, ToggleButtonGroup } from "@mui/material";
 import { inputColStyling } from "../../constants/bootstrapClasses";
 import { FormProps } from "../../types";
 import CustomFormInput from "../UI/Input/CustomFormInput";
@@ -8,6 +8,7 @@ import { FieldValues } from "react-hook-form";
 import { useApi } from "../../hooks/useApi";
 import { useEffect, useState } from "react";
 import ClearIcon from '@mui/icons-material/Clear';
+import CustomIconButton from "../UI/IconButton/CustomIconButton";
 import CustomFieldset from "../CustomFieldset";
 import { isFciEmployee } from "../../config/config";
 
@@ -125,9 +126,7 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
                                     endAdornment: !disableAll && (
                                         <InputAdornment position="end">
                                             {(verified || formData?.employeeId) && (
-                                                <IconButton onClick={clearForm} disabled={disableAll}>
-                                                    <ClearIcon fontSize="small" />
-                                                </IconButton>
+                                                <CustomIconButton icon="Clear" onClick={clearForm} disabled={disableAll} />
                                             )}
                                             <VerifyIconButton
                                                 onClick={verifyEmployeeById}

--- a/ui/src/components/RaiseTicket/TicketDetails.tsx
+++ b/ui/src/components/RaiseTicket/TicketDetails.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from "react";
 import { Checkbox, FormControlLabel } from "@mui/material";
 import { getAllEmployeesByLevel, getAllLevels } from "../../services/LevelService";
 import { getCategories, getSubCategories } from "../../services/CategoryService";
+import { getStatuses } from "../../services/StatusService";
 import { currentUserDetails } from "../../config/config";
 
 interface TicketDetailsProps extends FormProps {
@@ -31,14 +32,6 @@ const severityOptions: DropdownOption[] = [
     { label: "LOW", value: "LOW" }
 ];
 
-const statusOptions: DropdownOption[] = [
-    { label: "Pending", value: "PENDING" },
-    { label: "On Hold", value: "ON_HOLD" },
-    { label: "Closed", value: "CLOSED" },
-    { label: "Reopened", value: "REOPENED" },
-    { label: "Resolved", value: "RESOLVED" },
-    { label: "Assign Further", value: "ASSIGN_FURTHER" }
-];
 
 const getDropdownOptions = <T,>(arr: any, labelKey: keyof T, valueKey: keyof T): DropdownOption[] =>
     Array.isArray(arr)
@@ -54,6 +47,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, formDa
     const { data: allEmployeesByLevel, pending, error, apiHandler: getAllEmployeesByLevelHandler } = useApi();
     const { data: allCategories, pending: isCategoriesLoading, error: categoriesError, apiHandler: getCategoriesApiHandler } = useApi();
     const { data: allSubCategories, pending: isSubCategoriesLoading, error: subCategoriesError, apiHandler: getSubCategoriesApiHandler } = useApi();
+    const { data: statusList, apiHandler: getStatusApiHandler } = useApi<string[]>();
 
     // Field visibility booleans
 
@@ -61,6 +55,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, formDa
     const assignToOptions: DropdownOption[] = getDropdownOptions(allEmployeesByLevel, 'name', 'employeeId');
     const categoryOptions: DropdownOption[] = getDropdownOptions(allCategories, 'category', 'category');
     const subCategoryOptions: DropdownOption[] = getDropdownOptions(allSubCategories, 'subCategory', 'subCategoryId');
+    const statusOptions: DropdownOption[] = Array.isArray(statusList) ? statusList.map(s => ({ label: s.replace(/_/g, ' '), value: s })) : [];
     const [assignFurther, setAssignFurther] = useState<boolean>(false);
 
     console.log(categoryOptions)
@@ -93,6 +88,10 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, formDa
 
     useEffect(() => {
         getCategoriesApiHandler(() => getCategories())
+    }, [])
+
+    useEffect(() => {
+        getStatusApiHandler(() => getStatuses())
     }, [])
 
     console.log({formData})

--- a/ui/src/components/UI/Dropdown/DropdownController.tsx
+++ b/ui/src/components/UI/Dropdown/DropdownController.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { SelectChangeEvent } from '@mui/material/Select';
+import GenericDropdown, { DropdownOption, GenericDropdownProps } from './GenericDropdown';
+
+interface DropdownControllerProps extends Omit<GenericDropdownProps, 'onChange' | 'options'> {
+    value?: string;
+    onChange: (value: string) => void;
+    options: DropdownOption[];
+}
+
+const DropdownController: React.FC<DropdownControllerProps> = ({ value, onChange, options, ...rest }) => {
+    const handleChange = (e: SelectChangeEvent) => {
+        onChange(e.target.value as string);
+    };
+    return <GenericDropdown value={value} onChange={handleChange} options={options} {...rest} />;
+};
+
+export default DropdownController;

--- a/ui/src/components/UI/IconButton/CustomIconButton.tsx
+++ b/ui/src/components/UI/IconButton/CustomIconButton.tsx
@@ -1,0 +1,19 @@
+import React, { Suspense } from 'react';
+import IconButton, { IconButtonProps } from '@mui/material/IconButton';
+
+interface CustomIconButtonProps extends IconButtonProps {
+    icon: string;
+}
+
+const CustomIconButton: React.FC<CustomIconButtonProps> = ({ icon, children, ...props }) => {
+    const Icon = React.lazy(() => import(`@mui/icons-material/${icon}`));
+    return (
+        <IconButton {...props}>
+            <Suspense fallback={null}>
+                {children ? children : <Icon fontSize="small" />}
+            </Suspense>
+        </IconButton>
+    );
+};
+
+export default CustomIconButton;

--- a/ui/src/context/ThemeContext.tsx
+++ b/ui/src/context/ThemeContext.tsx
@@ -1,0 +1,17 @@
+import React, { createContext, useMemo, useState } from 'react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+
+export const ThemeModeContext = createContext<{ mode: 'light' | 'dark'; toggle: () => void }>({ mode: 'light', toggle: () => {} });
+
+const CustomThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const [mode, setMode] = useState<'light' | 'dark'>('light');
+    const toggle = () => setMode(prev => (prev === 'light' ? 'dark' : 'light'));
+    const theme = useMemo(() => createTheme({ palette: { mode } }), [mode]);
+    return (
+        <ThemeModeContext.Provider value={{ mode, toggle }}>
+            <ThemeProvider theme={theme}>{children}</ThemeProvider>
+        </ThemeModeContext.Provider>
+    );
+};
+
+export default CustomThemeProvider;

--- a/ui/src/pages/AllTickets.tsx
+++ b/ui/src/pages/AllTickets.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Table } from "antd";
-import { Avatar, Box, Tooltip, ToggleButton, ToggleButtonGroup, Card, CardContent, Typography, TextField, MenuItem } from "@mui/material";
+import { Avatar, Box, Tooltip } from "@mui/material";
 import ViewModuleIcon from "@mui/icons-material/ViewModule";
 import TableRowsIcon from "@mui/icons-material/TableRows";
 import VisibilityIcon from "@mui/icons-material/Visibility";
@@ -8,10 +7,15 @@ import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import { useApi } from "../hooks/useApi";
 import { useDebounce } from "../hooks/useDebounce";
 import { getTickets } from "../services/TicketService";
+import { getStatuses } from "../services/StatusService";
 import PaginationControls from "../components/PaginationControls";
 import { useNavigate } from "react-router-dom";
 import Title from "../components/Title";
 import MasterIcon from "../components/UI/Icons/MasterIcon";
+import TicketsTable from "../components/AllTickets/TicketsTable";
+import TicketCard from "../components/AllTickets/TicketCard";
+import ViewToggle from "../components/AllTickets/ViewToggle";
+import DropdownController from "../components/UI/Dropdown/DropdownController";
 
 interface Employee {
     name?: string;
@@ -32,6 +36,7 @@ interface Ticket {
 
 const AllTickets: React.FC = () => {
     const { data, pending, error, apiHandler } = useApi<any>();
+    const { data: statusList, apiHandler: statusApiHandler } = useApi<string[]>();
     const navigate = useNavigate();
     const [search, setSearch] = useState("");
     const [viewMode, setViewMode] = useState<"grid" | "table">("table");
@@ -39,6 +44,7 @@ const AllTickets: React.FC = () => {
     const [page, setPage] = useState(1);
     const [totalPages, setTotalPages] = useState(1);
     const [statusFilter, setStatusFilter] = useState("ALL");
+    const [statusOptions, setStatusOptions] = useState<string[]>([]);
 
     const priorityConfig: Record<string, { color: string; count: number }> = {
         Low: { color: 'success.light', count: 1 },
@@ -48,6 +54,16 @@ const AllTickets: React.FC = () => {
     };
 
     const debouncedSearch = useDebounce(search, 300);
+
+    useEffect(() => {
+        statusApiHandler(() => getStatuses());
+    }, []);
+
+    useEffect(() => {
+        if (Array.isArray(statusList)) {
+            setStatusOptions(['ALL', ...statusList]);
+        }
+    }, [statusList]);
 
     useEffect(() => {
         apiHandler(() => getTickets(page - 1, 5));
@@ -144,115 +160,37 @@ const AllTickets: React.FC = () => {
                     onChange={(e) => setSearch(e.target.value)}
                     sx={{ mr: 2 }}
                 />
-                <TextField
-                    select
+                <DropdownController
                     label="Status"
-                    size="small"
                     value={statusFilter}
-                    onChange={(e) => setStatusFilter(e.target.value)}
-                    sx={{ width: 150, mr: 2 }}
-                >
-                    <MenuItem value="ALL">All</MenuItem>
-                    <MenuItem value="PENDING">Pending</MenuItem>
-                    <MenuItem value="ON_HOLD">On Hold</MenuItem>
-                    <MenuItem value="CLOSED">Closed</MenuItem>
-                    <MenuItem value="REOPENED">Reopened</MenuItem>
-                    <MenuItem value="RESOLVED">Resolved</MenuItem>
-                    <MenuItem value="ASSIGN_FURTHER">Assign Further</MenuItem>
-                </TextField>
-                <ToggleButtonGroup
+                    onChange={setStatusFilter}
+                    options={statusOptions.map(s => ({ label: s, value: s }))}
+                    style={{ width: 150, marginRight: 8 }}
+                />
+                <ViewToggle
                     value={viewMode}
-                    exclusive
-                    onChange={(_, val) => val && setViewMode(val)}
-                    size="small"
-                >
-                    <ToggleButton value="grid">
-                        <ViewModuleIcon fontSize="small" />
-                    </ToggleButton>
-                    <ToggleButton value="table">
-                        <TableRowsIcon fontSize="small" />
-                    </ToggleButton>
-                </ToggleButtonGroup>
+                    onChange={setViewMode}
+                    options={[
+                        { icon: ViewModuleIcon, value: 'grid' },
+                        { icon: TableRowsIcon, value: 'table' }
+                    ]}
+                />
             </div>
             {pending && <p>Loading...</p>}
             {error && <p className="text-danger">Error loading tickets</p>}
-            {!pending && viewMode === "table" && (
+            {!pending && viewMode === 'table' && (
                 <div>
-                    <Table
-                        dataSource={filtered}
-                        columns={columns}
-                        rowKey="id"
-                        pagination={false}
-                        onRow={(record) => ({ onClick: () => navigate(`/tickets/${record.id}`) })}
-                    />
+                    <TicketsTable tickets={filtered} onRowClick={(id) => navigate(`/tickets/${id}`)} />
                     <PaginationControls page={page} totalPages={totalPages} onChange={(_, val) => setPage(val)} className="mt-3" />
                 </div>
             )}
-            {!pending && viewMode === "grid" && (
+            {!pending && viewMode === 'grid' && (
                 <div className="row">
-                    {filtered.map((t) => {
-                        const p = priorityConfig[t.priority as keyof typeof priorityConfig] || { color: 'grey.400', count: 1 };
-                        return (
-                            <div className="col-md-4 mb-3" key={t.id}>
-                                <Card
-                                    onClick={() => navigate(`/tickets/${t.id}`)}
-                                    sx={{
-                                        cursor: 'pointer',
-                                        border: '2px solid',
-                                        borderColor: (theme: any) => `${theme.palette[p.color.split('.')[0]]?.[p.color.split('.')[1]]}40`,
-                                        boxShadow: 'none',
-                                        height: '100%',
-                                        position: 'relative',
-                                        transition: 'background-color 0.2s, transform 0.2s',
-                                        '&:hover': {
-                                            backgroundColor: 'rgba(0,0,0,0.04)',
-                                            transform: 'scale(1.02)'
-                                        }
-                                    }}
-                                >
-                                    <CardContent sx={{ pb: 4 }}>
-                                        <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center' }}>
-                                            <span style={{
-                                                maxWidth: 200,
-                                                whiteSpace: 'nowrap',
-                                                overflow: 'hidden',
-                                                textOverflow: 'ellipsis'
-                                            }} title={t.subject}>{t.subject}</span>
-                                            {t.isMaster && <MasterIcon />}
-                                        </Typography>
-                                        <Typography variant="body2">Id: {t.id}</Typography>
-                                        <Typography variant="body2">Requestor: {t.employee?.name || "-"}</Typography>
-                                        <Typography variant="body2">Category: {t.category}</Typography>
-                                        <Typography variant="body2">Sub-Category: {t.subCategory}</Typography>
-                                    </CardContent>
-                                    <Box sx={{ position: 'absolute', bottom: 4, right: 4, color: p.color }}>
-                                        <Tooltip title={t.priority}>
-                                            <Box
-                                                sx={{
-                                                    position: 'relative',
-                                                    width: 24,
-                                                    height: 24 + (p.count - 1) * 10, // adjust height based on count
-                                                }}
-                                            >
-                                                {Array.from({ length: p.count }).map((_, i) => (
-                                                    <KeyboardArrowUpIcon
-                                                        key={i}
-                                                        fontSize="small"
-                                                        sx={{
-                                                            position: 'absolute',
-                                                            left: 0,
-                                                            top: `${i * 10}px`, // adjust spacing between arrows
-                                                            zIndex: p.count - i,
-                                                        }}
-                                                    />
-                                                ))}
-                                            </Box>
-                                        </Tooltip>
-                                    </Box>
-                                </Card>
-                            </div>
-                        );
-                    })}
+                    {filtered.map((t) => (
+                        <div className="col-md-4 mb-3" key={t.id}>
+                            <TicketCard ticket={t} priorityConfig={priorityConfig} onClick={() => navigate(`/tickets/${t.id}`)} />
+                        </div>
+                    ))}
                 </div>
             )}
         </div>

--- a/ui/src/pages/CategoriesMaster.tsx
+++ b/ui/src/pages/CategoriesMaster.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { Autocomplete, Button, IconButton, List, ListItem, TextField, Box } from '@mui/material';
+import { Autocomplete, Button, List, ListItem, TextField, Box } from '@mui/material';
 import { Edit as EditIcon, Delete as DeleteIcon } from '@mui/icons-material';
+import CustomIconButton from '../components/UI/IconButton/CustomIconButton';
 import Title from '../components/Title';
 import { getCategories, addCategory, updateCategory, deleteCategory, getAllSubCategories, addSubCategory, updateSubCategory, deleteSubCategory } from '../services/CategoryService';
 import { useApi } from '../hooks/useApi';
@@ -151,12 +152,8 @@ const CategoriesMaster: React.FC = () => {
                                 >
                                     <span style={{ flexGrow: 1 }}>{cat.category}</span>
                                     <Box className="actions" sx={{ visibility: 'hidden' }} onClick={e => e.stopPropagation()}>
-                                        <IconButton size="small" onClick={() => handleEditCategory(cat)}>
-                                            <EditIcon fontSize="small" />
-                                        </IconButton>
-                                        <IconButton size="small" onClick={() => handleDeleteCategory(cat.categoryId)}>
-                                            <DeleteIcon fontSize="small" />
-                                        </IconButton>
+                                        <CustomIconButton icon="Edit" size="small" onClick={() => handleEditCategory(cat)} />
+                                        <CustomIconButton icon="Delete" size="small" onClick={() => handleDeleteCategory(cat.categoryId)} />
                                     </Box>
                                 </ListItem>
                             ))}
@@ -188,12 +185,8 @@ const CategoriesMaster: React.FC = () => {
                                 >
                                     <span style={{ flexGrow: 1 }}>{cat.category}</span>
                                     <Box className="actions" sx={{ visibility: 'hidden' }} onClick={e => e.stopPropagation()}>
-                                        <IconButton size="small" onClick={() => handleEditCategory(cat)}>
-                                            <EditIcon fontSize="small" />
-                                        </IconButton>
-                                        <IconButton size="small" onClick={() => handleDeleteCategory(cat.categoryId)}>
-                                            <DeleteIcon fontSize="small" />
-                                        </IconButton>
+                                        <CustomIconButton icon="Edit" size="small" onClick={() => handleEditCategory(cat)} />
+                                        <CustomIconButton icon="Delete" size="small" onClick={() => handleDeleteCategory(cat.categoryId)} />
                                     </Box>
                                 </ListItem>
                             ))}
@@ -232,12 +225,8 @@ const CategoriesMaster: React.FC = () => {
                                 >
                                     <span style={{ flexGrow: 1 }}>{sc.subCategory}</span>
                                     <Box className="actions" sx={{ visibility: 'hidden' }} onClick={e => e.stopPropagation()}>
-                                        <IconButton size="small" onClick={() => handleEditSubCategory(sc)}>
-                                            <EditIcon fontSize="small" />
-                                        </IconButton>
-                                        <IconButton size="small" onClick={() => handleDeleteSubCategory(sc.subCategoryId)}>
-                                            <DeleteIcon fontSize="small" />
-                                        </IconButton>
+                                        <CustomIconButton icon="Edit" size="small" onClick={() => handleEditSubCategory(sc)} />
+                                        <CustomIconButton icon="Delete" size="small" onClick={() => handleDeleteSubCategory(sc.subCategoryId)} />
                                     </Box>
                                 </ListItem>
                             ))}
@@ -270,12 +259,8 @@ const CategoriesMaster: React.FC = () => {
                                 >
                                     <span style={{ flexGrow: 1 }}>{sc.subCategory}</span>
                                     <Box className="actions" sx={{ visibility: 'hidden' }} onClick={e => e.stopPropagation()}>
-                                        <IconButton size="small" onClick={() => handleEditSubCategory(sc)}>
-                                            <EditIcon fontSize="small" />
-                                        </IconButton>
-                                        <IconButton size="small" onClick={() => handleDeleteSubCategory(sc.subCategoryId)}>
-                                            <DeleteIcon fontSize="small" />
-                                        </IconButton>
+                                        <CustomIconButton icon="Edit" size="small" onClick={() => handleEditSubCategory(sc)} />
+                                        <CustomIconButton icon="Delete" size="small" onClick={() => handleDeleteSubCategory(sc.subCategoryId)} />
                                     </Box>
                                 </ListItem>
                             ))}

--- a/ui/src/services/StatusService.ts
+++ b/ui/src/services/StatusService.ts
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const baseURL = 'http://localhost:8081';
+
+export function getStatuses() {
+    return axios.get(`${baseURL}/ticket-statuses`);
+}


### PR DESCRIPTION
## Summary
- extract ticket table, card and toggle components
- add CustomIconButton and DropdownController components
- fetch ticket status list from backend
- implement dark theme with header toggle
- widen orange sidebar and add green header
- use dynamic icons everywhere

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d1a1c72a48332bc0e81e0da188837