### PR TITLE
Add employee CRUD and connect escalation UI

### DIFF
--- a/api/src/main/java/com/example/api/controller/EmployeeController.java
+++ b/api/src/main/java/com/example/api/controller/EmployeeController.java
@@ -1,5 +1,6 @@
 package com.example.api.controller;
 
+import com.example.api.dto.EmployeeDto;
 import com.example.api.models.Employee;
 import com.example.api.service.EmployeeService;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +19,11 @@ public class EmployeeController {
         this.employeeService = employeeService;
     }
 
+    @GetMapping
+    public ResponseEntity<List<EmployeeDto>> getAllEmployees() {
+        return ResponseEntity.ok(employeeService.getAllEmployees());
+    }
+
     @GetMapping("/{employeeId}")
     public ResponseEntity<?> getEmployeeDetails(@PathVariable Integer employeeId) {
 //        Optional<Employee> employee = employeeService.getEmployeeDetails(employeeId);
@@ -27,5 +33,24 @@ public class EmployeeController {
                         .noContent()
                         .header("Error-Message", "Employee not found with id: " + employeeId)
                         .build());
+    }
+
+    @PostMapping
+    public ResponseEntity<Employee> addEmployee(@RequestBody Employee employee) {
+        return ResponseEntity.ok(employeeService.saveEmployee(employee));
+    }
+
+    @PutMapping("/{employeeId}")
+    public ResponseEntity<Employee> updateEmployee(@PathVariable Integer employeeId,
+                                                   @RequestBody Employee employee) {
+        return employeeService.updateEmployee(employeeId, employee)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{employeeId}")
+    public ResponseEntity<Void> deleteEmployee(@PathVariable Integer employeeId) {
+        employeeService.deleteEmployee(employeeId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/api/src/main/java/com/example/api/service/EmployeeService.java
+++ b/api/src/main/java/com/example/api/service/EmployeeService.java
@@ -1,10 +1,11 @@
 package com.example.api.service;
 
+import com.example.api.dto.EmployeeDto;
 import com.example.api.models.Employee;
 import com.example.api.repository.EmployeeRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.CrossOrigin;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -17,5 +18,38 @@ public class EmployeeService {
 
     public Optional<Employee> getEmployeeDetails(Integer employeeId) {
         return employeeRepository.findById(employeeId);
+    }
+
+    public List<EmployeeDto> getAllEmployees() {
+        return employeeRepository.findAll().stream().map(emp -> {
+            EmployeeDto dto = new EmployeeDto();
+            dto.setEmployeeId(emp.getEmployeeId());
+            dto.setUserId(emp.getUserId());
+            dto.setName(emp.getName());
+            dto.setEmailId(emp.getEmailId());
+            dto.setMobileNo(emp.getMobileNo());
+            dto.setOffice(emp.getOffice());
+            return dto;
+        }).toList();
+    }
+
+    public Employee saveEmployee(Employee employee) {
+        return employeeRepository.save(employee);
+    }
+
+    public Optional<Employee> updateEmployee(Integer id, Employee updated) {
+        return employeeRepository.findById(id)
+                .map(existing -> {
+                    existing.setName(updated.getName());
+                    existing.setEmailId(updated.getEmailId());
+                    existing.setMobileNo(updated.getMobileNo());
+                    existing.setOffice(updated.getOffice());
+                    existing.setUserId(updated.getUserId());
+                    return employeeRepository.save(existing);
+                });
+    }
+
+    public void deleteEmployee(Integer id) {
+        employeeRepository.deleteById(id);
     }
 }

--- a/ui/src/pages/EscalationMaster.tsx
+++ b/ui/src/pages/EscalationMaster.tsx
@@ -1,21 +1,70 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Title from '../components/Title';
 import CustomFieldset from '../components/CustomFieldset';
 import GenericInput from '../components/UI/Input/GenericInput';
 import GenericButton from '../components/UI/Button';
 import { Table } from 'antd';
 import DeleteIcon from '@mui/icons-material/Delete';
+import { addEmployee, deleteEmployee, getAllEmployees } from '../services/EmployeeService';
+import { useApi } from '../hooks/useApi';
 
 const EscalationMaster: React.FC = () => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+
+  const { data: employeeData, apiHandler } = useApi<any>();
+  const { apiHandler: addApiHandler } = useApi<any>();
+  const { apiHandler: deleteApiHandler } = useApi<any>();
+
+  const fetchEmployees = () => {
+    apiHandler(() => getAllEmployees());
+  };
+
+  useEffect(() => {
+    fetchEmployees();
+  }, []);
+
+  const handleSubmit = () => {
+    if (!name || !email || !phone) return;
+    const payload = {
+      name,
+      emailId: email,
+      mobileNo: phone,
+    };
+    addApiHandler(() => addEmployee(payload)).then(() => {
+      fetchEmployees();
+      setName('');
+      setEmail('');
+      setPhone('');
+    });
+  };
+
+  const handleDelete = (id: number) => {
+    deleteApiHandler(() => deleteEmployee(id)).then(() => fetchEmployees());
+  };
+
+  const handleCancel = () => {
+    setName('');
+    setEmail('');
+    setPhone('');
+  };
+
   const columns = [
     { title: 'Name', dataIndex: 'name', key: 'name' },
-    { title: 'Designation', dataIndex: 'designation', key: 'designation' },
-    { title: 'Email', dataIndex: 'email', key: 'email' },
-    { title: 'Contact', dataIndex: 'contact', key: 'contact' },
+    { title: 'Designation', dataIndex: 'office', key: 'office' },
+    { title: 'Email', dataIndex: 'emailId', key: 'emailId' },
+    { title: 'Contact', dataIndex: 'mobileNo', key: 'mobileNo' },
     {
       title: 'Action',
       key: 'action',
-      render: () => <DeleteIcon fontSize="small" style={{ color: 'red', cursor: 'pointer' }} />,
+      render: (_: any, record: any) => (
+        <DeleteIcon
+          fontSize="small"
+          style={{ color: 'red', cursor: 'pointer' }}
+          onClick={() => handleDelete(record.employeeId)}
+        />
+      ),
     },
   ];
 
@@ -25,25 +74,25 @@ const EscalationMaster: React.FC = () => {
       <CustomFieldset title="Add new User for Escalation">
         <div className="row g-3">
           <div className="col-md-4">
-            <GenericInput label="Name" fullWidth />
+            <GenericInput label="Name" fullWidth value={name} onChange={e => setName(e.target.value)} />
           </div>
           <div className="col-md-4">
-            <GenericInput label="Email ID" fullWidth />
+            <GenericInput label="Email ID" fullWidth value={email} onChange={e => setEmail(e.target.value)} />
           </div>
           <div className="col-md-4">
-            <GenericInput label="Phone Number" fullWidth />
+            <GenericInput label="Phone Number" fullWidth value={phone} onChange={e => setPhone(e.target.value)} />
           </div>
         </div>
         <div className="mt-3">
-          <GenericButton variant="contained" color="success" className="me-2">
+          <GenericButton variant="contained" color="success" className="me-2" onClick={handleSubmit}>
             Submit
           </GenericButton>
-          <GenericButton variant="contained" color="error">
+          <GenericButton variant="contained" color="error" onClick={handleCancel}>
             Cancel
           </GenericButton>
         </div>
       </CustomFieldset>
-      <Table columns={columns as any} dataSource={[]} rowKey="name" className="mt-4" pagination={false} />
+      <Table columns={columns as any} dataSource={Array.isArray(employeeData) ? employeeData : []} rowKey="employeeId" className="mt-4" pagination={false} />
     </div>
   );
 };

--- a/ui/src/services/EmployeeService.ts
+++ b/ui/src/services/EmployeeService.ts
@@ -8,3 +8,11 @@ export function getEmployeeDetails(payload: string) {
 export function getAllEmployees() {
     return axios.get(`${BASE_URL}/employees`);
 }
+
+export function addEmployee(employee: any) {
+    return axios.post(`${BASE_URL}/employees`, employee);
+}
+
+export function deleteEmployee(id: number) {
+    return axios.delete(`${BASE_URL}/employees/${id}`);
+}


### PR DESCRIPTION
## Summary
- implement full CRUD endpoints for employees
- expose endpoints in `EmployeeController`
- extend `EmployeeService` with save, update, delete and list operations
- enhance frontend service with `addEmployee` and `deleteEmployee`
- wire up `EscalationMaster` page to call employee APIs

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation)*
- `npm test --silent` *(fails: missing module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_684fec9b3e48833285b7e5edab4b94b0