### PR TITLE
Add theme palette support and profile avatar

### DIFF
--- a/ui/src/components/Layout/Header.tsx
+++ b/ui/src/components/Layout/Header.tsx
@@ -1,6 +1,8 @@
 import React, { useContext } from 'react';
 import { ThemeModeContext } from '../../context/ThemeContext';
 import CustomIconButton from '../UI/IconButton/CustomIconButton';
+import Avatar from '@mui/material/Avatar';
+import { currentUserDetails } from '../../config/config';
 
 interface HeaderProps {
     collapsed: boolean;
@@ -9,10 +11,42 @@ interface HeaderProps {
 
 const Header: React.FC<HeaderProps> = ({ collapsed, toggleSidebar }) => {
     const { toggle, mode } = useContext(ThemeModeContext);
+    const initials = currentUserDetails.name
+        ? currentUserDetails.name
+              .split(' ')
+              .map(n => n.charAt(0))
+              .join('')
+              .slice(0, 2)
+              .toUpperCase()
+        : '';
+
     return (
-        <header style={{ backgroundColor: 'green', color: 'white', width: '100%', padding: '10px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-            <CustomIconButton className="text-white" icon={collapsed ? 'menu' : 'chevronleft'} onClick={toggleSidebar} />
-            <CustomIconButton icon={mode === 'light' ? 'darkmode' : 'lightmode'} onClick={toggle} />
+        <header
+            style={{
+                backgroundColor: 'green',
+                color: 'white',
+                width: '100%',
+                padding: '10px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+            }}
+        >
+            <CustomIconButton
+                className="text-white"
+                icon={collapsed ? 'menu' : 'chevronleft'}
+                onClick={toggleSidebar}
+            />
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <CustomIconButton
+                    style={{ color: 'white' }}
+                    icon={mode === 'light' ? 'darkmode' : 'lightmode'}
+                    onClick={toggle}
+                />
+                <Avatar sx={{ bgcolor: '#757575', width: 32, height: 32, fontSize: 14 }}>
+                    {initials}
+                </Avatar>
+            </div>
         </header>
     );
 };

--- a/ui/src/config/config.ts
+++ b/ui/src/config/config.ts
@@ -8,6 +8,7 @@ export const currentUserDetails = Users.helpdesk;
 // export const currentUserDetails = Users.fci
 export const FciTheme = envConfig.FciTheme;
 
-export const isFciEmployee = currentUserDetails.role.includes("FCI_EMPLOYEE")
-export const isHelpdesk = currentUserDetails.role.includes('HELPDESK')
-console.log({ isFciEmployee, isHelpdesk })
+export const isFciEmployee = currentUserDetails.role.includes('FCI_EMPLOYEE');
+export const isHelpdesk = currentUserDetails.role.includes('HELPDESK');
+console.log({ isFciEmployee, isHelpdesk });
+

--- a/ui/src/context/ThemeContext.tsx
+++ b/ui/src/context/ThemeContext.tsx
@@ -1,12 +1,13 @@
 import React, { createContext, useMemo, useState } from 'react';
-import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { ThemeProvider } from '@mui/material/styles';
+import { allThemes, ThemeName } from '../themes';
 
-export const ThemeModeContext = createContext<{ mode: 'light' | 'dark'; toggle: () => void }>({ mode: 'light', toggle: () => {} });
+export const ThemeModeContext = createContext<{ mode: ThemeName; toggle: () => void }>({ mode: 'light', toggle: () => {} });
 
 const CustomThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-    const [mode, setMode] = useState<'light' | 'dark'>('light');
+    const [mode, setMode] = useState<ThemeName>('light');
     const toggle = () => setMode(prev => (prev === 'light' ? 'dark' : 'light'));
-    const theme = useMemo(() => createTheme({ palette: { mode } }), [mode]);
+    const theme = useMemo(() => allThemes[mode], [mode]);
     return (
         <ThemeModeContext.Provider value={{ mode, toggle }}>
             <ThemeProvider theme={theme}>{children}</ThemeProvider>

--- a/ui/src/themes.ts
+++ b/ui/src/themes.ts
@@ -1,0 +1,72 @@
+import { createTheme } from '@mui/material/styles';
+
+const lightTheme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: { main: '#1976d2' },
+    secondary: { main: '#9c27b0' },
+    background: {
+      default: '#f5f5f5',
+      paper: '#ffffff',
+    },
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+        },
+      },
+    },
+  },
+});
+
+const darkTheme = createTheme({
+  palette: {
+    mode: 'dark',
+    primary: { main: '#90caf9' },
+    secondary: { main: '#ce93d8' },
+    background: {
+      default: '#303030',
+      paper: '#424242',
+    },
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+        },
+      },
+    },
+  },
+});
+
+const fciTheme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: { main: '#2e7d32' },
+    secondary: { main: '#ff9800' },
+    background: {
+      default: '#fafafa',
+      paper: '#ffffff',
+    },
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+        },
+      },
+    },
+  },
+});
+
+export const allThemes = {
+  light: lightTheme,
+  dark: darkTheme,
+  fci: fciTheme,
+};
+
+export type ThemeName = keyof typeof allThemes;


### PR DESCRIPTION
## Summary
- create MUI theme palette objects for light, dark and FCI themes
- update ThemeContext to use the new palettes
- add profile avatar showing the current user's initials in the Header
- fix trailing characters in config

## Testing
- `npm install`
- `npm test --silent` *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68505b2871d88332bc0f32564b438c25