### PR TITLE
Reflect requestor schema update in API and UI

### DIFF
--- a/api/src/main/java/com/example/api/dto/TicketDto.java
+++ b/api/src/main/java/com/example/api/dto/TicketDto.java
@@ -18,7 +18,9 @@ public class TicketDto {
     private Date reportedDate;
     private Mode mode;
     private int employeeId;
-    private Integer requestorId;
+    private String requestorName;
+    private String requestorEmailId;
+    private String requestorMobileNo;
     private String stakeholder;
     private String subject;
     private String description;

--- a/api/src/main/java/com/example/api/mapper/DtoMapper.java
+++ b/api/src/main/java/com/example/api/mapper/DtoMapper.java
@@ -47,7 +47,9 @@ public class DtoMapper {
         dto.setReportedDate(ticket.getReportedDate());
         dto.setMode(ticket.getMode());
         dto.setEmployeeId(ticket.getEmployeeId());
-        dto.setRequestorId(ticket.getRequestorId());
+        dto.setRequestorName(ticket.getRequestorName());
+        dto.setRequestorEmailId(ticket.getRequestorEmailId());
+        dto.setRequestorMobileNo(ticket.getRequestorMobileNo());
         dto.setStakeholder(ticket.getStakeholder());
         dto.setSubject(ticket.getSubject());
         dto.setDescription(ticket.getDescription());

--- a/api/src/main/java/com/example/api/models/Ticket.java
+++ b/api/src/main/java/com/example/api/models/Ticket.java
@@ -5,7 +5,6 @@ import com.example.api.enums.Priority;
 import com.example.api.enums.Severity;
 import com.example.api.enums.TicketStatus;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.example.api.models.Requestor;
 import jakarta.persistence.*;
 import lombok.Data;
 
@@ -29,12 +28,14 @@ public class Ticket {
     @JoinColumn(name = "employee_id", referencedColumnName = "employee_id")
     private Employee employee;
 
-    @Column(name = "requestor_id", insertable = false, updatable = false)
-    private Integer requestorId;
+    @Column(name = "requestor_name")
+    private String requestorName;
 
-    @ManyToOne
-    @JoinColumn(name = "requestor_id", referencedColumnName = "requestor_id")
-    private Requestor requestor;
+    @Column(name = "requestor_email_id")
+    private String requestorEmailId;
+
+    @Column(name = "requestor_mobile_no")
+    private String requestorMobileNo;
     private String stakeholder;
     private String subject;
     private String description;

--- a/api/src/main/java/com/example/api/service/TicketService.java
+++ b/api/src/main/java/com/example/api/service/TicketService.java
@@ -3,7 +3,6 @@ package com.example.api.service;
 import com.example.api.dto.TicketDto;
 import com.example.api.mapper.DtoMapper;
 import com.example.api.models.Employee;
-import com.example.api.models.Requestor;
 import com.example.api.models.Ticket;
 import com.example.api.models.TicketComment;
 import com.example.api.repository.EmployeeRepository;
@@ -11,7 +10,6 @@ import com.example.api.repository.TicketCommentRepository;
 import com.example.api.repository.TicketRepository;
 import com.example.api.repository.LevelRepository;
 import com.example.api.service.AssignmentHistoryService;
-import com.example.api.service.RequestorService;
 import com.example.api.typesense.TypesenseClient;
 import org.springframework.stereotype.Service;
 import org.typesense.model.SearchResult;
@@ -28,20 +26,17 @@ public class TicketService {
     private final TicketCommentRepository commentRepository;
     private final AssignmentHistoryService assignmentHistoryService;
     private final LevelRepository levelRepository;
-    private final RequestorService requestorService;
 
 
     public TicketService(TypesenseClient typesenseClient, TicketRepository ticketRepository,
                          EmployeeRepository employeeRepository, TicketCommentRepository commentRepository,
-                         AssignmentHistoryService assignmentHistoryService, LevelRepository levelRepository,
-                         RequestorService requestorService) {
+                         AssignmentHistoryService assignmentHistoryService, LevelRepository levelRepository) {
         this.typesenseClient = typesenseClient;
         this.ticketRepository = ticketRepository;
         this.employeeRepository = employeeRepository;
         this.commentRepository = commentRepository;
         this.assignmentHistoryService = assignmentHistoryService;
         this.levelRepository = levelRepository;
-        this.requestorService = requestorService;
     }
 
     public List<Ticket> getTickets() {
@@ -64,10 +59,6 @@ public class TicketService {
         System.out.println("TicketService: addTicket - method");
         if(ticket.isMaster()) ticket.setMasterId(null);
 
-        if (ticket.getRequestor() != null) {
-            Requestor savedReq = requestorService.save(ticket.getRequestor());
-            ticket.setRequestor(savedReq);
-        }
 
         if (ticket.getEmployeeId() != 0) {
             Employee employee = employeeRepository.findById(ticket.getEmployeeId()).orElseThrow();

--- a/ui/src/components/AllTickets/TicketCard.tsx
+++ b/ui/src/components/AllTickets/TicketCard.tsx
@@ -3,10 +3,6 @@ import { Card, CardContent, Typography, Box, Tooltip } from '@mui/material';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import MasterIcon from '../UI/Icons/MasterIcon';
 
-interface Employee {
-    name?: string;
-}
-
 export interface TicketCardData {
     id: number;
     subject: string;
@@ -14,7 +10,7 @@ export interface TicketCardData {
     subCategory: string;
     priority: string;
     isMaster: boolean;
-    employee?: Employee;
+    requestorName?: string;
 }
 
 interface PriorityConfig { color: string; count: number; }
@@ -35,7 +31,7 @@ const TicketCard: React.FC<TicketCardProps> = ({ ticket, priorityConfig, onClick
                     {ticket.isMaster && <MasterIcon />}
                 </Typography>
                 <Typography variant="body2">Id: {ticket.id}</Typography>
-                <Typography variant="body2">Requestor: {ticket.employee?.name || '-'}</Typography>
+                <Typography variant="body2">Requestor: {ticket.requestorName || '-'}</Typography>
                 <Typography variant="body2">Category: {ticket.category}</Typography>
                 <Typography variant="body2">Sub-Category: {ticket.subCategory}</Typography>
             </CardContent>

--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -3,12 +3,6 @@ import { Table } from 'antd';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import MasterIcon from '../UI/Icons/MasterIcon';
 
-interface Employee {
-    name?: string;
-    emailId?: string;
-    mobileNo?: string;
-}
-
 export interface TicketRow {
     id: number;
     subject: string;
@@ -16,7 +10,9 @@ export interface TicketRow {
     subCategory: string;
     priority: string;
     isMaster: boolean;
-    employee?: Employee;
+    requestorName?: string;
+    requestorEmailId?: string;
+    requestorMobileNo?: string;
     status?: string;
 }
 
@@ -42,17 +38,17 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onRowClick }) => {
             {
                 title: 'Requestor Name',
                 key: 'name',
-                render: (_: any, record: TicketRow) => record.employee?.name || '-',
+                render: (_: any, record: TicketRow) => record.requestorName || '-',
             },
             {
                 title: 'Email',
                 key: 'email',
-                render: (_: any, record: TicketRow) => record.employee?.emailId || '-',
+                render: (_: any, record: TicketRow) => record.requestorEmailId || '-',
             },
             {
                 title: 'Mobile',
                 key: 'mobile',
-                render: (_: any, record: TicketRow) => record.employee?.mobileNo || '-',
+                render: (_: any, record: TicketRow) => record.requestorMobileNo || '-',
             },
             { title: 'Category', dataIndex: 'category', key: 'category' },
             { title: 'Sub-Category', dataIndex: 'subCategory', key: 'subCategory' },

--- a/ui/src/pages/AllTickets.tsx
+++ b/ui/src/pages/AllTickets.tsx
@@ -113,17 +113,17 @@ const AllTickets: React.FC = () => {
             {
                 title: "Requestor Name",
                 key: "name",
-                render: (_: any, record: Ticket) => record.employee?.name || "-",
+                render: (_: any, record: Ticket) => record.requestorName || "-",
             },
             {
                 title: "Email",
                 key: "email",
-                render: (_: any, record: Ticket) => record.employee?.emailId || "-",
+                render: (_: any, record: Ticket) => record.requestorEmailId || "-",
             },
             {
                 title: "Mobile",
                 key: "mobile",
-                render: (_: any, record: Ticket) => record.employee?.mobileNo || "-",
+                render: (_: any, record: Ticket) => record.requestorMobileNo || "-",
             },
             {
                 title: "Category",

--- a/ui/src/pages/RaiseTicket.tsx
+++ b/ui/src/pages/RaiseTicket.tsx
@@ -32,12 +32,10 @@ const RaiseTicket: React.FC<any> = () => {
 
         const payload = {
             ...rest,
-            requestor: {
-                name,
-                emailId,
-                mobileNo,
-                stakeholderType: stakeholder
-            }
+            requestorName: name,
+            requestorEmailId: emailId,
+            requestorMobileNo: mobileNo,
+            stakeholder
         };
 
         apiHandler(() => addTicket(payload))

--- a/ui/src/pages/TicketDetails.tsx
+++ b/ui/src/pages/TicketDetails.tsx
@@ -20,13 +20,9 @@ interface Ticket {
     reportedDate: string;
     mode: string;
     employeeId: number;
-    employee?: {
-        name?: string;
-        emailId?: string;
-        mobileNo?: string;
-        role?: string;
-        office?: string;
-    };
+    requestorName?: string;
+    requestorEmailId?: string;
+    requestorMobileNo?: string;
     subject: string;
     description: string;
     category: string;

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -26,12 +26,6 @@ export interface Category {
     subCategories: SubCategory[];
 }
 
-export interface Employee {
-    name?: string;
-    emailId?: string;
-    mobileNo?: string;
-}
-
 export interface Ticket {
     id: number;
     subject: string;
@@ -39,7 +33,9 @@ export interface Ticket {
     subCategory: string;
     priority: string;
     isMaster: boolean;
-    employee?: Employee;
+    requestorName?: string;
+    requestorEmailId?: string;
+    requestorMobileNo?: string;
     status?: string;
 }
 


### PR DESCRIPTION
## Summary
- replace `requestor_id` references with inline requestor fields
- adjust DTO, mapper, and service layer
- update React pages and components to use new requestor fields

## Testing
- `./api/gradlew -p api test` *(fails: Cannot find a Java installation, and network access to `jitpack.io` blocked)*
- `npm test` *(fails: `react-scripts` not found because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6851159d8c5c83329c85ab3ea48e46d0