### PR TITLE
Integrate FileGator login

### DIFF
--- a/api/src/main/java/com/example/api/controller/FilegatorController.java
+++ b/api/src/main/java/com/example/api/controller/FilegatorController.java
@@ -1,0 +1,42 @@
+package com.example.api.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/filegator")
+@CrossOrigin(origins = "http://localhost:3000")
+public class FilegatorController {
+
+    @PostMapping("/login")
+    public ResponseEntity<Void> login(HttpServletResponse servletResponse) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("username", "admin");
+        body.add("password", "admin");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+        ResponseEntity<String> response = restTemplate.postForEntity("http://localhost:8080/login", request, String.class);
+
+        List<String> cookies = response.getHeaders().get(HttpHeaders.SET_COOKIE);
+        if (cookies != null) {
+            for (String cookie : cookies) {
+                servletResponse.addHeader(HttpHeaders.SET_COOKIE, cookie);
+            }
+        }
+        return ResponseEntity.ok().build();
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,5 +16,5 @@ services:
       # - ./users.json:/var/www/filegator/private/users.json
 
       # load your own custom configuration file
-      # - ./configuration.php:/var/www/filegator/configuration.php
+        - ./filegator/configuration.php:/var/www/filegator/configuration.php
 

--- a/filegator/configuration.php
+++ b/filegator/configuration.php
@@ -1,0 +1,121 @@
+<?php
+
+return [
+    'public_path' => APP_PUBLIC_PATH,
+    'public_dir' => APP_PUBLIC_DIR,
+    'overwrite_on_upload' => false,
+    'timezone' => 'UTC', // https://www.php.net/manual/en/timezones.php
+    'download_inline' => ['pdf'], // download inline in the browser, array of extensions, use * for all
+    'lockout_attempts' => 5, // max failed login attempts before ip lockout
+    'lockout_timeout' => 15, // ip lockout timeout in seconds
+
+    'frontend_config' => [
+        'app_name' => 'FileGator',
+        'app_version' => APP_VERSION,
+        'language' => 'english',
+        'logo' => 'https://filegator.io/filegator_logo.svg',
+        'upload_max_size' => 100 * 1024 * 1024, // 100MB
+        'upload_chunk_size' => 1 * 1024 * 1024, // 1MB
+        'upload_simultaneous' => 3,
+        'default_archive_name' => 'archive.zip',
+        'editable' => ['.txt', '.css', '.js', '.ts', '.html', '.php', '.json', '.md'],
+        'date_format' => 'YY/MM/DD hh:mm:ss', // see: https://momentjs.com/docs/#/displaying/format/
+        'guest_redirection' => '', // useful for external auth adapters
+        'search_simultaneous' => 5,
+        'filter_entries' => [],
+        'pagination' => ['', 5, 10, 15],
+    ],
+
+    'services' => [
+        'Filegator\Services\Logger\LoggerInterface' => [
+            'handler' => '\Filegator\Services\Logger\Adapters\MonoLogger',
+            'config' => [
+                'monolog_handlers' => [
+                    function () {
+                        return new \Monolog\Handler\StreamHandler(
+                            __DIR__.'/private/logs/app.log',
+                            \Monolog\Logger::DEBUG
+                        );
+                    },
+                ],
+            ],
+        ],
+        'Filegator\Services\Session\SessionStorageInterface' => [
+            'handler' => '\Filegator\Services\Session\Adapters\SessionStorage',
+            'config' => [
+                'handler' => function () {
+                    $save_path = null; // use default system path
+                    //$save_path = __DIR__.'/private/sessions';
+                    $handler = new \Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeFileSessionHandler($save_path);
+
+                    return new \Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage([
+                            "cookie_samesite" => "Lax",
+                            "cookie_secure" => null,
+                            "cookie_httponly" => true,
+                        ], $handler);
+                },
+            ],
+        ],
+        'Filegator\Services\Cors\Cors' => [
+            'handler' => '\Filegator\Services\Cors\Cors',
+            'config' => [
+                'enabled' => APP_ENV == 'production' ? false : true,
+            ],
+        ],
+        'Filegator\Services\Tmpfs\TmpfsInterface' => [
+            'handler' => '\Filegator\Services\Tmpfs\Adapters\Tmpfs',
+            'config' => [
+                'path' => __DIR__.'/private/tmp/',
+                'gc_probability_perc' => 10,
+                'gc_older_than' => 60 * 60 * 24 * 2, // 2 days
+            ],
+        ],
+        'Filegator\Services\Security\Security' => [
+            'handler' => '\Filegator\Services\Security\Security',
+            'config' => [
+                'csrf_protection' => true,
+                'csrf_key' => "123456", // randomize this
+                'ip_allowlist' => [],
+                'ip_denylist' => [],
+                // Allows FileGator to run inside an iframe.
+                'allow_insecure_overlays' => true,
+            ],
+        ],
+        'Filegator\Services\View\ViewInterface' => [
+            'handler' => '\Filegator\Services\View\Adapters\Vuejs',
+            'config' => [
+                'add_to_head' => '',
+                'add_to_body' => '',
+            ],
+        ],
+        'Filegator\Services\Storage\Filesystem' => [
+            'handler' => '\Filegator\Services\Storage\Filesystem',
+            'config' => [
+                'separator' => '/',
+                'config' => [],
+                'adapter' => function () {
+                    return new \League\Flysystem\Adapter\Local(
+                        __DIR__.'/repository'
+                    );
+                },
+            ],
+        ],
+        'Filegator\Services\Archiver\ArchiverInterface' => [
+            'handler' => '\Filegator\Services\Archiver\Adapters\ZipArchiver',
+            'config' => [],
+        ],
+        'Filegator\Services\Auth\AuthInterface' => [
+            'handler' => '\Filegator\Services\Auth\Adapters\JsonFile',
+            'config' => [
+                'file' => __DIR__.'/private/users.json',
+            ],
+        ],
+        'Filegator\Services\Router\Router' => [
+            'handler' => '\Filegator\Services\Router\Router',
+            'config' => [
+                'query_param' => 'r',
+                'routes_file' => __DIR__.'/backend/Controllers/routes.php',
+            ],
+        ],
+    ],
+];

--- a/ui/src/pages/KnowledgeBase.tsx
+++ b/ui/src/pages/KnowledgeBase.tsx
@@ -1,7 +1,12 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Title from "../components/Title";
+import { initFilegatorSession } from "../services/FilegatorService";
 
 const KnowledgeBase: React.FC = () => {
+    useEffect(() => {
+        initFilegatorSession();
+    }, []);
+
     return (
         <div className="container">
             {/* <Title text="Knowledge Base" /> */}

--- a/ui/src/services/FilegatorService.ts
+++ b/ui/src/services/FilegatorService.ts
@@ -1,0 +1,6 @@
+import axios from 'axios';
+import { BASE_URL } from './api';
+
+export function initFilegatorSession() {
+    return axios.post(`${BASE_URL}/filegator/login`, null, { withCredentials: true });
+}


### PR DESCRIPTION
## Summary
- allow iframe embedding in FileGator configuration
- expose FileGator config via docker-compose
- add endpoint in API to obtain FileGator session cookie
- call new endpoint when Knowledge Base page loads

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation)*
- `npm test --silent` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6854e1374ddc8332b0d3c63024f0ce42