### PR TITLE
Add missing translations for Ticket Details

### DIFF
--- a/ui/src/components/RaiseTicket/TicketDetails.tsx
+++ b/ui/src/components/RaiseTicket/TicketDetails.tsx
@@ -243,9 +243,9 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, errors
                 )}
                 {showIsMaster && (
                     <div className="col-md-5 mb-3 px-4 d-flex align-items-center">
-                        <FormControlLabel
+                    <FormControlLabel
                             control={<Checkbox {...register('isMaster')} disabled={disableAll} />}
-                            label="Mark this ticket as Master"
+                            label={t('Mark this ticket as Master')}
                         />
                     </div>
                 )}
@@ -283,7 +283,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, errors
                 {showAttachment && (
                     <div className="col-md-6 d-flex align-items-center mb-3 px-4">
                         <label htmlFor="attachment" className="form-label me-2 mb-0" style={{ whiteSpace: "nowrap" }}>
-                            Attachment
+                            {t('Attachment')}
                         </label>
                         <CustomFormInput
                             name="attachment"
@@ -312,14 +312,14 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, errors
                 )}
                 {showAssignFurther && (
                     <div className="col-md-4 mb-3 px-4 d-flex align-items-center">
-                        <FormControlLabel
+                    <FormControlLabel
                             control={
                                 <Checkbox
                                     disabled={disableAll}
                                     onChange={e => setAssignFurther?.(e.target.checked)}
                                 />
                             }
-                            label="Assign Further"
+                            label={t('Assign Further')}
                         />
                     </div>
                 )}

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -64,5 +64,16 @@
   "Show more": "Show more",
   "No comments": "No comments",
   "No options available": "No options available",
-  "Ticket": "Ticket"
+  "Ticket": "Ticket",
+  "Category of Ticket": "Category of Ticket",
+  "Impact": "Impact",
+  "Subject": "Subject",
+  "Description": "Description",
+  "Attachment": "Attachment",
+  "No file chosen for attachment": "No file chosen for attachment",
+  "Update Status": "Update Status",
+  "Assign to Level": "Assign to Level",
+  "Assign to": "Assign to",
+  "Assign Further": "Assign Further",
+  "Mark this ticket as Master": "Mark this ticket as Master"
 }

--- a/ui/src/locales/hi/translation.json
+++ b/ui/src/locales/hi/translation.json
@@ -64,5 +64,16 @@
   "Show more": "और दिखाएं",
   "No comments": "कोई टिप्पणी नहीं",
   "No options available": "कोई विकल्प उपलब्ध नहीं",
-  "Ticket": "टिकट"
+  "Ticket": "टिकट",
+  "Category of Ticket": "टिकट की श्रेणी",
+  "Impact": "प्रभाव",
+  "Subject": "विषय",
+  "Description": "विवरण",
+  "Attachment": "संलग्नक",
+  "No file chosen for attachment": "संलग्नक के लिए कोई फ़ाइल नहीं चुनी गई",
+  "Update Status": "स्थिति अपडेट करें",
+  "Assign to Level": "लेवल को असाइन करें",
+  "Assign to": "असाइन करें",
+  "Assign Further": "आगे असाइन करें",
+  "Mark this ticket as Master": "इस टिकट को मास्टर के रूप में चिन्हित करें"
 }


### PR DESCRIPTION
## Summary
- provide translations for various ticket details fields
- translate the "Attachment" label and master checkbox
- translate the Assign Further checkbox

## Testing
- `./gradlew test` *(fails: Java 17 toolchain not found)*
- `npm test` in `ui` *(fails: react-scripts missing)*

------
https://chatgpt.com/codex/tasks/task_e_68584c1b28708332a4ae225c4b537ad2