### PR TITLE
Add ConfigMap and PVC for FileGator deployment

### DIFF
--- a/filegator/KUBERNETES.md
+++ b/filegator/KUBERNETES.md
@@ -1,0 +1,23 @@
+# Running FileGator on Minikube
+
+The deployment uses a local image and Kubernetes manifests located in this directory.
+
+## Build and load the image
+
+```
+cd filegator
+# build the container image
+docker build -t filegator-local:latest .
+# make the image available inside the cluster
+minikube image load filegator-local:latest
+```
+
+## Apply the manifests
+
+```
+kubectl apply -f filegator-configmap.yaml
+kubectl apply -f filegator-pvc.yaml
+kubectl apply -f filegator-deployment.yaml
+```
+
+The service exposes FileGator on NodePort `30080` (HTTP) and `30081`.

--- a/filegator/filegator-configmap.yaml
+++ b/filegator/filegator-configmap.yaml
@@ -1,0 +1,148 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: filegator-config
+  labels:
+    app: filegator
+data:
+  php.ini: |
+    opcache.enable=1
+    opcache.enable_cli=1
+    opcache.memory_consumption=128
+    opcache.interned_strings_buffer=8
+    opcache.max_accelerated_files=1000
+  configuration.php: |
+    <?php
+    
+    return [
+        'public_path' => APP_PUBLIC_PATH,
+        'public_dir' => APP_PUBLIC_DIR,
+        'overwrite_on_upload' => false,
+        'timezone' => 'UTC', // https://www.php.net/manual/en/timezones.php
+        'download_inline' => ['pdf'], // download inline in the browser, array of extensions, use * for all
+        'lockout_attempts' => 5, // max failed login attempts before ip lockout
+        'lockout_timeout' => 15, // ip lockout timeout in seconds
+    
+        'frontend_config' => [
+            'app_name' => 'FileGator',
+            'app_version' => APP_VERSION,
+            'language' => 'english',
+            'logo' => 'https://filegator.io/filegator_logo.svg',
+            'upload_max_size' => 100 * 1024 * 1024, // 100MB
+            'upload_chunk_size' => 1 * 1024 * 1024, // 1MB
+            'upload_simultaneous' => 3,
+            'default_archive_name' => 'archive.zip',
+            'editable' => ['.txt', '.css', '.js', '.ts', '.html', '.php', '.json', '.md'],
+            'date_format' => 'YY/MM/DD hh:mm:ss', // see: https://momentjs.com/docs/#/displaying/format/
+            'guest_redirection' => '', // useful for external auth adapters
+            'search_simultaneous' => 5,
+            'filter_entries' => [],
+            'pagination' => ['', 5, 10, 15],
+        ],
+    
+        'services' => [
+            'Filegator\Services\Logger\LoggerInterface' => [
+                'handler' => '\Filegator\Services\Logger\Adapters\MonoLogger',
+                'config' => [
+                    'monolog_handlers' => [
+                        function () {
+                            return new \Monolog\Handler\StreamHandler(
+                                __DIR__.'/private/logs/app.log',
+                                \Monolog\Logger::DEBUG
+                            );
+                        },
+                    ],
+                ],
+            ],
+            'Filegator\Services\Session\SessionStorageInterface' => [
+                'handler' => '\Filegator\Services\Session\Adapters\SessionStorage',
+                'config' => [
+                    'handler' => function () {
+                        $save_path = null; // use default system path
+                        //$save_path = __DIR__.'/private/sessions';
+                        $handler = new \Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeFileSessionHandler($save_path);
+    
+                        return new \Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage([
+                                "cookie_samesite" => "None",
+                                "cookie_secure" => true,
+                                "cookie_httponly" => true,
+                            ], $handler);
+                    },
+                ],
+            ],
+            'Filegator\Services\Cors\Cors' => [
+                'handler' => '\Filegator\Services\Cors\Cors',
+                'config' => [
+                    // 'enabled' => APP_ENV == 'production' ? false : true,
+                    'enabled' => true,
+                ],
+            ],
+            'Filegator\Services\Tmpfs\TmpfsInterface' => [
+                'handler' => '\Filegator\Services\Tmpfs\Adapters\Tmpfs',
+                'config' => [
+                    'path' => __DIR__.'/private/tmp/',
+                    'gc_probability_perc' => 10,
+                    'gc_older_than' => 60 * 60 * 24 * 2, // 2 days
+                ],
+            ],
+            'Filegator\Services\Security\Security' => [
+                'handler' => '\Filegator\Services\Security\Security',
+                'config' => [
+                    'csrf_protection' => true,
+                    'csrf_key' => "123456", // randomize this
+                    'ip_allowlist' => [],
+                    'ip_denylist' => [],
+                    // Allows FileGator to run inside an iframe.
+                    'allow_insecure_overlays' => true,
+                ],
+            ],
+            'Filegator\Services\View\ViewInterface' => [
+                'handler' => '\Filegator\Services\View\Adapters\Vuejs',
+                'config' => [
+                    'add_to_head' => '',
+                    'add_to_body' => '',
+                ],
+            ],
+            'Filegator\Services\Storage\Filesystem' => [
+                'handler' => '\Filegator\Services\Storage\Filesystem',
+                'config' => [
+                    'separator' => '/',
+                    'config' => [],
+                    'adapter' => function () {
+                        return new \League\Flysystem\Adapter\Local(
+                            // __DIR__.'/repository'
+                            '/var/www/filegator/repository'
+                        );
+                    },
+                ],
+            ],
+            'Filegator\Services\Archiver\ArchiverInterface' => [
+                'handler' => '\Filegator\Services\Archiver\Adapters\ZipArchiver',
+                'config' => [],
+            ],
+            'Filegator\Services\Auth\AuthInterface' => [
+                'handler' => '\Filegator\Services\Auth\Adapters\Database',
+                'config' => [
+                    'driver' => 'mysqli',
+                    'host' => '192.168.51.165', // IPv4 of host computer
+                    'port' => 3306,
+                    'username' => 'root',
+                    'password' => '1234',
+                    'database' => 'ticketing_system',
+                ],
+            ],
+            // 'Filegator\Services\Auth\AuthInterface' => [
+            //     'handler' => '\Filegator\Services\Auth\Adapters\JsonFile',
+            //     'config' => [
+            //         'file' => __DIR__.'/private/users.json',
+            //     ],
+            // ],
+            'Filegator\Services\Router\Router' => [
+                'handler' => '\Filegator\Services\Router\Router',
+                'config' => [
+                    'query_param' => 'r',
+                    'routes_file' => __DIR__.'/backend/Controllers/routes.php',
+                ],
+            ],
+        ],
+    ];

--- a/filegator/filegator-deployment.yaml
+++ b/filegator/filegator-deployment.yaml
@@ -42,17 +42,20 @@ spec:
             path: "/mnt/d/14 9 13 9 20/Projects/Ticketing System/TicketingSystem/filegator/backend"
             type: Directory
         - name: ini-file
-          hostPath:
-            path: "/mnt/d/14 9 13 9 20/Projects/Ticketing System/TicketingSystem/filegator/backend/php.ini"
-            type: File
+          configMap:
+            name: filegator-config
+            items:
+              - key: php.ini
+                path: php.ini
         - name: config
-          hostPath:
-            path: "/mnt/d/14 9 13 9 20/Projects/Ticketing System/TicketingSystem/filegator/configuration.php"
-            type: File
+          configMap:
+            name: filegator-config
+            items:
+              - key: configuration.php
+                path: configuration.php
         - name: file-data
-          hostPath:
-            path: "/mnt/d/14 9 13 9 20/Projects/Ticketing System/TicketingSystem/filegator/data"
-            type: DirectoryOrCreate
+          persistentVolumeClaim:
+            claimName: filegator-repository-pvc
 ---
 apiVersion: v1
 kind: Service

--- a/filegator/filegator-pvc.yaml
+++ b/filegator/filegator-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: filegator-repository-pvc
+  labels:
+    app: filegator
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
## Summary
- package config files into `filegator-configmap.yaml`
- create a persistent volume claim for uploaded files
- mount the new ConfigMap and PVC in the deployment
- document how to build the image for Minikube and apply the manifests

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686218ed63d483329fcfce5d5d0621ba