### PR TITLE
Improve sidebar responsiveness

### DIFF
--- a/ui/src/components/Layout/SidebarLayout.tsx
+++ b/ui/src/components/Layout/SidebarLayout.tsx
@@ -2,21 +2,44 @@ import React, { useState } from "react";
 import { Outlet } from "react-router-dom";
 import Sidebar from "./Sidebar";
 import Header from "./Header";
+import Drawer from "@mui/material/Drawer";
+import { useTheme, useMediaQuery } from "@mui/material";
 
 const SidebarLayout: React.FC = () => {
-  const [collapsed, setCollapsed] = useState(false);
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  const [collapsedState, setCollapsedState] = useState(false);
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const toggleSidebar = () => {
+    if (isMobile) {
+      setMobileOpen(!mobileOpen);
+    } else {
+      setCollapsedState(!collapsedState);
+    }
+  };
+
+  const collapsed = isMobile ? !mobileOpen : collapsedState;
 
   return (
     <>
-      <Header
-        collapsed={collapsed}
-        toggleSidebar={() => setCollapsed(!collapsed)}
-      />
+      <Header collapsed={collapsed} toggleSidebar={toggleSidebar} />
       <div
         className="d-flex pb-2"
         style={{ maxHeight: "97vh", minHeight: "97vh" }}
       >
-        <Sidebar collapsed={collapsed} />
+        {isMobile ? (
+          <Drawer
+            variant="temporary"
+            open={mobileOpen}
+            onClose={toggleSidebar}
+            ModalProps={{ keepMounted: true }}
+          >
+            <Sidebar collapsed={false} />
+          </Drawer>
+        ) : (
+          <Sidebar collapsed={collapsedState} />
+        )}
         <div
           className="flex-grow-1 p-3"
           style={{ marginTop: "0", overflowY: "scroll" }}


### PR DESCRIPTION
## Summary
- make SidebarLayout responsive using Material UI Drawer
- toggle sidebar visibility on mobile screens

## Testing
- `npm ci --omit=optional --legacy-peer-deps`
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6864b7081bdc83329467169b28e3ba98