### PR TITLE
Add assignment history UI and controller

### DIFF
--- a/api/src/main/java/com/example/api/controller/AssignmentHistoryController.java
+++ b/api/src/main/java/com/example/api/controller/AssignmentHistoryController.java
@@ -1,0 +1,24 @@
+package com.example.api.controller;
+
+import com.example.api.models.AssignmentHistory;
+import com.example.api.service.AssignmentHistoryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/assignment-history")
+@CrossOrigin(origins = "http://localhost:3000")
+public class AssignmentHistoryController {
+    private final AssignmentHistoryService historyService;
+
+    public AssignmentHistoryController(AssignmentHistoryService historyService) {
+        this.historyService = historyService;
+    }
+
+    @GetMapping("/{ticketId}")
+    public ResponseEntity<List<AssignmentHistory>> getHistory(@PathVariable int ticketId) {
+        return ResponseEntity.ok(historyService.getHistoryForTicket(ticketId));
+    }
+}

--- a/db/ticketing_system_dump.sql
+++ b/db/ticketing_system_dump.sql
@@ -71,6 +71,10 @@ CREATE TABLE `status_history` (
 
 LOCK TABLES `status_history` WRITE;
 /*!40000 ALTER TABLE `status_history` DISABLE KEYS */;
+INSERT INTO `status_history` VALUES 
+  (1,1,'arjunm','PENDING','ON_HOLD','2025-06-09 10:00:00'),
+  (2,5,'helpdesk.user','ON_HOLD','CLOSED','2025-06-09 10:05:00'),
+  (3,6,'eshas','PENDING','REOPENED','2025-06-09 10:10:00');
 /*!40000 ALTER TABLE `status_history` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/ui/src/components/AssignmentHistory/index.tsx
+++ b/ui/src/components/AssignmentHistory/index.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react';
+import { Table } from 'antd';
+import ViewToggle from '../UI/ViewToggle';
+import { useApi } from '../../hooks/useApi';
+import { getAssignmentHistory } from '../../services/AssignmentHistoryService';
+import { Timeline, TimelineItem, TimelineSeparator, TimelineDot, TimelineConnector, TimelineContent } from '@mui/lab';
+import { Paper } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+
+interface HistoryEntry {
+    id: number;
+    assignedBy: string;
+    assignedTo: string;
+    timestamp: string;
+}
+
+interface AssignmentHistoryProps {
+    ticketId: number;
+}
+
+const AssignmentHistory: React.FC<AssignmentHistoryProps> = ({ ticketId }) => {
+    const { data, apiHandler } = useApi<any>();
+    const [view, setView] = useState<'table' | 'timeline'>('table');
+    const { t } = useTranslation();
+
+    useEffect(() => {
+        apiHandler(() => getAssignmentHistory(ticketId));
+    }, [ticketId]);
+
+    const columns = [
+        { title: t('Assigned By'), dataIndex: 'assignedBy', key: 'assignedBy' },
+        { title: t('Assigned To'), dataIndex: 'assignedTo', key: 'assignedTo' },
+        {
+            title: t('Timestamp'),
+            dataIndex: 'timestamp',
+            key: 'timestamp',
+            render: (v: string) => new Date(v).toLocaleString(),
+        },
+    ];
+
+    const history = Array.isArray(data) ? data : [];
+
+    return (
+        <div>
+            <div className="d-flex justify-content-end mb-2">
+                <ViewToggle
+                    value={view}
+                    onChange={setView}
+                    options={[
+                        { icon: 'table', value: 'table' },
+                        { icon: 'timeline', value: 'timeline' }
+                    ]}
+                />
+            </div>
+            {view === 'table' ? (
+                <Table dataSource={history} columns={columns as any} rowKey="id" pagination={false} />
+            ) : (
+                <Timeline>
+                    {history.map((h, idx) => (
+                        <TimelineItem key={h.id}>
+                            <TimelineSeparator>
+                                <TimelineDot />
+                                {idx < history.length - 1 && <TimelineConnector />}
+                            </TimelineSeparator>
+                            <TimelineContent>
+                                <Paper elevation={2} sx={{ p: 1 }}>
+                                    <strong>{h.assignedTo}</strong>
+                                    <div style={{ fontSize: 12 }}>
+                                        {new Date(h.timestamp).toLocaleString()} - {h.assignedBy}
+                                    </div>
+                                </Paper>
+                            </TimelineContent>
+                        </TimelineItem>
+                    ))}
+                </Timeline>
+            )}
+        </div>
+    );
+};
+
+export default AssignmentHistory;

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -80,5 +80,8 @@
   "Updated By": "Updated By",
   "Timestamp": "Timestamp",
   "Previous Status": "Previous Status",
-  "Current Status": "Current Status"
+  "Current Status": "Current Status",
+  "Track Assignment History": "Track Assignment History",
+  "Assigned By": "Assigned By",
+  "Assigned To": "Assigned To"
 }

--- a/ui/src/locales/hi/translation.json
+++ b/ui/src/locales/hi/translation.json
@@ -80,5 +80,8 @@
   "Updated By": "अद्यतन करने वाला",
   "Timestamp": "समय",
   "Previous Status": "पिछली स्थिति",
-  "Current Status": "वर्तमान स्थिति"
+  "Current Status": "वर्तमान स्थिति",
+  "Track Assignment History": "असाइनमेंट इतिहास देखें",
+  "Assigned By": "द्वारा असाइन किया गया",
+  "Assigned To": "किसे असाइन किया गया"
 }

--- a/ui/src/pages/TicketDetails.tsx
+++ b/ui/src/pages/TicketDetails.tsx
@@ -14,6 +14,7 @@ import GenericButton from "../components/UI/Button";
 import Switch from "@mui/material/Switch";
 import CommentsSection from "../components/Comments/CommentsSection";
 import StatusHistory from "../components/StatusHistory";
+import AssignmentHistory from "../components/AssignmentHistory";
 import { IconButton } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
@@ -51,6 +52,7 @@ const TicketDetails: React.FC = () => {
     const statusValue = useWatch({ control, name: 'status' });
     const [editing, setEditing] = useState<boolean>(false);
     const [showHistory, setShowHistory] = useState<boolean>(false);
+    const [showAssignmentHistory, setShowAssignmentHistory] = useState<boolean>(false);
 
     // API calls
     const getTicketHandler = (ticketId: any) => {
@@ -157,12 +159,16 @@ const TicketDetails: React.FC = () => {
             </form>
 
             <CommentsSection ticketId={Number(ticketId)} />
-            <div className="mt-3">
+            <div className="mt-3 d-flex gap-2">
                 <GenericButton variant="outlined" onClick={() => setShowHistory(!showHistory)}>
                     {t('Track Ticket Status')}
                 </GenericButton>
+                <GenericButton variant="outlined" onClick={() => setShowAssignmentHistory(!showAssignmentHistory)}>
+                    {t('Track Assignment History')}
+                </GenericButton>
             </div>
             {showHistory && <StatusHistory ticketId={Number(ticketId)} />}
+            {showAssignmentHistory && <AssignmentHistory ticketId={Number(ticketId)} />}
         </div>
     );
 };

--- a/ui/src/services/AssignmentHistoryService.ts
+++ b/ui/src/services/AssignmentHistoryService.ts
@@ -1,0 +1,6 @@
+import axios from 'axios';
+import { BASE_URL } from './api';
+
+export function getAssignmentHistory(ticketId: number) {
+    return axios.get(`${BASE_URL}/assignment-history/${ticketId}`);
+}


### PR DESCRIPTION
## Summary
- add AssignmentHistoryController API endpoint
- show assignment history in TicketDetails with toggles
- create AssignmentHistory component and service
- add translation keys for assignment history
- add dummy status history entries in SQL dump

## Testing
- `npm install` *(fails: could not resolve dependencies)*
- `CI=true npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*
- `./gradlew test` *(fails: Java toolchain not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e57d991a88332b291d3ac585a7925