### PR TITLE
Implement collapsible fieldsets and move history buttons

### DIFF
--- a/ui/src/components/AssignmentHistory/index.tsx
+++ b/ui/src/components/AssignmentHistory/index.tsx
@@ -4,7 +4,7 @@ import ViewToggle from '../UI/ViewToggle';
 import { useApi } from '../../hooks/useApi';
 import { getAssignmentHistory } from '../../services/AssignmentHistoryService';
 import { Timeline, TimelineItem, TimelineSeparator, TimelineDot, TimelineConnector, TimelineContent } from '@mui/lab';
-import { Paper } from '@mui/material';
+import { Paper, useTheme, useMediaQuery } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 
 interface HistoryEntry {
@@ -22,6 +22,8 @@ const AssignmentHistory: React.FC<AssignmentHistoryProps> = ({ ticketId }) => {
     const { data, apiHandler } = useApi<any>();
     const [view, setView] = useState<'table' | 'timeline'>('table');
     const { t } = useTranslation();
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
     useEffect(() => {
         apiHandler(() => getAssignmentHistory(ticketId));
@@ -55,7 +57,7 @@ const AssignmentHistory: React.FC<AssignmentHistoryProps> = ({ ticketId }) => {
             {view === 'table' ? (
                 <Table dataSource={history} columns={columns as any} rowKey="id" pagination={false} />
             ) : (
-                <Timeline>
+                <Timeline orientation={isMobile ? 'vertical' : 'horizontal'}>
                     {history.map((h, idx) => (
                         <TimelineItem key={h.id}>
                             <TimelineSeparator>

--- a/ui/src/components/CustomFieldset.tsx
+++ b/ui/src/components/CustomFieldset.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { cardContainer1Header } from "../constants/bootstrapClasses";
 import { FciTheme } from "../config/config";
 import { useTheme } from "@mui/material";
+import CustomIconButton from "./UI/IconButton/CustomIconButton";
 
 interface CustomFieldsetProps {
     title: string;
@@ -14,28 +15,31 @@ interface CustomFieldsetProps {
 
 const CustomFieldset: React.FC<CustomFieldsetProps> = ({ title, children, className = "", style, actionElement, disabled }) => {
     const theme = useTheme();
+    const [collapsed, setCollapsed] = useState(false);
 
-    console.log(theme)
-    
     useEffect(() => {
-        console.log(theme)
         document.documentElement.style.setProperty('--sub-heading-text-color', theme.palette.success.main);
         document.documentElement.style.setProperty('--sub-heading-disabled-text-color', theme.palette.success.dark);
     }, [theme.palette.mode]);
 
+    const toggleCollapse = () => setCollapsed(!collapsed);
+
     if (FciTheme) return (
         <div className="form-container">
-            <div className={`form-title-disabled ${true ? '-disabled' : ''}`}>
-                <h4>{title}</h4>
+            <div className={`form-title-disabled ${disabled ? '-disabled' : ''} d-flex justify-content-between align-items-center`} onClick={toggleCollapse} style={{cursor:'pointer'}}>
+                <h4 className="mb-0">{title}</h4>
+                <CustomIconButton icon={collapsed ? 'arrowdown' : 'arrowup'} size="small" />
             </div>
-            <div className="p-2">
-                {actionElement && (
-                    <div className="d-flex m-2 justify-content-end">
-                        {actionElement}
-                    </div>
-                )}
-                {children}
-            </div>
+            {!collapsed && (
+                <div className="p-2">
+                    {actionElement && (
+                        <div className="d-flex m-2 justify-content-end">
+                            {actionElement}
+                        </div>
+                    )}
+                    {children}
+                </div>
+            )}
         </div>
     );
 
@@ -47,9 +51,9 @@ const CustomFieldset: React.FC<CustomFieldsetProps> = ({ title, children, classN
             }}
         >
             <legend
-                className={`${cardContainer1Header}`}
+                className={`${cardContainer1Header} d-flex justify-content-between align-items-center`}
                 style={{
-                    width: "fit-content",
+                    width: "calc(100% - 2rem)",
                     fontSize: "1rem",
                     fontWeight: "500",
                     padding: "0 8px",
@@ -58,17 +62,23 @@ const CustomFieldset: React.FC<CustomFieldsetProps> = ({ title, children, classN
                     top: "-1.1rem",
                     left: "1rem",
                     backgroundColor: "white",
-                    display: "inline-block"
+                    display: "flex"
                 }}
+                onClick={toggleCollapse}
             >
-                {title}
+                <span>{title}</span>
+                <CustomIconButton icon={collapsed ? 'arrowdown' : 'arrowup'} size="small" />
             </legend>
-            {actionElement && (
-                <div style={{ position: 'absolute', top: 8, right: 8 }}>
-                    {actionElement}
+            {!collapsed && (
+                <div>
+                    {actionElement && (
+                        <div style={{ position: 'absolute', top: 8, right: 8 }}>
+                            {actionElement}
+                        </div>
+                    )}
+                    {children}
                 </div>
             )}
-            {children}
         </fieldset>
     );
 };

--- a/ui/src/components/StatusHistory/index.tsx
+++ b/ui/src/components/StatusHistory/index.tsx
@@ -4,7 +4,7 @@ import ViewToggle from '../UI/ViewToggle';
 import { useApi } from '../../hooks/useApi';
 import { getStatusHistory } from '../../services/StatusHistoryService';
 import { Timeline, TimelineItem, TimelineSeparator, TimelineDot, TimelineConnector, TimelineContent } from '@mui/lab';
-import { Paper } from '@mui/material';
+import { Paper, useTheme, useMediaQuery } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 
 interface HistoryEntry {
@@ -23,6 +23,8 @@ const StatusHistory: React.FC<StatusHistoryProps> = ({ ticketId }) => {
     const { data, apiHandler } = useApi<any>();
     const [view, setView] = useState<'table' | 'timeline'>('table');
     const { t } = useTranslation();
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
     useEffect(() => {
         apiHandler(() => getStatusHistory(ticketId));
@@ -67,7 +69,7 @@ const StatusHistory: React.FC<StatusHistoryProps> = ({ ticketId }) => {
             {view === 'table' ? (
                 <Table dataSource={history} columns={columns as any} rowKey="id" pagination={false} />
             ) : (
-                <Timeline>
+                <Timeline orientation={isMobile ? 'vertical' : 'horizontal'}>
                     {history.map((h, idx) => (
                         <TimelineItem key={h.id}>
                             <TimelineSeparator>

--- a/ui/src/components/UI/IconButton/CustomIconButton.tsx
+++ b/ui/src/components/UI/IconButton/CustomIconButton.tsx
@@ -11,6 +11,8 @@ import DarkModeIcon from '@mui/icons-material/DarkMode';
 import LightModeIcon from '@mui/icons-material/LightMode';
 import TranslateIcon from '@mui/icons-material/Translate';
 import TimelineIcon from '@mui/icons-material/Timeline';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 
 // Define the icon map
 const iconMap = {
@@ -24,7 +26,9 @@ const iconMap = {
     darkmode: DarkModeIcon,
     lightmode: LightModeIcon,
     translate: TranslateIcon,
-    timeline: TimelineIcon
+    timeline: TimelineIcon,
+    arrowdown: KeyboardArrowDownIcon,
+    arrowup: KeyboardArrowUpIcon
 };
 
 // Valid keys for the icon map

--- a/ui/src/pages/TicketDetails.tsx
+++ b/ui/src/pages/TicketDetails.tsx
@@ -133,6 +133,18 @@ const TicketDetails: React.FC = () => {
 
             <form onSubmit={handleSubmit(onSubmitUpdate)}>
                 <RequestDetails register={register} control={control} errors={errors} disableAll isFieldSetDisabled />
+
+                <div className="mt-3 d-flex gap-2">
+                    <GenericButton variant="outlined" onClick={() => setShowHistory(!showHistory)}>
+                        {t('Track Ticket Status')}
+                    </GenericButton>
+                    <GenericButton variant="outlined" onClick={() => setShowAssignmentHistory(!showAssignmentHistory)}>
+                        {t('Track Assignment History')}
+                    </GenericButton>
+                </div>
+                {showHistory && <StatusHistory ticketId={Number(ticketId)} />}
+                {showAssignmentHistory && <AssignmentHistory ticketId={Number(ticketId)} />}
+
                 <RequestorDetails register={register} control={control} errors={errors} setValue={setValue} disableAll />
 
                 <TicketDetailsForm
@@ -159,16 +171,6 @@ const TicketDetails: React.FC = () => {
             </form>
 
             <CommentsSection ticketId={Number(ticketId)} />
-            <div className="mt-3 d-flex gap-2">
-                <GenericButton variant="outlined" onClick={() => setShowHistory(!showHistory)}>
-                    {t('Track Ticket Status')}
-                </GenericButton>
-                <GenericButton variant="outlined" onClick={() => setShowAssignmentHistory(!showAssignmentHistory)}>
-                    {t('Track Assignment History')}
-                </GenericButton>
-            </div>
-            {showHistory && <StatusHistory ticketId={Number(ticketId)} />}
-            {showAssignmentHistory && <AssignmentHistory ticketId={Number(ticketId)} />}
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- make `CustomFieldset` collapsible with arrow icon
- add arrow icons in `CustomIconButton`
- display status and assignment history controls above Requestor Details
- show timeline horizontally on desktop and vertically on mobile

## Testing
- `npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f78ebf2108332b966fffb94391a42