### PR TITLE
Add reusable table component with dark theme

### DIFF
--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Table } from 'antd';
+import GenericTable from '../UI/GenericTable';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import MasterIcon from '../UI/Icons/MasterIcon';
 
@@ -66,7 +66,7 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onRowClick }) => {
     );
 
     return (
-        <Table
+        <GenericTable
             dataSource={tickets}
             columns={columns as any}
             rowKey="id"

--- a/ui/src/components/AssignmentHistory/index.tsx
+++ b/ui/src/components/AssignmentHistory/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Table } from 'antd';
+import GenericTable from '../UI/GenericTable';
 import ViewToggle from '../UI/ViewToggle';
 import { useApi } from '../../hooks/useApi';
 import { getAssignmentHistory } from '../../services/AssignmentHistoryService';
@@ -55,7 +55,7 @@ const AssignmentHistory: React.FC<AssignmentHistoryProps> = ({ ticketId }) => {
                 />
             </div>
             {view === 'table' ? (
-                <Table dataSource={history} columns={columns as any} rowKey="id" pagination={false} />
+                <GenericTable dataSource={history} columns={columns as any} rowKey="id" pagination={false} />
             ) : (
                 <Timeline>
                     {history.map((h, idx) => (

--- a/ui/src/components/StatusHistory/index.tsx
+++ b/ui/src/components/StatusHistory/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Table } from 'antd';
+import GenericTable from '../UI/GenericTable';
 import ViewToggle from '../UI/ViewToggle';
 import { useApi } from '../../hooks/useApi';
 import { getStatusHistory } from '../../services/StatusHistoryService';
@@ -25,8 +25,6 @@ const StatusHistory: React.FC<StatusHistoryProps> = ({ ticketId }) => {
     const { t } = useTranslation();
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
-
-    const isDarkMode = theme.palette.mode === 'dark';
 
     useEffect(() => {
         apiHandler(() => getStatusHistory(ticketId));
@@ -69,9 +67,7 @@ const StatusHistory: React.FC<StatusHistoryProps> = ({ ticketId }) => {
                 />
             </div>
             {view === 'table' ? (
-                <div className={isDarkMode ? 'table-dark-theme' : ''}>
-                    <Table dataSource={history} columns={columns as any} rowKey="id" pagination={false} />
-                </div>
+                <GenericTable dataSource={history} columns={columns as any} rowKey="id" pagination={false} />
             ) : (
                 <Timeline>
                     {history.map((h, idx) => (

--- a/ui/src/components/UI/GenericTable.tsx
+++ b/ui/src/components/UI/GenericTable.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Table, TableProps } from 'antd';
+import { useTheme } from '@mui/material';
+
+const GenericTable = <T extends object = any>({ className, ...props }: TableProps<T>) => {
+    const theme = useTheme();
+    const isDark = theme.palette.mode === 'dark';
+    const classes = `${isDark ? 'table-dark-theme' : ''} ${className ?? ''}`.trim();
+    return <Table className={classes} {...props} />;
+};
+
+export default GenericTable;

--- a/ui/src/pages/EscalationMaster.tsx
+++ b/ui/src/pages/EscalationMaster.tsx
@@ -4,7 +4,7 @@ import CustomFieldset from '../components/CustomFieldset';
 import { useTranslation } from 'react-i18next';
 import GenericInput from '../components/UI/Input/GenericInput';
 import GenericButton from '../components/UI/Button';
-import { Table } from 'antd';
+import GenericTable from '../components/UI/GenericTable';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { addEmployee, deleteEmployee, getAllEmployees } from '../services/EmployeeService';
 import { useApi } from '../hooks/useApi';
@@ -128,7 +128,7 @@ const EscalationMaster: React.FC = () => {
       <div className="my-3 w-25">
         <GenericInput label="Search" fullWidth value={search} onChange={e => setSearch(e.target.value)} />
       </div>
-      <Table columns={columns as any} dataSource={filtered} rowKey="employeeId" className="mt-4" pagination={false} />
+      <GenericTable columns={columns as any} dataSource={filtered} rowKey="employeeId" className="mt-4" pagination={false} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- implement `GenericTable` that automatically applies dark theme classes
- replace direct AntD table usage with new component in status history, assignment history, escalation master page, and tickets table

## Testing
- `npm test --silent --prefix .. -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f9496974c8332aed8939e09da384e