### PR TITLE
Rotate history sidebar buttons

### DIFF
--- a/ui/src/components/HistorySidebar.tsx
+++ b/ui/src/components/HistorySidebar.tsx
@@ -24,9 +24,23 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ ticketId }) => {
     return (
         <>
             {!open && (
-                <div style={{ position: 'fixed', right: 0, top: '40%', zIndex: 1300, display: 'flex', flexDirection: 'column', gap: 8 }}>
-                    <Button variant="contained" size="small" onClick={() => handleOpen('status')}>{t('Status History')}</Button>
-                    <Button variant="contained" size="small" onClick={() => handleOpen('assignment')}>{t('Assignment History')}</Button>
+                <div style={{ position: 'fixed', right: -40, top: '40%', zIndex: 1300, display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    <Button
+                        variant="contained"
+                        size="small"
+                        onClick={() => handleOpen('status')}
+                        sx={{ transform: 'rotate(-90deg)' }}
+                    >
+                        {t('Status History')}
+                    </Button>
+                    <Button
+                        variant="contained"
+                        size="small"
+                        onClick={() => handleOpen('assignment')}
+                        sx={{ transform: 'rotate(-90deg)' }}
+                    >
+                        {t('Assignment History')}
+                    </Button>
                 </div>
             )}
             <Drawer anchor="right" open={open} onClose={handleClose}>


### PR DESCRIPTION
## Summary
- rotate Status History and Assignment History buttons

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm ci` *(fails to resolve deps)*

------
https://chatgpt.com/codex/tasks/task_e_68709a72bc488332b027f65f262f2b90