### PR TITLE
Fix header logos path

### DIFF
--- a/ui/src/components/Layout/Header.tsx
+++ b/ui/src/components/Layout/Header.tsx
@@ -44,8 +44,12 @@ const Header: React.FC<HeaderProps> = ({ collapsed, toggleSidebar }) => {
         onClick={toggleSidebar}
       />
       <div>
-        {theme.palette.mode === 'light' && <img src="./logo.png" style={{ height: '50px' }} />}
-        {theme.palette.mode === 'dark' && <img src="./fciLogo.png" style={{ height: '50px' }} />}
+        {theme.palette.mode === 'light' && (
+          <img src="/logo.png" style={{ height: '50px' }} />
+        )}
+        {theme.palette.mode === 'dark' && (
+          <img src="/fciLogo.png" style={{ height: '50px' }} />
+        )}
       </div>
       <div className="d-flex align-items-center" style={{ marginLeft: "auto", gap: "8px" }}>
         <CustomIconButton


### PR DESCRIPTION
## Summary
- fix path references for the header logos so they render

## Testing
- `./gradlew test --no-daemon` *(fails: could not resolve from `jitpack.io`)*
- `npm test -- --watchAll=false` *(fails: cannot find module `react-router-dom`)*

------
https://chatgpt.com/codex/tasks/task_e_6875deb6c4308332a2366ed6cc13fa1d