### PR TITLE
Update dark mode header and sidebar styling

### DIFF
--- a/ui/src/components/Layout/Header.tsx
+++ b/ui/src/components/Layout/Header.tsx
@@ -24,21 +24,27 @@ const Header: React.FC<HeaderProps> = ({ collapsed, toggleSidebar }) => {
       .toUpperCase()
     : "";
 
+  const headerBgColor =
+    theme.palette.mode === "dark"
+      ? theme.palette.secondary.main
+      : theme.palette.primary.main;
+
   return (
     <header
       style={{
-        backgroundColor: theme.palette.primary.main,
-        color: theme.palette.getContrastText(theme.palette.primary.main),
+        backgroundColor: headerBgColor,
+        color: theme.palette.getContrastText(headerBgColor),
         width: "100%",
         padding: "10px",
         display: "flex",
         alignItems: "center",
         justifyContent: "space-between",
+        borderBottom: "1px solid lightgreen",
       }}
     >
       <CustomIconButton
         style={{
-          color: theme.palette.getContrastText(theme.palette.primary.main),
+          color: theme.palette.getContrastText(headerBgColor),
         }}
         icon={collapsed ? "menu" : "chevronleft"}
         onClick={toggleSidebar}
@@ -54,14 +60,14 @@ const Header: React.FC<HeaderProps> = ({ collapsed, toggleSidebar }) => {
       <div className="d-flex align-items-center" style={{ marginLeft: "auto", gap: "8px" }}>
         <CustomIconButton
           style={{
-            color: theme.palette.getContrastText(theme.palette.primary.main),
+            color: theme.palette.getContrastText(headerBgColor),
           }}
           icon={mode === "light" ? "darkmode" : "lightmode"}
           onClick={toggle}
         />
         <CustomIconButton
           style={{
-            color: theme.palette.getContrastText(theme.palette.primary.main),
+            color: theme.palette.getContrastText(headerBgColor),
           }}
           icon="translate"
           onClick={toggleLanguage}

--- a/ui/src/components/Layout/Sidebar.tsx
+++ b/ui/src/components/Layout/Sidebar.tsx
@@ -54,6 +54,8 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
 
   const bgColor = theme.palette.secondary.main;
   const textColor = theme.palette.mode === 'dark' ? '#FFA64D' : '#FFFFFF';
+  const sidebarBorder =
+    theme.palette.mode === 'dark' ? `1px solid ${textColor}` : undefined;
 
   return (
     <div
@@ -65,6 +67,7 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
         transition: "width 0.3s",
         display: "flex",
         flexDirection: "column",
+        borderRight: sidebarBorder,
       }}
     >
       <List component="nav">


### PR DESCRIPTION
## Summary
- keep header background consistent with sidebar when dark theme
- add a light green bottom border to the header
- add a dark theme right border on the sidebar

## Testing
- `CI=true npm test --silent` *(fails: Cannot find module 'react-router-dom')*
- `./gradlew test` *(fails: Java toolchain auto-detection problem)*

------
https://chatgpt.com/codex/tasks/task_e_6875f2fa0fc883329997c97b14e47a68