### PR TITLE
Update sidebar and dark mode styles

### DIFF
--- a/ui/src/components/Layout/Sidebar.tsx
+++ b/ui/src/components/Layout/Sidebar.tsx
@@ -53,14 +53,8 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
   const theme = useTheme();
 
   const bgColor = theme.palette.secondary.main;
-  const textColor =
-    theme.palette.mode === 'dark'
-      ? theme.palette.success.main
-      : '#FFFFFF';
-  const sidebarBorder =
-    theme.palette.mode === 'dark'
-      ? `1px solid ${theme.palette.success.main}`
-      : undefined;
+  const textColor = '#ff9800';
+  const sidebarBorder = `1px solid ${textColor}`;
 
   return (
     <div

--- a/ui/src/themes.ts
+++ b/ui/src/themes.ts
@@ -32,6 +32,9 @@ const darkTheme = createTheme({
       default: '#303030',
       paper: '#424242',
     },
+    action: {
+      disabledBackground: '#555555',
+    },
   },
   components: {
     MuiButton: {


### PR DESCRIPTION
## Summary
- use constant orange color for sidebar text and border
- set dark mode disabled background to dark grey

## Testing
- `npm test -- -u --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6876072fde288332aa1fc9ab08314491