### PR TITLE
Configure Freemarker bean usage

### DIFF
--- a/api/src/main/java/com/example/notification/config/FreemarkerConfig.java
+++ b/api/src/main/java/com/example/notification/config/FreemarkerConfig.java
@@ -2,12 +2,14 @@ package com.example.notification.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
 import java.io.IOException;
 
 @Configuration
 public class FreemarkerConfig {
     @Bean
+    @Primary
     public freemarker.template.Configuration freemarkerConfiguration() throws IOException {
         freemarker.template.Configuration cfg = new freemarker.template.Configuration(freemarker.template.Configuration.VERSION_2_3_33);
         cfg.setClassLoaderForTemplateLoading(getClass().getClassLoader(), "/notification/templates");

--- a/api/src/main/java/com/example/notification/service/EmailNotifier.java
+++ b/api/src/main/java/com/example/notification/service/EmailNotifier.java
@@ -5,6 +5,7 @@ import com.example.notification.enums.ChannelType;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import jakarta.mail.internet.MimeMessage;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
@@ -18,7 +19,7 @@ public class EmailNotifier implements Notifier {
     private final NotificationProperties properties;
     private final JavaMailSender mailSender;
 
-    public EmailNotifier(Configuration freemarker, NotificationProperties properties, JavaMailSender mailSender) {
+    public EmailNotifier(@Qualifier("freemarkerConfiguration") Configuration freemarker, NotificationProperties properties, JavaMailSender mailSender) {
         this.freemarker = freemarker;
         this.properties = properties;
         this.mailSender = mailSender;

--- a/api/src/main/java/com/example/notification/service/InAppNotifier.java
+++ b/api/src/main/java/com/example/notification/service/InAppNotifier.java
@@ -4,6 +4,7 @@ import com.example.notification.config.NotificationProperties;
 import com.example.notification.enums.ChannelType;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
@@ -15,7 +16,7 @@ public class InAppNotifier implements Notifier{
     private final Configuration freemarker;
     private final SimpMessagingTemplate messagingTemplate;
 
-    public InAppNotifier(Configuration freemarker, SimpMessagingTemplate messagingTemplate) {
+    public InAppNotifier(@Qualifier("freemarkerConfiguration") Configuration freemarker, SimpMessagingTemplate messagingTemplate) {
         this.freemarker = freemarker;
         this.messagingTemplate = messagingTemplate;
     }

--- a/api/src/main/java/com/example/notification/service/SmsNotifier.java
+++ b/api/src/main/java/com/example/notification/service/SmsNotifier.java
@@ -7,6 +7,7 @@ import com.twilio.rest.api.v2010.account.Message;
 import com.twilio.type.PhoneNumber;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import java.io.StringWriter;
@@ -18,7 +19,7 @@ public class SmsNotifier implements Notifier {
     private final Configuration freemarker;
     private final TwilioProperties twilioProperties;
 
-    public SmsNotifier(NotificationProperties properties, Configuration freemarker, TwilioProperties twilioProperties) {
+    public SmsNotifier(NotificationProperties properties, @Qualifier("freemarkerConfiguration") Configuration freemarker, TwilioProperties twilioProperties) {
         this.properties = properties;
         this.freemarker = freemarker;
         this.twilioProperties = twilioProperties;


### PR DESCRIPTION
## Summary
- mark custom Freemarker configuration bean as primary
- wire notifiers to use the custom Freemarker bean via `@Qualifier`

## Testing
- `./gradlew test` *(fails: could not resolve dependencies from jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_68761ddb93fc8332882903157e017cd2