### PR TITLE
Switch repository ID types to String

### DIFF
--- a/api/src/main/java/com/example/api/repository/AssignmentHistoryRepository.java
+++ b/api/src/main/java/com/example/api/repository/AssignmentHistoryRepository.java
@@ -8,6 +8,6 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface AssignmentHistoryRepository extends JpaRepository<AssignmentHistory, Integer> {
+public interface AssignmentHistoryRepository extends JpaRepository<AssignmentHistory, String> {
     List<AssignmentHistory> findByTicketOrderByTimestampAsc(Ticket ticket);
 }

--- a/api/src/main/java/com/example/api/repository/CategoryRepository.java
+++ b/api/src/main/java/com/example/api/repository/CategoryRepository.java
@@ -3,5 +3,5 @@ package com.example.api.repository;
 import com.example.api.models.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CategoryRepository extends JpaRepository<Category, Integer> {
+public interface CategoryRepository extends JpaRepository<Category, String> {
 }

--- a/api/src/main/java/com/example/api/repository/DocumentRepository.java
+++ b/api/src/main/java/com/example/api/repository/DocumentRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface DocumentRepository extends JpaRepository<Document, Integer> {
+public interface DocumentRepository extends JpaRepository<Document, String> {
     List<Document> findByIsDeletedFalse();
 }

--- a/api/src/main/java/com/example/api/repository/LevelRepository.java
+++ b/api/src/main/java/com/example/api/repository/LevelRepository.java
@@ -3,6 +3,6 @@ package com.example.api.repository;
 import com.example.api.models.Level;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface LevelRepository extends JpaRepository<Level, Integer> {
+public interface LevelRepository extends JpaRepository<Level, String> {
     java.util.Optional<Level> findByLevelName(String levelName);
 }

--- a/api/src/main/java/com/example/api/repository/PriorityRepository.java
+++ b/api/src/main/java/com/example/api/repository/PriorityRepository.java
@@ -3,5 +3,5 @@ package com.example.api.repository;
 import com.example.api.models.Priority;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PriorityRepository extends JpaRepository<Priority, Integer> {
+public interface PriorityRepository extends JpaRepository<Priority, String> {
 }

--- a/api/src/main/java/com/example/api/repository/RequestorRepository.java
+++ b/api/src/main/java/com/example/api/repository/RequestorRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface RequestorRepository extends JpaRepository<Requestor, Integer> {
+public interface RequestorRepository extends JpaRepository<Requestor, String> {
 }

--- a/api/src/main/java/com/example/api/repository/SeverityRepository.java
+++ b/api/src/main/java/com/example/api/repository/SeverityRepository.java
@@ -3,5 +3,5 @@ package com.example.api.repository;
 import com.example.api.models.Severity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SeverityRepository extends JpaRepository<Severity, Integer> {
+public interface SeverityRepository extends JpaRepository<Severity, String> {
 }

--- a/api/src/main/java/com/example/api/repository/StatusHistoryRepository.java
+++ b/api/src/main/java/com/example/api/repository/StatusHistoryRepository.java
@@ -8,6 +8,6 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface StatusHistoryRepository extends JpaRepository<StatusHistory, Integer> {
+public interface StatusHistoryRepository extends JpaRepository<StatusHistory, String> {
     List<StatusHistory> findByTicketOrderByTimestampAsc(Ticket ticket);
 }

--- a/api/src/main/java/com/example/api/repository/SubCategoryRepository.java
+++ b/api/src/main/java/com/example/api/repository/SubCategoryRepository.java
@@ -3,5 +3,5 @@ package com.example.api.repository;
 import com.example.api.models.SubCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SubCategoryRepository extends JpaRepository<SubCategory, Integer> {
+public interface SubCategoryRepository extends JpaRepository<SubCategory, String> {
 }

--- a/api/src/main/java/com/example/api/repository/TicketCommentRepository.java
+++ b/api/src/main/java/com/example/api/repository/TicketCommentRepository.java
@@ -8,6 +8,6 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface TicketCommentRepository extends JpaRepository<TicketComment, Integer> {
+public interface TicketCommentRepository extends JpaRepository<TicketComment, String> {
     List<TicketComment> findByTicketOrderByCreatedAtDesc(Ticket ticket);
 }

--- a/api/src/main/java/com/example/api/repository/TicketRepository.java
+++ b/api/src/main/java/com/example/api/repository/TicketRepository.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
-public interface TicketRepository extends JpaRepository<Ticket, Integer> {
+public interface TicketRepository extends JpaRepository<Ticket, String> {
     public List<Ticket> findByIsMasterTrue();
 
     public List<Ticket> findByLastModifiedAfter(LocalDateTime lastSyncedTime);

--- a/api/src/main/java/com/example/api/repository/UserRepository.java
+++ b/api/src/main/java/com/example/api/repository/UserRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Integer> {
+public interface UserRepository extends JpaRepository<User, String> {
     Optional<User> findByUsername(String username);
 }

--- a/api/src/main/java/com/example/api/service/AssignmentHistoryService.java
+++ b/api/src/main/java/com/example/api/service/AssignmentHistoryService.java
@@ -19,7 +19,7 @@ public class AssignmentHistoryService {
         this.ticketRepository = ticketRepository;
     }
 
-    public AssignmentHistory addHistory(int ticketId, String assignedBy, String assignedTo) {
+    public AssignmentHistory addHistory(String ticketId, String assignedBy, String assignedTo) {
         Ticket ticket = ticketRepository.findById(ticketId).orElseThrow();
         AssignmentHistory history = new AssignmentHistory();
         history.setTicket(ticket);
@@ -29,7 +29,7 @@ public class AssignmentHistoryService {
         return historyRepository.save(history);
     }
 
-    public List<AssignmentHistory> getHistoryForTicket(int ticketId) {
+    public List<AssignmentHistory> getHistoryForTicket(String ticketId) {
         Ticket ticket = ticketRepository.findById(ticketId).orElseThrow();
         return historyRepository.findByTicketOrderByTimestampAsc(ticket);
     }

--- a/api/src/main/java/com/example/api/service/CategoryService.java
+++ b/api/src/main/java/com/example/api/service/CategoryService.java
@@ -34,7 +34,7 @@ public class CategoryService {
         return categoryRepository.save(category);
     }
 
-    public Optional<Category> updateCategory(Integer id, Category updated) {
+    public Optional<Category> updateCategory(String id, Category updated) {
         return categoryRepository.findById(id)
                 .map(existing -> {
                     existing.setCategory(updated.getCategory());
@@ -42,18 +42,18 @@ public class CategoryService {
                 });
     }
 
-    public void deleteCategory(Integer id) {
+    public void deleteCategory(String id) {
         categoryRepository.deleteById(id);
     }
 
     @Transactional
-    public void deleteCategories(List<Integer> ids) {
+    public void deleteCategories(List<String> ids) {
         categoryRepository.deleteAllById(ids);
     }
 
     public Optional<Set<SubCategoryDto>> getSubCategoriesByCategory(String categoryId) {
         return categoryRepository
-                .findById(Integer.valueOf(categoryId))
+                .findById(categoryId)
                 .map(category -> category.getSubCategories().stream()
                         .map(DtoMapper::toSubCategoryDto)
                         .collect(java.util.stream.Collectors.toSet()));

--- a/api/src/main/java/com/example/api/service/DocumentService.java
+++ b/api/src/main/java/com/example/api/service/DocumentService.java
@@ -22,7 +22,7 @@ public class DocumentService {
         return documentRepository.save(doc);
     }
 
-    public Document updateDocument(Integer id, Document doc) {
+    public Document updateDocument(String id, Document doc) {
         Document existing = documentRepository.findById(id).orElseThrow();
         existing.setTitle(doc.getTitle());
         existing.setDescription(doc.getDescription());
@@ -31,7 +31,7 @@ public class DocumentService {
         return documentRepository.save(existing);
     }
 
-    public void softDeleteDocument(Integer id) {
+    public void softDeleteDocument(String id) {
         Document existing = documentRepository.findById(id).orElseThrow();
 //        existing.setIsDeleted(true);
         documentRepository.save(existing);

--- a/api/src/main/java/com/example/api/service/LevelService.java
+++ b/api/src/main/java/com/example/api/service/LevelService.java
@@ -31,7 +31,7 @@ public class LevelService {
 
     public Optional<Set<UserDto>> getUsersByLevel(String levelId) {
         return levelRepository
-                .findById(Integer.valueOf(levelId))
+                .findById(levelId)
                 .map(level -> {
                     Set<UserDto> userDtos = new HashSet<>();
                     for (User user : level.getUsers()) { // This access triggers lazy loading

--- a/api/src/main/java/com/example/api/service/StatusHistoryService.java
+++ b/api/src/main/java/com/example/api/service/StatusHistoryService.java
@@ -20,7 +20,7 @@ public class StatusHistoryService {
         this.ticketRepository = ticketRepository;
     }
 
-    public StatusHistory addHistory(int ticketId, String updatedBy, TicketStatus previousStatus, TicketStatus currentStatus) {
+    public StatusHistory addHistory(String ticketId, String updatedBy, TicketStatus previousStatus, TicketStatus currentStatus) {
         Ticket ticket = ticketRepository.findById(ticketId).orElseThrow();
         StatusHistory history = new StatusHistory();
         history.setTicket(ticket);
@@ -31,7 +31,7 @@ public class StatusHistoryService {
         return historyRepository.save(history);
     }
 
-    public List<StatusHistory> getHistoryForTicket(int ticketId) {
+    public List<StatusHistory> getHistoryForTicket(String ticketId) {
         Ticket ticket = ticketRepository.findById(ticketId).orElseThrow();
         return historyRepository.findByTicketOrderByTimestampAsc(ticket);
     }

--- a/api/src/main/java/com/example/api/service/SubCategoryService.java
+++ b/api/src/main/java/com/example/api/service/SubCategoryService.java
@@ -28,11 +28,11 @@ public class SubCategoryService {
             .toList();
     }
 
-    public Optional<SubCategory> getSubCategoryDetails(Integer subCategoryId) {
+    public Optional<SubCategory> getSubCategoryDetails(String subCategoryId) {
         return subCategoryRepository.findById(subCategoryId);
     }
 
-    public SubCategory saveSubCategory(Integer categoryId, SubCategory subCategory) {
+    public SubCategory saveSubCategory(String categoryId, SubCategory subCategory) {
         Category category = categoryRepository.findById(categoryId)
             .orElseThrow(() -> new RuntimeException("Category not found"));
         subCategory.setCategory(category);
@@ -42,7 +42,7 @@ public class SubCategoryService {
         return subCategoryRepository.save(subCategory);
     }
 
-    public Optional<SubCategory> updateSubCategory(Integer id, SubCategory updated) {
+    public Optional<SubCategory> updateSubCategory(String id, SubCategory updated) {
         return subCategoryRepository.findById(id)
             .map(existing -> {
                 existing.setSubCategory(updated.getSubCategory());
@@ -50,7 +50,7 @@ public class SubCategoryService {
             });
     }
 
-    public void deleteSubCategory(Integer id) {
+    public void deleteSubCategory(String id) {
         subCategoryRepository.deleteById(id);
     }
 }

--- a/api/src/main/java/com/example/api/service/TicketService.java
+++ b/api/src/main/java/com/example/api/service/TicketService.java
@@ -62,7 +62,7 @@ public class TicketService {
         return ticketPage.map(DtoMapper::toTicketDto);
     }
 
-    public TicketDto getTicket(int id) {
+    public TicketDto getTicket(String id) {
         Ticket ticket = ticketRepository.findById(id).orElse(null);
         return DtoMapper.toTicketDto(ticket);
     }
@@ -119,7 +119,7 @@ public class TicketService {
         return typesenseClient.searchTickets(query);
     }
 
-    public TicketDto updateTicket(int id, Ticket updated) {
+    public TicketDto updateTicket(String id, Ticket updated) {
         Ticket existing = ticketRepository.findById(id).orElseThrow();
         String previousAssignedTo = existing.getAssignedTo();
         TicketStatus previousStatus = existing.getStatus();
@@ -146,14 +146,14 @@ public class TicketService {
         return DtoMapper.toTicketDto(saved);
     }
 
-    public TicketDto linkToMaster(int id, int masterId) {
+    public TicketDto linkToMaster(String id, String masterId) {
         Ticket ticket = ticketRepository.findById(id).orElseThrow();
-        ticket.setMasterId(masterId);
+        ticket.setMasterId(masterId != null ? Integer.valueOf(masterId) : null);
         Ticket saved = ticketRepository.save(ticket);
         return DtoMapper.toTicketDto(saved);
     }
 
-    public TicketComment addComment(int ticketId, String comment) {
+    public TicketComment addComment(String ticketId, String comment) {
         Ticket ticket = ticketRepository.findById(ticketId).orElseThrow();
         TicketComment tc = new TicketComment();
         tc.setTicket(ticket);
@@ -162,7 +162,7 @@ public class TicketService {
         return commentRepository.save(tc);
     }
 
-    public List<TicketComment> getComments(int ticketId, Integer count) {
+    public List<TicketComment> getComments(String ticketId, Integer count) {
         Ticket ticket = ticketRepository.findById(ticketId).orElseThrow();
         List<TicketComment> list = commentRepository.findByTicketOrderByCreatedAtDesc(ticket);
         if (count == null || count >= list.size()) {
@@ -171,13 +171,13 @@ public class TicketService {
         return list.subList(0, count);
     }
 
-    public TicketComment updateComment(int commentId, String comment) {
+    public TicketComment updateComment(String commentId, String comment) {
         TicketComment existing = commentRepository.findById(commentId).orElseThrow();
         existing.setComment(comment);
         return commentRepository.save(existing);
     }
 
-    public void deleteComment(int commentId) {
+    public void deleteComment(String commentId) {
         commentRepository.deleteById(commentId);
     }
 

--- a/api/src/main/java/com/example/api/service/UserService.java
+++ b/api/src/main/java/com/example/api/service/UserService.java
@@ -16,7 +16,7 @@ public class UserService {
         this.userRepository = userRepository;
     }
 
-    public Optional<User> getUserDetails(Integer userId) {
+    public Optional<User> getUserDetails(String userId) {
         return userRepository.findById(userId);
     }
 
@@ -37,7 +37,7 @@ public class UserService {
         return userRepository.save(user);
     }
 
-    public Optional<User> updateUser(Integer id, User updated) {
+    public Optional<User> updateUser(String id, User updated) {
         return userRepository.findById(id)
                 .map(existing -> {
                     existing.setName(updated.getName());
@@ -49,7 +49,7 @@ public class UserService {
                 });
     }
 
-    public void deleteUser(Integer id) {
+    public void deleteUser(String id) {
         userRepository.deleteById(id);
     }
 }


### PR DESCRIPTION
## Summary
- change `JpaRepository` generics to use `String` IDs
- update service methods to accept and return string IDs
- adjust lookup logic for repositories
- run `./gradlew build`

## Testing
- `./gradlew build` *(fails: Could not get resource 'https://jitpack.io/...')*

------
https://chatgpt.com/codex/tasks/task_e_68772a1473c88332896159bb2bc1de19