### PR TITLE
Switch IDs to strings in frontend

### DIFF
--- a/ui/src/components/AllTickets/TicketCard.tsx
+++ b/ui/src/components/AllTickets/TicketCard.tsx
@@ -4,7 +4,7 @@ import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import MasterIcon from '../UI/Icons/MasterIcon';
 
 export interface TicketCardData {
-    id: number;
+    id: string;
     subject: string;
     category: string;
     subCategory: string;

--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -5,7 +5,7 @@ import VisibilityIcon from '@mui/icons-material/Visibility';
 import MasterIcon from '../UI/Icons/MasterIcon';
 
 export interface TicketRow {
-    id: number;
+    id: string;
     subject: string;
     category: string;
     subCategory: string;
@@ -19,7 +19,7 @@ export interface TicketRow {
 
 interface TicketsTableProps {
     tickets: TicketRow[];
-    onRowClick: (id: number) => void;
+    onRowClick: (id: string) => void;
 }
 
 const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onRowClick }) => {

--- a/ui/src/components/AssignmentHistory/index.tsx
+++ b/ui/src/components/AssignmentHistory/index.tsx
@@ -8,14 +8,14 @@ import { Paper, useTheme, useMediaQuery } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 
 interface HistoryEntry {
-    id: number;
+    id: string;
     assignedBy: string;
     assignedTo: string;
     timestamp: string;
 }
 
 interface AssignmentHistoryProps {
-    ticketId: number;
+    ticketId: string;
 }
 
 const AssignmentHistory: React.FC<AssignmentHistoryProps> = ({ ticketId }) => {

--- a/ui/src/components/Comments/CommentsSection.tsx
+++ b/ui/src/components/Comments/CommentsSection.tsx
@@ -6,13 +6,13 @@ import CustomFieldset from '../CustomFieldset';
 import { useTranslation } from 'react-i18next';
 
 interface Comment {
-    id: number;
+    id: string;
     comment: string;
     createdAt: string;
 }
 
 interface CommentsSectionProps {
-    ticketId: number;
+    ticketId: string;
 }
 
 const timeSince = (dateStr: string) => {
@@ -36,7 +36,7 @@ const CommentsSection: React.FC<CommentsSectionProps> = ({ ticketId }) => {
 
     const [comments, setComments] = useState<Comment[]>([]);
     const [commentText, setCommentText] = useState('');
-    const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
+    const [editingCommentId, setEditingCommentId] = useState<string | null>(null);
     const [editText, setEditText] = useState('');
     const [showMore, setShowMore] = useState(false);
 
@@ -69,7 +69,7 @@ const CommentsSection: React.FC<CommentsSectionProps> = ({ ticketId }) => {
         setEditText(c.comment);
     };
 
-    const saveEdit = (id: number) => {
+    const saveEdit = (id: string) => {
         updateCommentApiHandler(() => updateComment(id, editText)).then(() => {
             setEditingCommentId(null);
             setEditText('');
@@ -77,7 +77,7 @@ const CommentsSection: React.FC<CommentsSectionProps> = ({ ticketId }) => {
         });
     };
 
-    const removeComment = (id: number) => {
+    const removeComment = (id: string) => {
         deleteCommentApiHandler(() => deleteComment(id)).then(() => {
             loadComments(comments.length);
         });

--- a/ui/src/components/HistorySidebar.tsx
+++ b/ui/src/components/HistorySidebar.tsx
@@ -6,7 +6,7 @@ import AssignmentHistory from './AssignmentHistory';
 import { useTranslation } from 'react-i18next';
 
 interface HistorySidebarProps {
-    ticketId: number;
+    ticketId: string;
 }
 
 const HistorySidebar: React.FC<HistorySidebarProps> = ({ ticketId }) => {

--- a/ui/src/components/RaiseTicket/LinkToMasterTicketModal.tsx
+++ b/ui/src/components/RaiseTicket/LinkToMasterTicketModal.tsx
@@ -57,7 +57,7 @@ const LinkToMasterTicketModal: React.FC<LinkToMasterTicketModalProps> = ({ open,
     };
 
     const handleSelect = (id: string) => {
-        getTicket(Number(id)).then(res => {
+        getTicket(id).then(res => {
             setSelected(res.data);
             setQuery('');
             setResults([]);
@@ -104,7 +104,7 @@ const LinkToMasterTicketModal: React.FC<LinkToMasterTicketModalProps> = ({ open,
                                     icon="Link"
                                     color={linked ? 'success' : 'primary'}
                                     onClick={() => {
-                                        linkTicketToMaster(currentTicket.id, selected.id).then(() => setLinked(true));
+                                        linkTicketToMaster(currentTicket.id.toString(), selected.id).then(() => setLinked(true));
                                     }}
                                 />
                             </Tooltip>

--- a/ui/src/components/StatusHistory/index.tsx
+++ b/ui/src/components/StatusHistory/index.tsx
@@ -8,7 +8,7 @@ import { Paper, useTheme, useMediaQuery } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 
 interface HistoryEntry {
-    id: number;
+    id: string;
     updatedBy: string;
     timestamp: string;
     previousStatus: string;
@@ -16,7 +16,7 @@ interface HistoryEntry {
 }
 
 interface StatusHistoryProps {
-    ticketId: number;
+    ticketId: string;
 }
 
 const StatusHistory: React.FC<StatusHistoryProps> = ({ ticketId }) => {

--- a/ui/src/pages/CategoriesMaster.tsx
+++ b/ui/src/pages/CategoriesMaster.tsx
@@ -77,7 +77,7 @@ const CategoriesMaster: React.FC = () => {
         }
     };
 
-    const handleDeleteCategory = (id: number) => {
+    const handleDeleteCategory = (id: string) => {
         if (window.confirm('Delete this category?')) {
             deleteCategory(id).then(() => {
                 if (selectedCategory?.categoryId === id) setSelectedCategory(null);
@@ -104,7 +104,7 @@ const CategoriesMaster: React.FC = () => {
         }
     };
 
-    const handleDeleteSubCategory = (id: number) => {
+    const handleDeleteSubCategory = (id: string) => {
         if (window.confirm('Delete this sub-category?')) {
             deleteSubCategory(id).then(() => fetchSubCategories());
         }

--- a/ui/src/pages/EscalationMaster.tsx
+++ b/ui/src/pages/EscalationMaster.tsx
@@ -69,7 +69,7 @@ const EscalationMaster: React.FC = () => {
     });
   };
 
-  const handleDelete = (id: number) => {
+  const handleDelete = (id: string) => {
     deleteApiHandler(() => deleteUser(id)).then(() => fetchUsers());
   };
 

--- a/ui/src/pages/TicketDetails.tsx
+++ b/ui/src/pages/TicketDetails.tsx
@@ -18,10 +18,10 @@ import { useTranslation } from "react-i18next";
 import { useSnackbar } from "../context/SnackbarContext";
 
 interface Ticket {
-    id: number;
+    id: string;
     reportedDate: string;
     mode: string;
-    UserId: number;
+    UserId: string;
     requestorName?: string;
     requestorEmailId?: string;
     requestorMobileNo?: string;
@@ -54,11 +54,11 @@ const TicketDetails: React.FC = () => {
 
     // API calls
     const getTicketHandler = (ticketId: any) => {
-        if (ticketId) getTicketApiHandler(() => getTicket(Number(ticketId)));
+        if (ticketId) getTicketApiHandler(() => getTicket(ticketId));
     }
     const updateTicketHandler = (ticketId: any, data: any) => {
         if (ticketId && data)
-            updateTicketApiHandler(() => updateTicket(Number(ticketId), data)).then((res: any) => {
+            updateTicketApiHandler(() => updateTicket(ticketId, data)).then((res: any) => {
                 setEditing(false);
                 if (res?.message) {
                     showMessage(res.message, 'success');
@@ -135,7 +135,7 @@ const TicketDetails: React.FC = () => {
                 </div>
             )}
 
-            <HistorySidebar ticketId={Number(ticketId)} />
+            <HistorySidebar ticketId={ticketId as string} />
             
             <form onSubmit={handleSubmit(onSubmitUpdate)}>
                 <RequestDetails register={register} control={control} errors={errors} disableAll isFieldSetDisabled />
@@ -166,7 +166,7 @@ const TicketDetails: React.FC = () => {
                 />
             </form>
 
-            <CommentsSection ticketId={Number(ticketId)} />
+            <CommentsSection ticketId={ticketId as string} />
         </div>
     );
 };

--- a/ui/src/services/AssignmentHistoryService.ts
+++ b/ui/src/services/AssignmentHistoryService.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { BASE_URL } from './api';
 
-export function getAssignmentHistory(ticketId: number) {
+export function getAssignmentHistory(ticketId: string) {
     return axios.get(`${BASE_URL}/assignment-history/${ticketId}`);
 }

--- a/ui/src/services/CategoryService.ts
+++ b/ui/src/services/CategoryService.ts
@@ -22,11 +22,11 @@ export function addSubCategory(subCategory: any) {
     return axios.post(`${BASE_URL}/categories/${subCategory?.categoryId}/sub-categories`, subCategory);
 }
 
-export function updateSubCategory(id: number, subCategory: any) {
+export function updateSubCategory(id: string, subCategory: any) {
     return axios.put(`${BASE_URL}/sub-categories/${id}`, subCategory);
 }
 
-export function deleteSubCategory(id: number) {
+export function deleteSubCategory(id: string) {
     return axios.delete(`${BASE_URL}/sub-categories/${id}`);
 }
 
@@ -44,15 +44,15 @@ export function addCategory(category: any) {
     return axios.post(`${BASE_URL}/categories`, category);
 }
 
-export function updateCategory(id: number, category: any) {
+export function updateCategory(id: string, category: any) {
     return axios.put(`${BASE_URL}/categories/${id}`, category);
 }
 
-export function deleteCategory(id: number) {
+export function deleteCategory(id: string) {
     return axios.delete(`${BASE_URL}/categories/${id}`);
 }
 
-export function deleteCategories(ids: number[]) {
+export function deleteCategories(ids: string[]) {
     const params = new URLSearchParams();
     ids.forEach(i => params.append('ids', i.toString()));
     return axios.delete(`${BASE_URL}/categories`, { params });

--- a/ui/src/services/StatusHistoryService.ts
+++ b/ui/src/services/StatusHistoryService.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { BASE_URL } from './api';
 
-export function getStatusHistory(ticketId: number) {
+export function getStatusHistory(ticketId: string) {
     return axios.get(`${BASE_URL}/status-history/${ticketId}`);
 }

--- a/ui/src/services/TicketService.ts
+++ b/ui/src/services/TicketService.ts
@@ -13,35 +13,35 @@ export function getTickets(page: number = 0, size: number = 5) {
     return axios.get(`${BASE_URL}/tickets?page=${page}&size=${size}`);
 }
 
-export function getTicket(id: number) {
+export function getTicket(id: string) {
     return axios.get(`${BASE_URL}/tickets/${id}`);
 }
 
-export function updateTicket(id: number, payload: any) {
+export function updateTicket(id: string, payload: any) {
     return axios.put(`${BASE_URL}/tickets/${id}`, payload);
 }
 
-export function linkTicketToMaster(id: number, masterId: number) {
+export function linkTicketToMaster(id: string, masterId: string) {
     return axios.put(`${BASE_URL}/tickets/${id}/link/${masterId}`);
 }
 
-export function addComment(id: number, comment: string) {
+export function addComment(id: string, comment: string) {
     return axios.post(`${BASE_URL}/tickets/${id}/comments`, comment, {
         headers: { 'Content-Type': 'text/plain' }
     });
 }
 
-export function getComments(id: number, count?: number) {
+export function getComments(id: string, count?: number) {
     const url = count ? `${BASE_URL}/tickets/${id}/comments?count=${count}` : `${BASE_URL}/tickets/${id}/comments`;
     return axios.get(url);
 }
 
-export function updateComment(commentId: number, comment: string) {
+export function updateComment(commentId: string, comment: string) {
     return axios.put(`${BASE_URL}/tickets/comments/${commentId}`, comment, {
         headers: { 'Content-Type': 'text/plain' }
     });
 }
 
-export function deleteComment(commentId: number) {
+export function deleteComment(commentId: string) {
     return axios.delete(`${BASE_URL}/tickets/comments/${commentId}`);
 }

--- a/ui/src/services/UserService.ts
+++ b/ui/src/services/UserService.ts
@@ -13,6 +13,6 @@ export function addUser(user: any) {
     return axios.post(`${BASE_URL}/users`, user);
 }
 
-export function deleteUser(id: number) {
+export function deleteUser(id: string) {
     return axios.delete(`${BASE_URL}/users/${id}`);
 }

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -9,16 +9,16 @@ export type FormProps<T extends FieldValues = FieldValues> = {
 };
 
 export interface SubCategory {
-    subCategoryId: number;
+    subCategoryId: string;
     subCategory: string;
     createdBy?: string;
     timestamp?: string;
-    categoryId?: number; // Optional, used when adding sub-categories directly
+    categoryId?: string; // Optional, used when adding sub-categories directly
     lastUpdated?: string;
 }
 
 export interface Category {
-    categoryId: number;
+    categoryId: string;
     category: string;
     createdBy?: string;
     timestamp?: string;
@@ -27,7 +27,7 @@ export interface Category {
 }
 
 export interface Ticket {
-    id: number;
+    id: string;
     subject: string;
     category: string;
     subCategory: string;


### PR DESCRIPTION
## Summary
- refactor types so all IDs are strings
- update service APIs to use string IDs
- update components and pages to send/receive string IDs
- verify build

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68772a23e0008332bc16e67c5c74bdc2