### PR TITLE
Convert remaining int IDs to strings

### DIFF
--- a/api/src/main/java/com/example/api/service/TicketService.java
+++ b/api/src/main/java/com/example/api/service/TicketService.java
@@ -148,7 +148,7 @@ public class TicketService {
 
     public TicketDto linkToMaster(String id, String masterId) {
         Ticket ticket = ticketRepository.findById(id).orElseThrow();
-        ticket.setMasterId(masterId != null ? Integer.valueOf(masterId) : null);
+        ticket.setMasterId(masterId);
         Ticket saved = ticketRepository.save(ticket);
         return DtoMapper.toTicketDto(saved);
     }

--- a/ui/src/components/RaiseTicket/LinkToMasterTicketModal.tsx
+++ b/ui/src/components/RaiseTicket/LinkToMasterTicketModal.tsx
@@ -27,7 +27,7 @@ const LinkToMasterTicketModal: React.FC<LinkToMasterTicketModalProps> = ({ open,
     const [selected, setSelected] = useState<any | null>(null);
     const [linked, setLinked] = useState(false);
     // TODO: replace with real current ticket details
-    const currentTicket = { id: 0, subject: 'Current Ticket' };
+    const currentTicket = { id: '', subject: 'Current Ticket' };
 
     let debouncedQuery = useDebounce(query, 500);
 
@@ -104,7 +104,7 @@ const LinkToMasterTicketModal: React.FC<LinkToMasterTicketModalProps> = ({ open,
                                     icon="Link"
                                     color={linked ? 'success' : 'primary'}
                                     onClick={() => {
-                                        linkTicketToMaster(currentTicket.id.toString(), selected.id).then(() => setLinked(true));
+                                        linkTicketToMaster(currentTicket.id, selected.id).then(() => setLinked(true));
                                     }}
                                 />
                             </Tooltip>

--- a/ui/src/components/RaiseTicket/SuccessfulModal.tsx
+++ b/ui/src/components/RaiseTicket/SuccessfulModal.tsx
@@ -4,12 +4,12 @@ import { useTranslation } from "react-i18next";
 
 interface SuccessfulModalProps {
     open: boolean;
-    ticketId: string | number;
+    ticketId: string;
     onClose: () => void;
 }
 
 const SuccessfulModal: React.FC<SuccessfulModalProps> = ({ open, ticketId, onClose }) => {
-    const encodedTicketId = encodeURIComponent(String(ticketId));
+    const encodedTicketId = encodeURIComponent(ticketId);
     const { t } = useTranslation();
 
     return (

--- a/ui/src/pages/RaiseTicket.tsx
+++ b/ui/src/pages/RaiseTicket.tsx
@@ -18,7 +18,7 @@ const RaiseTicket: React.FC<any> = () => {
 
     const [successfullModalOpen, setSuccessfulModalOpen] = useState(false);
     const [linkToMasterTicketModalOpen, setLinkToMasterTicketModalOpen] = useState(false);
-    const [createdTicketId, setCreatedTicketId] = useState<string | number | null>(null);
+    const [createdTicketId, setCreatedTicketId] = useState<string | null>(null);
 
 
     const onSubmit = (data: any) => {
@@ -72,7 +72,7 @@ const RaiseTicket: React.FC<any> = () => {
             {/* Link to Master Ticket Modal */}
             <LinkToMasterTicketModal open={linkToMasterTicketModalOpen} onClose={onLinkToMasterTicketModalClose} />
             {/* Successful Modal */}
-            <SuccessfulModal ticketId={String(createdTicketId ?? '')} open={successfullModalOpen} onClose={onClose} />
+            <SuccessfulModal ticketId={createdTicketId ?? ''} open={successfullModalOpen} onClose={onClose} />
         </div>
     )
 }


### PR DESCRIPTION
## Summary
- use string masterId in TicketService
- make SuccessfulModal use string ticket ID
- track created ticket ID as string
- keep master ticket id placeholder as a string

## Testing
- `./gradlew test --no-daemon` *(fails: Cannot find a Java installation)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877326866048332b383f892f86efd58