### PR TITLE
Refine RBAC flow

### DIFF
--- a/api/src/main/java/com/example/api/controller/AuthController.java
+++ b/api/src/main/java/com/example/api/controller/AuthController.java
@@ -3,21 +3,25 @@ package com.example.api.controller;
 import com.example.api.dto.LoginRequest;
 import com.example.api.models.User;
 import com.example.api.service.AuthService;
+import com.example.api.service.PermissionService;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
+import java.util.List;
 
 @RestController
 @RequestMapping("/auth")
 @CrossOrigin(origins = "http://localhost:3000", allowCredentials = "true")
 public class AuthController {
     private final AuthService authService;
+    private final PermissionService permissionService;
 
-    public AuthController(AuthService authService) {
+    public AuthController(AuthService authService, PermissionService permissionService) {
         this.authService = authService;
+        this.permissionService = permissionService;
     }
 
     @PostMapping("/login")
@@ -27,9 +31,15 @@ public class AuthController {
                     session.setAttribute("userId", emp.getUserId());
                     session.setAttribute("username", request.getUsername());
                     session.setAttribute("password", request.getPassword());
+
+                    var permissions = permissionService.mergeRolePermissions(
+                            request.getRoles() == null ? List.of() : request.getRoles());
+
                     return ResponseEntity.ok(Map.of(
                             "userId", emp.getUserId(),
-                            "name", emp.getName()));
+                            "name", emp.getName(),
+                            "permissions", permissions
+                    ));
                 })
                 .orElseGet(() -> ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                         .body(Map.of("message", "Invalid credentials")));

--- a/api/src/main/java/com/example/api/dto/LoginRequest.java
+++ b/api/src/main/java/com/example/api/dto/LoginRequest.java
@@ -3,6 +3,7 @@ package com.example.api.dto;
 public class LoginRequest {
     private String username;
     private String password;
+    private java.util.List<String> roles;
 
     public String getUsername() {
         return username;
@@ -18,5 +19,13 @@ public class LoginRequest {
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public java.util.List<String> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(java.util.List<String> roles) {
+        this.roles = roles;
     }
 }

--- a/api/src/main/java/com/example/api/permissions/PermissionsConfig.java
+++ b/api/src/main/java/com/example/api/permissions/PermissionsConfig.java
@@ -1,0 +1,12 @@
+package com.example.api.permissions;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@Setter
+public class PermissionsConfig {
+    private Map<String, RolePermission> roles;
+}

--- a/api/src/main/java/com/example/api/permissions/RolePermission.java
+++ b/api/src/main/java/com/example/api/permissions/RolePermission.java
@@ -1,0 +1,13 @@
+package com.example.api.permissions;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@Setter
+public class RolePermission {
+    private Map<String, Map<String, Object>> sidebar;
+    private Map<String, Map<String, Object>> forms;
+}

--- a/api/src/main/java/com/example/api/service/PermissionService.java
+++ b/api/src/main/java/com/example/api/service/PermissionService.java
@@ -1,0 +1,122 @@
+package com.example.api.service;
+
+import com.example.api.permissions.PermissionsConfig;
+import com.example.api.permissions.RolePermission;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PostConstruct;
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+@Service
+public class PermissionService {
+    private PermissionsConfig config;
+
+    @PostConstruct
+    public void loadPermissions() throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        File file = new File("config/permissions.json");
+        config = mapper.readValue(file, PermissionsConfig.class);
+    }
+
+    private List<RolePermission> getRolePermissions(List<String> roles) {
+        List<RolePermission> list = new ArrayList<>();
+        if (config == null || config.getRoles() == null) {
+            return list;
+        }
+        roles.forEach(r -> {
+            RolePermission rp = config.getRoles().get(r);
+            if (rp != null) {
+                list.add(rp);
+            }
+        });
+        return list;
+    }
+
+    public boolean hasSidebarAccess(List<String> roles, String key) {
+        return getRolePermissions(roles).stream()
+                .map(RolePermission::getSidebar)
+                .filter(m -> m != null)
+                .map(m -> m.get(key))
+                .anyMatch(obj -> {
+                    if (obj instanceof Map<?, ?> mp) {
+                        Object show = mp.get("show");
+                        return Boolean.TRUE.equals(show);
+                    }
+                    return false;
+                });
+    }
+
+    public boolean hasFormAccess(List<String> roles, String form, String action) {
+        return getRolePermissions(roles).stream()
+                .map(RolePermission::getForms)
+                .filter(m -> m != null)
+                .map(m -> m.get(form))
+                .anyMatch(obj -> checkAction(obj, action));
+    }
+
+    public boolean hasFieldAccess(List<String> roles, String form, String field) {
+        return getRolePermissions(roles).stream()
+                .map(RolePermission::getForms)
+                .filter(m -> m != null)
+                .map(m -> m.get(form))
+                .anyMatch(obj -> {
+                    if (obj instanceof Map<?, ?> fm) {
+                        Object fieldsObj = fm.get("fields");
+                        if (fieldsObj instanceof Map<?, ?> fieldsMap) {
+                            Object value = fieldsMap.get(field);
+                            return Boolean.TRUE.equals(value);
+                        }
+                    }
+                    return false;
+                });
+    }
+
+    private boolean checkAction(Object fpObj, String action) {
+        if (fpObj instanceof Map<?, ?> fp) {
+            Object value = fp.get(action);
+            return Boolean.TRUE.equals(value);
+        }
+        return false;
+    }
+
+    public RolePermission mergeRolePermissions(List<String> roles) {
+        RolePermission result = new RolePermission();
+        result.setSidebar(new HashMap<>());
+        result.setForms(new HashMap<>());
+        for (RolePermission rp : getRolePermissions(roles)) {
+            mergeOuter(result.getSidebar(), rp.getSidebar());
+            mergeOuter(result.getForms(), rp.getForms());
+        }
+        return result;
+    }
+
+    private void mergeOuter(Map<String, Map<String, Object>> target,
+                            Map<String, Map<String, Object>> source) {
+        if (source == null) {
+            return;
+        }
+        source.forEach((key, value) -> {
+            Map<String, Object> existing =
+                    target.computeIfAbsent(key, k -> new HashMap<>());
+            deepMerge(existing, value);
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private void deepMerge(Map<String, Object> target, Map<String, Object> source) {
+        if (source == null) {
+            return;
+        }
+        source.forEach((key, value) -> {
+            Object existing = target.get(key);
+            if (existing instanceof Map<?, ?> && value instanceof Map<?, ?>) {
+                deepMerge((Map<String, Object>) existing, (Map<String, Object>) value);
+            } else {
+                target.put(key, value);
+            }
+        });
+    }
+}

--- a/config/permissions.json
+++ b/config/permissions.json
@@ -1,0 +1,168 @@
+{
+  "roles": {
+    "USER": {
+      "sidebar": {
+        "tickets": { "show": true },
+        "create-ticket": { "show": true },
+        "knowledge-base": { "show": true }
+      },
+      "forms": {
+        "RequestDetails": {
+          "view": true,
+          "create": true,
+          "update": false,
+          "fields": {
+            "ticketId": false,
+            "reportedDate": true,
+            "mode": false
+          }
+        },
+        "RequestorDetails": {
+          "view": true,
+          "create": true,
+          "update": false,
+          "fields": {
+            "userId": true,
+            "requestorName": true,
+            "emailId": true,
+            "mobileNo": true,
+            "stakeholder": true,
+            "role": false,
+            "office": false
+          }
+        },
+        "TicketDetails": {
+          "view": true,
+          "create": true,
+          "update": false,
+          "fields": {
+            "assignedToLevel": false,
+            "assignedTo": false,
+            "category": true,
+            "subCategory": true,
+            "priority": true,
+            "severity": false,
+            "recommendedSeverity": false,
+            "impact": true,
+            "isMaster": true,
+            "subject": true,
+            "description": true,
+            "attachment": true,
+            "status": false,
+            "assignFurther": false
+          }
+        }
+      }
+    },
+    "ADMIN": {
+      "sidebar": {
+        "tickets": { "show": true },
+        "create-ticket": { "show": true },
+        "knowledge-base": { "show": true },
+        "categories-master": { "show": true },
+        "escalation-master": { "show": true }
+      },
+      "forms": {
+        "RequestDetails": {
+          "view": true,
+          "create": true,
+          "update": true,
+          "fields": {
+            "ticketId": true,
+            "reportedDate": true,
+            "mode": true
+          }
+        },
+        "RequestorDetails": {
+          "view": true,
+          "create": true,
+          "update": true,
+          "fields": {
+            "userId": true,
+            "requestorName": true,
+            "emailId": true,
+            "mobileNo": true,
+            "stakeholder": true,
+            "role": true,
+            "office": true
+          }
+        },
+        "TicketDetails": {
+          "view": true,
+          "create": true,
+          "update": true,
+          "fields": {
+            "assignedToLevel": true,
+            "assignedTo": true,
+            "category": true,
+            "subCategory": true,
+            "priority": true,
+            "severity": true,
+            "recommendedSeverity": true,
+            "impact": true,
+            "isMaster": true,
+            "subject": true,
+            "description": true,
+            "attachment": true,
+            "status": true,
+            "assignFurther": true
+          }
+        }
+      }
+    },
+    "HELPDESK": {
+      "sidebar": {
+        "tickets": { "show": true },
+        "create-ticket": { "show": true },
+        "knowledge-base": { "show": true }
+      },
+      "forms": {
+        "RequestDetails": {
+          "view": true,
+          "create": true,
+          "update": true,
+          "fields": {
+            "ticketId": true,
+            "reportedDate": true,
+            "mode": true
+          }
+        },
+        "RequestorDetails": {
+          "view": true,
+          "create": true,
+          "update": true,
+          "fields": {
+            "userId": true,
+            "requestorName": true,
+            "emailId": true,
+            "mobileNo": true,
+            "stakeholder": true,
+            "role": true,
+            "office": true
+          }
+        },
+        "TicketDetails": {
+          "view": true,
+          "create": true,
+          "update": true,
+          "fields": {
+            "assignedToLevel": true,
+            "assignedTo": true,
+            "category": true,
+            "subCategory": true,
+            "priority": true,
+            "severity": true,
+            "recommendedSeverity": true,
+            "impact": true,
+            "isMaster": true,
+            "subject": true,
+            "description": true,
+            "attachment": true,
+            "status": true,
+            "assignFurther": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/ui/src/components/Layout/Sidebar.tsx
+++ b/ui/src/components/Layout/Sidebar.tsx
@@ -12,35 +12,40 @@ import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
 import LibraryBooksIcon from "@mui/icons-material/LibraryBooks";
 import CategoryIcon from "@mui/icons-material/Category";
 import { currentUserDetails } from "../../config/config";
+import { checkSidebarAccess } from "../../utils/permissions";
 import SupervisorAccountIcon from "@mui/icons-material/SupervisorAccount";
 import { useTheme } from "@mui/material/styles";
 
 const menuItems = [
   {
+    key: "tickets",
     label: "My Tickets",
     to: "/tickets",
     icon: <ListAltIcon />,
   },
   {
+    key: "create-ticket",
     label: "Raise Ticket",
     to: "/create-ticket",
     icon: <AddCircleOutlineIcon />,
   },
   {
+    key: "knowledge-base",
     label: "Knowledge Base",
     to: "/knowledge-base",
     icon: <LibraryBooksIcon />,
   },
   {
+    key: "categories-master",
     label: "Categories Master",
     to: "/categories-master",
     icon: <CategoryIcon />,
   },
   {
+    key: "escalation-master",
     label: "Escalation Master",
     to: "/escalation-master",
     icon: <SupervisorAccountIcon />,
-    roles: ["ADMIN", "IT"],
   },
 ];
 
@@ -71,11 +76,8 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
       }}
     >
       <List component="nav">
-        {menuItems.map(({ label, to, icon, roles }) => {
-          if (
-            roles &&
-            !roles.some((r) => currentUserDetails.role.includes(r))
-          ) {
+        {menuItems.map(({ key, label, to, icon }) => {
+          if (!checkSidebarAccess(key)) {
             return null;
           }
           return (

--- a/ui/src/components/RaiseTicket/RequestDetails.tsx
+++ b/ui/src/components/RaiseTicket/RequestDetails.tsx
@@ -6,6 +6,7 @@ import CustomFormInput from "../UI/Input/CustomFormInput";
 import { useWatch } from "react-hook-form";
 import CustomFieldset from "../CustomFieldset";
 import { currentUserDetails, isFciUser, isHelpdesk } from "../../config/config";
+import { checkFieldAccess } from "../../utils/permissions";
 import React, { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -21,9 +22,9 @@ const modeOptions: DropdownOption[] = [
 ];
 
 const RequestDetails: React.FC<RequestDetailsProps> = ({ register, control, errors, setValue, disableAll = false, isFieldSetDisabled }) => {
-    const showTicketId = false;
-    const showReportedDate = true;
-    const showModeDropdown = true;
+    const showTicketId = checkFieldAccess('RequestDetails', 'ticketId');
+    const showReportedDate = checkFieldAccess('RequestDetails', 'reportedDate');
+    const showModeDropdown = checkFieldAccess('RequestDetails', 'mode');
 
     const ticketId = useWatch({ control, name: 'ticketId' });
     const mode = useWatch({ control, name: 'mode' });

--- a/ui/src/components/RaiseTicket/TicketDetails.tsx
+++ b/ui/src/components/RaiseTicket/TicketDetails.tsx
@@ -12,6 +12,7 @@ import { getAllUsersByLevel, getAllLevels } from "../../services/LevelService";
 import { getCategories, getSubCategories } from "../../services/CategoryService";
 import { getStatuses } from "../../services/StatusService";
 import { currentUserDetails } from "../../config/config";
+import { checkFieldAccess } from "../../utils/permissions";
 import { getPriorities } from "../../services/PriorityService";
 import { getSeverities } from "../../services/SeverityService";
 
@@ -64,25 +65,25 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, errors
     const subjectValue = useWatch({ control, name: 'subject' });
     const descriptionValue = useWatch({ control, name: 'description' });
 
-    let showAssignedToLevel = !createMode;
-    let showAssignedTo = !createMode;
-    let showCategory = true;
-    let showSubCategory = true;
-    let showPriority = true;
+    let showAssignedToLevel = checkFieldAccess('TicketDetails', 'assignedToLevel') && !createMode;
+    let showAssignedTo = checkFieldAccess('TicketDetails', 'assignedTo') && !createMode;
+    let showCategory = checkFieldAccess('TicketDetails', 'category');
+    let showSubCategory = checkFieldAccess('TicketDetails', 'subCategory');
+    let showPriority = checkFieldAccess('TicketDetails', 'priority');
     const isIT = currentUserDetails?.role.includes('IT');
-    let showSeverityFields = isIT;
-    let showSeverity = true;
-    let showRecommendedSeverity = true;
-    let showImpact = !isIT;
-    let showSelectedImpact = isIT;
-    let showIsMaster = true;
-    let showSubject = true;
-    let showDescription = true;
-    let showAttachment = true;
-    let showStatus = true;
-    let showAssignFurther = true;
-    let showAssignToLevelDropdown = true;
-    let showAssignToDropdown = true;
+    let showSeverityFields = checkFieldAccess('TicketDetails', 'severity');
+    let showSeverity = checkFieldAccess('TicketDetails', 'severity');
+    let showRecommendedSeverity = checkFieldAccess('TicketDetails', 'recommendedSeverity');
+    let showImpact = checkFieldAccess('TicketDetails', 'impact');
+    let showSelectedImpact = checkFieldAccess('TicketDetails', 'impact');
+    let showIsMaster = checkFieldAccess('TicketDetails', 'isMaster');
+    let showSubject = checkFieldAccess('TicketDetails', 'subject');
+    let showDescription = checkFieldAccess('TicketDetails', 'description');
+    let showAttachment = checkFieldAccess('TicketDetails', 'attachment');
+    let showStatus = checkFieldAccess('TicketDetails', 'status');
+    let showAssignFurther = checkFieldAccess('TicketDetails', 'assignFurther');
+    let showAssignToLevelDropdown = checkFieldAccess('TicketDetails', 'assignedToLevel');
+    let showAssignToDropdown = checkFieldAccess('TicketDetails', 'assignedTo');
 
     useEffect(() => {
         getAllLevelApiHandler(() => getAllLevels())

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { loginUser } from "../services/AuthService";
+import { currentUserDetails } from "../config/config";
+import { setPermissions } from "../utils/permissions";
 
 const Login: React.FC = () => {
     const [userId, setUserId] = useState("");
@@ -9,8 +11,11 @@ const Login: React.FC = () => {
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
-        loginUser({ username: userId, password })
-            .then(() => {
+        loginUser({ username: userId, password, roles: currentUserDetails.role as string[] })
+            .then(res => {
+                if (res.data && res.data.permissions) {
+                    setPermissions(res.data.permissions);
+                }
                 navigate("/");
             });
     };

--- a/ui/src/services/AuthService.ts
+++ b/ui/src/services/AuthService.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { BASE_URL } from "./api";
 
-export function loginUser(payload: { username: string; password: string }) {
+export function loginUser(payload: { username: string; password: string; roles: string[] }) {
     return axios.post(`${BASE_URL}/auth/login`, payload, { withCredentials: true });
 }
 

--- a/ui/src/utils/permissions.ts
+++ b/ui/src/utils/permissions.ts
@@ -1,0 +1,32 @@
+export interface SidebarItemPermission {
+  show?: boolean;
+  children?: { [key: string]: SidebarItemPermission };
+  [key: string]: any;
+}
+
+export interface RolePermission {
+  sidebar?: { [key: string]: SidebarItemPermission };
+  forms?: { [form: string]: { [key: string]: any } };
+}
+
+let currentPermissions: RolePermission | null = null;
+
+export function setPermissions(perm: RolePermission) {
+  currentPermissions = perm;
+}
+
+export function checkSidebarAccess(key: string): boolean {
+  return currentPermissions?.sidebar?.[key]?.show ?? false;
+}
+
+export function checkFormAccess(form: string, type: 'view' | 'create' | 'update'): boolean {
+  const fp: any = currentPermissions?.forms?.[form];
+  return !!fp && !!fp[type];
+}
+
+export function checkFieldAccess(form: string, field: string): boolean {
+  const fp: any = currentPermissions?.forms?.[form];
+  if (!fp) return false;
+  const fields: any = fp.fields || {};
+  return !!fields[field];
+}


### PR DESCRIPTION
## Summary
- include role list in `LoginRequest`
- merge role permissions server-side and send with login response
- expose new permission storage helper in React
- update sidebar and ticket forms to read permissions without passing roles

## Testing
- `npm ls --depth=0`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68777360f7408332a2459b5238695149