### PR TITLE
Persist user details in session storage

### DIFF
--- a/ui/src/components/Layout/Header.tsx
+++ b/ui/src/components/Layout/Header.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react";
 import { ThemeModeContext } from "../../context/ThemeContext";
 import CustomIconButton from "../UI/IconButton/CustomIconButton";
 import Avatar from "@mui/material/Avatar";
-import { currentUserDetails } from "../../config/config";
+import { getCurrentUserDetails } from "../../config/config";
 import { useTheme } from "@mui/material/styles";
 import { LanguageContext } from "../../context/LanguageContext";
 
@@ -15,8 +15,9 @@ const Header: React.FC<HeaderProps> = ({ collapsed, toggleSidebar }) => {
   const { toggle, mode } = useContext(ThemeModeContext);
   const { toggleLanguage } = useContext(LanguageContext);
   const theme = useTheme();
-  const initials = currentUserDetails.name
-    ? currentUserDetails.name
+  const user = getCurrentUserDetails();
+  const initials = user.name
+    ? user.name
       .split(" ")
       .map((n) => n.charAt(0))
       .join("")

--- a/ui/src/components/Layout/Sidebar.tsx
+++ b/ui/src/components/Layout/Sidebar.tsx
@@ -11,7 +11,6 @@ import ListAltIcon from "@mui/icons-material/ListAlt";
 import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline";
 import LibraryBooksIcon from "@mui/icons-material/LibraryBooks";
 import CategoryIcon from "@mui/icons-material/Category";
-import { currentUserDetails } from "../../config/config";
 import { checkSidebarAccess } from "../../utils/permissions";
 import SupervisorAccountIcon from "@mui/icons-material/SupervisorAccount";
 import { useTheme } from "@mui/material/styles";

--- a/ui/src/components/RaiseTicket/RequestDetails.tsx
+++ b/ui/src/components/RaiseTicket/RequestDetails.tsx
@@ -5,7 +5,7 @@ import GenericDropdownController from "../UI/Dropdown/GenericDropdownController"
 import CustomFormInput from "../UI/Input/CustomFormInput";
 import { useWatch } from "react-hook-form";
 import CustomFieldset from "../CustomFieldset";
-import { currentUserDetails, isFciUser, isHelpdesk } from "../../config/config";
+import { isHelpdesk } from "../../config/config";
 import { checkFieldAccess } from "../../utils/permissions";
 import React, { useEffect } from "react";
 import { useTranslation } from "react-i18next";
@@ -28,12 +28,13 @@ const RequestDetails: React.FC<RequestDetailsProps> = ({ register, control, erro
 
     const ticketId = useWatch({ control, name: 'ticketId' });
     const mode = useWatch({ control, name: 'mode' });
+    const helpdesk = isHelpdesk();
 
     useEffect(() => {
-        if (!isHelpdesk && (!mode || mode !== "Self")) {
+        if (!helpdesk && (!mode || mode !== "Self")) {
             setValue && setValue("mode", "Self");
         }
-    }, [setValue, mode]);
+    }, [setValue, mode, helpdesk]);
 
     const { t } = useTranslation();
     return (
@@ -66,7 +67,7 @@ const RequestDetails: React.FC<RequestDetailsProps> = ({ register, control, erro
                             label="Mode"
                             options={modeOptions}
                             className="form-select"
-                            disabled={disableAll || !isHelpdesk}
+                            disabled={disableAll || !helpdesk}
                         />
                     </div>
                 )}

--- a/ui/src/components/RaiseTicket/RequestorDetails.tsx
+++ b/ui/src/components/RaiseTicket/RequestorDetails.tsx
@@ -10,7 +10,7 @@ import { useDebounce } from "../../hooks/useDebounce";
 import React, { useEffect, useState } from "react";
 import CustomIconButton from "../UI/IconButton/CustomIconButton";
 import CustomFieldset from "../CustomFieldset";
-import { currentUserDetails, FciTheme, isFciUser, isHelpdesk } from "../../config/config";
+import { getCurrentUserDetails, FciTheme, isFciUser, isHelpdesk } from "../../config/config";
 import DropdownController from "../UI/Dropdown/DropdownController";
 import GenericDropdownController from "../UI/Dropdown/GenericDropdownController";
 import { DropdownOption } from "../UI/Dropdown/GenericDropdown";
@@ -36,6 +36,9 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
     const [disabled, setDisabled] = useState<boolean>(false);
     const [viewMode, setViewMode] = useState<ViewMode>("nonFci");
     const { t } = useTranslation();
+
+    const fciUser = isFciUser();
+    const helpdesk = isHelpdesk();
 
     const isDisabled = disableAll || disabled;
 
@@ -73,7 +76,7 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
             setValue("requestorName", data.requestorName);
             setValue("emailId", data.emailId);
             setValue("mobileNo", data.mobileNo);
-            if (isFciUser) {
+            if (fciUser) {
                 setValue("role", data.role);
                 setValue("office", data.office);
             } else {
@@ -95,7 +98,7 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
     useEffect(() => {
         if (debouncedUserId) {
             setDisabled(true);
-            if (disableAll || isFciUser) verifyUserById(debouncedUserId);
+            if (disableAll || fciUser) verifyUserById(debouncedUserId);
         } else clearRequestorDetailsForm();
 
         setVerified(false);
@@ -107,18 +110,18 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
 
     useEffect(() => {
         // Ticket creation by FCI user - SELF
-        if (isFciUser && createMode) {
-            const fciUser = currentUserDetails as typeof currentUserDetails & { userId: string };
-            if (setValue && fciUser.userId) setValue("userId", fciUser.userId);
+        if (fciUser && createMode) {
+            const user = getCurrentUserDetails();
+            if (setValue && user.userId) setValue("userId", user.userId);
         }
-        if (isHelpdesk && mode === 'Self' && createMode) {
-            const hdUser = currentUserDetails as typeof currentUserDetails & { userId: string };
+        if (helpdesk && mode === 'Self' && createMode) {
+            const hdUser = getCurrentUserDetails();
             if (setValue && hdUser.userId) {
                 setValue('userId', hdUser.userId);
                 verifyUserById(hdUser.userId);
             }
         }
-    }, [isFciUser, isHelpdesk, mode, createMode]);
+    }, [fciUser, helpdesk, mode, createMode]);
 
     const verifyUserById = (userId: string) => {
         // Logic to verify user by ID
@@ -140,13 +143,13 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
         setVerified(false);
     };
 
-    const isSelfHelpdesk = isHelpdesk && mode === 'Self';
+    const isSelfHelpdesk = helpdesk && mode === 'Self';
 
-    const showOnBehalfCheckbox = isHelpdesk && createMode && mode !== 'Self';
+    const showOnBehalfCheckbox = helpdesk && createMode && mode !== 'Self';
 
-    const showFciToggle = !isFciUser && !isHelpdesk;
+    const showFciToggle = !fciUser && !helpdesk;
     const showUserId =
-        viewMode === FCI_User || isFciUser || onBehalfFciUser || isSelfHelpdesk;
+        viewMode === FCI_User || fciUser || onBehalfFciUser || isSelfHelpdesk;
     const userIdLabel = isSelfHelpdesk ? 'User ID' : 'Employee ID';
     const showRequestorName = true;
     const showEmailId = true;
@@ -155,24 +158,24 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
         !onBehalfFciUser &&
         !isSelfHelpdesk &&
         viewMode === 'nonFci' &&
-        !isFciUser;
+        !fciUser;
     const showRole =
-        viewMode === FCI_User || isFciUser || onBehalfFciUser || isSelfHelpdesk;
+        viewMode === FCI_User || fciUser || onBehalfFciUser || isSelfHelpdesk;
     const showOffice =
-        (viewMode === FCI_User || isFciUser || onBehalfFciUser) && !isSelfHelpdesk;
+        (viewMode === FCI_User || fciUser || onBehalfFciUser) && !isSelfHelpdesk;
 
     const isNonFci =
-        viewMode === NON_FCI_User && !isFciUser && !onBehalfFciUser && !isSelfHelpdesk;
+        viewMode === NON_FCI_User && !fciUser && !onBehalfFciUser && !isSelfHelpdesk;
     const isFciMode =
-        viewMode === FCI_User || isFciUser || onBehalfFciUser || isSelfHelpdesk;
+        viewMode === FCI_User || fciUser || onBehalfFciUser || isSelfHelpdesk;
 
     const isUserIdDisabled =
-        disableAll || isFciUser || isSelfHelpdesk || !createMode;
-    const isNameDisabled = isDisabled || isFciUser || isSelfHelpdesk || !createMode;
-    const isEmailIdDisabled = isDisabled || isFciUser || isSelfHelpdesk || !createMode;
-    const isMobileNoDisabled = isDisabled || isFciUser || isSelfHelpdesk || !createMode;
-    const isRoleDisabled = isDisabled || isFciUser || isSelfHelpdesk || !createMode;
-    const isOfficeDisabled = isDisabled || isFciUser || isSelfHelpdesk || !createMode;
+        disableAll || fciUser || isSelfHelpdesk || !createMode;
+    const isNameDisabled = isDisabled || fciUser || isSelfHelpdesk || !createMode;
+    const isEmailIdDisabled = isDisabled || fciUser || isSelfHelpdesk || !createMode;
+    const isMobileNoDisabled = isDisabled || fciUser || isSelfHelpdesk || !createMode;
+    const isRoleDisabled = isDisabled || fciUser || isSelfHelpdesk || !createMode;
+    const isOfficeDisabled = isDisabled || fciUser || isSelfHelpdesk || !createMode;
     const isStakeholderDisabled = false || !createMode;
 
     const isRequestorOrOnBehalfFci = !createMode && userId

--- a/ui/src/components/RaiseTicket/TicketDetails.tsx
+++ b/ui/src/components/RaiseTicket/TicketDetails.tsx
@@ -11,7 +11,7 @@ import { Checkbox, FormControlLabel } from "@mui/material";
 import { getAllUsersByLevel, getAllLevels } from "../../services/LevelService";
 import { getCategories, getSubCategories } from "../../services/CategoryService";
 import { getStatuses } from "../../services/StatusService";
-import { currentUserDetails } from "../../config/config";
+import { getCurrentUserDetails } from "../../config/config";
 import { checkFieldAccess } from "../../utils/permissions";
 import { getPriorities } from "../../services/PriorityService";
 import { getSeverities } from "../../services/SeverityService";
@@ -70,7 +70,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, errors
     let showCategory = checkFieldAccess('TicketDetails', 'category');
     let showSubCategory = checkFieldAccess('TicketDetails', 'subCategory');
     let showPriority = checkFieldAccess('TicketDetails', 'priority');
-    const isIT = currentUserDetails?.role.includes('IT');
+    const isIT = getCurrentUserDetails()?.role.includes('IT');
     let showSeverityFields = checkFieldAccess('TicketDetails', 'severity');
     let showSeverity = checkFieldAccess('TicketDetails', 'severity');
     let showRecommendedSeverity = checkFieldAccess('TicketDetails', 'recommendedSeverity');
@@ -116,9 +116,8 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, errors
     }, [category])
 
     useEffect(() => {
-        // Set assignedBy to current userId from localStorage if available
         if (register && typeof register === 'function') {
-            register('assignedBy', { value: localStorage.getItem('userId') || currentUserDetails?.userId || 'john.doe' });
+            register('assignedBy', { value: getCurrentUserDetails()?.userId || 'john.doe' });
         }
     }, [register]);
 
@@ -324,7 +323,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, errors
                         />
                     </div>
                 )}
-                {!currentUserDetails?.role.includes("USER") && assignFurther && (
+                {!getCurrentUserDetails()?.role.includes("USER") && assignFurther && (
                     <>
                         {showAssignToLevelDropdown && (
                             <div className="col-md-4 mb-3  px-4">

--- a/ui/src/config/config.ts
+++ b/ui/src/config/config.ts
@@ -1,14 +1,21 @@
 import { envConfig } from './envconfig';
+import { getUserDetails } from '../utils/Utils';
 
 const Users = envConfig.Users;
 
 export const Roles = envConfig.Roles;
 export const devMode = envConfig.devMode;
-export const currentUserDetails = Users.helpdesk;
-// export const currentUserDetails = Users.fci
 export const FciTheme = envConfig.FciTheme;
 
-export const isFciUser = currentUserDetails.role.includes('FCI_User');
-export const isHelpdesk = currentUserDetails.role.includes('HELPDESK');
-console.log({ isFciUser, isHelpdesk });
+export function getCurrentUserDetails() {
+  return getUserDetails() || Users.helpdesk;
+}
+
+export function isFciUser() {
+  return getCurrentUserDetails().role.includes('FCI_User');
+}
+
+export function isHelpdesk() {
+  return getCurrentUserDetails().role.includes('HELPDESK');
+}
 

--- a/ui/src/pages/CategoriesMaster.tsx
+++ b/ui/src/pages/CategoriesMaster.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { getCategories, addCategory, updateCategory, deleteCategory, getAllSubCategories, addSubCategory, updateSubCategory, deleteSubCategory } from '../services/CategoryService';
 import { useApi } from '../hooks/useApi';
 import { Category, SubCategory } from '../types';
-import { currentUserDetails } from '../config/config';
+import { getCurrentUserDetails } from '../config/config';
 import GenericInput from '../components/UI/Input/GenericInput';
 
 const CategoriesMaster: React.FC = () => {
@@ -65,7 +65,7 @@ const CategoriesMaster: React.FC = () => {
         const name = categoryInput.trim();
         if (!name) return;
         if (!categories.find(c => c.category.toLowerCase() === name.toLowerCase())) {
-            addCategory({ category: name, createdBy: currentUserDetails.userId }).then(() => fetchCategories());
+            addCategory({ category: name, createdBy: getCurrentUserDetails().userId }).then(() => fetchCategories());
         }
         setCategoryInput('');
     }
@@ -90,7 +90,7 @@ const CategoriesMaster: React.FC = () => {
         const name = subCategoryInput.trim();
         if (!name || !selectedCategory) return;
         if (!selectedCategory.subCategories.find(sc => sc.subCategory.toLowerCase() === name.toLowerCase())) {
-            const newSub = { subCategory: name, categoryId: selectedCategory.categoryId, createdBy: currentUserDetails.userId };
+            const newSub = { subCategory: name, categoryId: selectedCategory.categoryId, createdBy: getCurrentUserDetails().userId };
 
             addSubCategoryApiHandler(() => addSubCategory(newSub)).then(() => fetchSubCategories());
         }

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { loginUser } from "../services/AuthService";
-import { currentUserDetails } from "../config/config";
+import { getCurrentUserDetails } from "../config/config";
 import { setPermissions } from "../utils/permissions";
+import { setUserDetails } from "../utils/Utils";
 
 const Login: React.FC = () => {
     const [userId, setUserId] = useState("");
@@ -11,10 +12,19 @@ const Login: React.FC = () => {
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
-        loginUser({ username: userId, password, roles: currentUserDetails.role as string[] })
+        const roles = getCurrentUserDetails().role as string[];
+        loginUser({ username: userId, password, roles })
             .then(res => {
-                if (res.data && res.data.permissions) {
-                    setPermissions(res.data.permissions);
+                if (res.data) {
+                    if (res.data.permissions) {
+                        setPermissions(res.data.permissions);
+                    }
+                    const details = {
+                        userId: res.data.userId || userId,
+                        role: roles,
+                        name: res.data.name
+                    };
+                    setUserDetails(details);
                 }
                 navigate("/");
             });

--- a/ui/src/utils/Utils.ts
+++ b/ui/src/utils/Utils.ts
@@ -1,0 +1,33 @@
+export interface UserDetails {
+  userId: string;
+  role: string[];
+  name?: string;
+  email?: string;
+  phone?: string;
+}
+
+const USER_KEY = 'userDetails';
+const PERM_KEY = 'userPermissions';
+
+export function setUserDetails(details: UserDetails) {
+  sessionStorage.setItem(USER_KEY, JSON.stringify(details));
+}
+
+export function getUserDetails(): UserDetails | null {
+  const data = sessionStorage.getItem(USER_KEY);
+  return data ? JSON.parse(data) : null;
+}
+
+export function setUserPermissions(perm: any) {
+  sessionStorage.setItem(PERM_KEY, JSON.stringify(perm));
+}
+
+export function getUserPermissions(): any {
+  const data = sessionStorage.getItem(PERM_KEY);
+  return data ? JSON.parse(data) : null;
+}
+
+export function clearSession() {
+  sessionStorage.removeItem(USER_KEY);
+  sessionStorage.removeItem(PERM_KEY);
+}

--- a/ui/src/utils/permissions.ts
+++ b/ui/src/utils/permissions.ts
@@ -8,24 +8,32 @@ export interface RolePermission {
   sidebar?: { [key: string]: SidebarItemPermission };
   forms?: { [form: string]: { [key: string]: any } };
 }
-
-let currentPermissions: RolePermission | null = null;
+import {
+  getUserPermissions,
+  setUserPermissions,
+} from './Utils';
 
 export function setPermissions(perm: RolePermission) {
-  currentPermissions = perm;
+  setUserPermissions(perm);
 }
 
 export function checkSidebarAccess(key: string): boolean {
-  return currentPermissions?.sidebar?.[key]?.show ?? false;
+  const perms = getUserPermissions() as RolePermission | null;
+  return perms?.sidebar?.[key]?.show ?? false;
 }
 
-export function checkFormAccess(form: string, type: 'view' | 'create' | 'update'): boolean {
-  const fp: any = currentPermissions?.forms?.[form];
+export function checkFormAccess(
+  form: string,
+  type: 'view' | 'create' | 'update',
+): boolean {
+  const perms = getUserPermissions() as RolePermission | null;
+  const fp: any = perms?.forms?.[form];
   return !!fp && !!fp[type];
 }
 
 export function checkFieldAccess(form: string, field: string): boolean {
-  const fp: any = currentPermissions?.forms?.[form];
+  const perms = getUserPermissions() as RolePermission | null;
+  const fp: any = perms?.forms?.[form];
   if (!fp) return false;
   const fields: any = fp.fields || {};
   return !!fields[field];


### PR DESCRIPTION
## Summary
- add `Utils.ts` helper to read/write session storage
- persist permissions in session storage
- update configuration to read current user from session
- save user details and permissions on login
- read session user info across components

## Testing
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6877e2b6647483329f052cbabd66254f