### PR TITLE
Add ticket assignee selector

### DIFF
--- a/db/ticketing_system_dump.sql
+++ b/db/ticketing_system_dump.sql
@@ -522,7 +522,7 @@ CREATE TABLE `user_levels` (
 
 LOCK TABLES `user_levels` WRITE;
 /*!40000 ALTER TABLE `user_levels` DISABLE KEYS */;
-INSERT INTO `user_levels` VALUES (205,1),(203,3),(204,3),(201,4),(202,4),(211,6);
+INSERT INTO `user_levels` VALUES (205,1),(203,3),(204,3),(201,4),(202,4),(211,6),(206,1),(207,1),(208,2),(209,2),(210,3),(212,3),(213,2),(214,1);
 /*!40000 ALTER TABLE `user_levels` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/ui/src/components/AllTickets/AssigneeDropdown.tsx
+++ b/ui/src/components/AllTickets/AssigneeDropdown.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useState } from 'react';
+import { Menu, Box, TextField, Chip, List, ListItemButton, ListItemText } from '@mui/material';
+import { getAllLevels, getAllUsersByLevel } from '../../services/LevelService';
+import { updateTicket } from '../../services/TicketService';
+import UserAvatar from '../UI/UserAvatar/UserAvatar';
+import { useApi } from '../../hooks/useApi';
+import { getCurrentUserDetails } from '../../config/config';
+
+interface AssigneeDropdownProps {
+    ticketId: string;
+    assigneeName?: string;
+    onAssigned?: (name: string) => void;
+}
+
+interface Level { levelId: string; levelName: string; }
+interface User { userId: string; name: string; }
+
+const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ ticketId, assigneeName, onAssigned }) => {
+    const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+    const open = Boolean(anchorEl);
+    const [search, setSearch] = useState('');
+    const [levels, setLevels] = useState<Level[]>([]);
+    const [selectedLevel, setSelectedLevel] = useState<string>('');
+    const [users, setUsers] = useState<User[]>([]);
+    const { apiHandler } = useApi<any>();
+
+    useEffect(() => {
+        getAllLevels().then(res => {
+            setLevels(res.data);
+            if (res.data[0]) {
+                setSelectedLevel(res.data[0].levelId);
+            }
+        });
+    }, []);
+
+    useEffect(() => {
+        if (selectedLevel) {
+            getAllUsersByLevel(selectedLevel).then(res => setUsers(res.data || []));
+        }
+    }, [selectedLevel]);
+
+    const handleSelect = (u: User) => {
+        const payload = { assignedTo: u.userId, assignedBy: getCurrentUserDetails()?.userId } as any;
+        apiHandler(() => updateTicket(ticketId, payload)).then(() => {
+            onAssigned?.(u.name);
+            setAnchorEl(null);
+        });
+    };
+
+    const filtered = users.filter(u =>
+        u.name.toLowerCase().includes(search.toLowerCase()) ||
+        u.userId.toLowerCase().includes(search.toLowerCase())
+    );
+
+    return (
+        <>
+            <UserAvatar name={assigneeName || ''} onClick={(e) => setAnchorEl(e.currentTarget)} />
+            <Menu anchorEl={anchorEl} open={open} onClose={() => setAnchorEl(null)}>
+                <Box sx={{ p: 1, width: 250 }}>
+                    <TextField value={search} onChange={e => setSearch(e.target.value)} placeholder="Search" size="small" fullWidth />
+                    <Box sx={{ mt: 1, mb: 1, display: 'flex', flexWrap: 'wrap' }}>
+                        {levels.map(l => (
+                            <Chip
+                                key={l.levelId}
+                                label={l.levelName}
+                                onClick={() => setSelectedLevel(l.levelId)}
+                                color={selectedLevel === l.levelId ? 'primary' : 'default'}
+                                size="small"
+                                sx={{ mr: 0.5, mb: 0.5 }}
+                            />
+                        ))}
+                    </Box>
+                    <List dense>
+                        {filtered.map(u => (
+                            <ListItemButton key={u.userId} onClick={() => handleSelect(u)}>
+                                <ListItemText primary={`${levels.find(l=>l.levelId===selectedLevel)?.levelName || ''} - ${u.name}`} />
+                            </ListItemButton>
+                        ))}
+                    </List>
+                </Box>
+            </Menu>
+        </>
+    );
+};
+
+export default AssigneeDropdown;

--- a/ui/src/components/AllTickets/TicketCard.tsx
+++ b/ui/src/components/AllTickets/TicketCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Card, CardContent, Typography, Box, Tooltip } from '@mui/material';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import MasterIcon from '../UI/Icons/MasterIcon';
+import AssigneeDropdown from './AssigneeDropdown';
 
 export interface TicketCardData {
     id: string;
@@ -11,6 +12,7 @@ export interface TicketCardData {
     priority: string;
     isMaster: boolean;
     requestorName?: string;
+    assignedTo?: string;
 }
 
 interface PriorityConfig { color: string; count: number; }
@@ -35,6 +37,9 @@ const TicketCard: React.FC<TicketCardProps> = ({ ticket, priorityConfig, onClick
                 <Typography variant="body2">Category: {ticket.category}</Typography>
                 <Typography variant="body2">Sub-Category: {ticket.subCategory}</Typography>
             </CardContent>
+            <Box sx={{ position: 'absolute', top: 8, right: 8 }}>
+                <AssigneeDropdown ticketId={ticket.id} assigneeName={ticket.assignedTo} />
+            </Box>
             <Box sx={{ position: 'absolute', bottom: 4, right: 4, color: p.color }}>
                 <Tooltip title={ticket.priority}>
                     <Box sx={{ position: 'relative', width: 24, height: 24 + (p.count - 1) * 10 }}>

--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import GenericTable from '../UI/GenericTable';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import MasterIcon from '../UI/Icons/MasterIcon';
+import AssigneeDropdown from './AssigneeDropdown';
 
 export interface TicketRow {
     id: string;
@@ -15,6 +16,7 @@ export interface TicketRow {
     requestorEmailId?: string;
     requestorMobileNo?: string;
     status?: string;
+    assignedTo?: string;
 }
 
 interface TicketsTableProps {
@@ -55,6 +57,13 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onRowClick }) => {
             { title: t('Category'), dataIndex: 'category', key: 'category' },
             { title: t('Sub-Category'), dataIndex: 'subCategory', key: 'subCategory' },
             { title: t('Priority'), dataIndex: 'priority', key: 'priority' },
+            {
+                title: t('Assignee'),
+                key: 'assignee',
+                render: (_: any, record: TicketRow) => (
+                    <AssigneeDropdown ticketId={record.id} assigneeName={record.assignedTo} />
+                )
+            },
             { title: t('Status'), dataIndex: 'status', key: 'status', render: (v: any) => v || '-' },
             {
                 title: t('Action'),

--- a/ui/src/components/UI/UserAvatar/UserAvatar.tsx
+++ b/ui/src/components/UI/UserAvatar/UserAvatar.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import Avatar from '@mui/material/Avatar';
+
+interface UserAvatarProps {
+    name: string;
+    onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+    size?: number;
+}
+
+const getInitials = (name: string) => {
+    if (!name) return '';
+    const parts = name.trim().split(' ');
+    const initials = parts.map(p => p[0]).slice(0,2).join('');
+    return initials.toUpperCase();
+};
+
+const UserAvatar: React.FC<UserAvatarProps> = ({ name, onClick, size = 32 }) => (
+    <Avatar
+        onClick={onClick}
+        sx={{ width: size, height: size, bgcolor: 'primary.main', cursor: onClick ? 'pointer' : 'default' }}
+    >
+        {getInitials(name)}
+    </Avatar>
+);
+
+export default UserAvatar;

--- a/ui/src/pages/AllTickets.tsx
+++ b/ui/src/pages/AllTickets.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from "react-i18next";
 import MasterIcon from "../components/UI/Icons/MasterIcon";
 import TicketsTable from "../components/AllTickets/TicketsTable";
 import TicketCard from "../components/AllTickets/TicketCard";
+import AssigneeDropdown from "../components/AllTickets/AssigneeDropdown";
 import ViewToggle from "../components/UI/ViewToggle";
 import GenericInput from "../components/UI/Input/GenericInput";
 import DropdownController from "../components/UI/Dropdown/DropdownController";
@@ -141,6 +142,13 @@ const AllTickets: React.FC = () => {
                 title: t('Priority'),
                 dataIndex: "priority",
                 key: "priority",
+            },
+            {
+                title: t('Assignee'),
+                key: 'assignee',
+                render: (_: any, record: Ticket) => (
+                    <AssigneeDropdown ticketId={record.id} assigneeName={record.assignedTo} />
+                )
             },
             {
                 title: t('Status'),

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -37,6 +37,7 @@ export interface Ticket {
     requestorEmailId?: string;
     requestorMobileNo?: string;
     status?: string;
+    assignedTo?: string;
 }
 
 export interface ToggleOption {


### PR DESCRIPTION
## Summary
- show assignee avatar in ticket table and grid card
- implement AssigneeDropdown for searching helpdesk users
- expose reusable UserAvatar component
- give helpdesk users levels in SQL dump

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68789a975a0c833292cdfe84fc05acfe