### PR TITLE
Fix search route and improve UI drawers

### DIFF
--- a/api/src/main/java/com/example/api/controller/TicketController.java
+++ b/api/src/main/java/com/example/api/controller/TicketController.java
@@ -36,8 +36,8 @@ public class TicketController {
         return ResponseEntity.ok(resp);
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<TicketDto> getTicket(@PathVariable String id) {
+    @GetMapping("/{id:[0-9a-fA-F\-]{36}}")
+    public ResponseEntity<TicketDto> getTicket(@PathVariable("id") String id) {
         TicketDto dto = ticketService.getTicket(id);
         if (dto == null) return ResponseEntity.notFound().build();
         return ResponseEntity.ok(dto);

--- a/ui/src/components/HistorySidebar.tsx
+++ b/ui/src/components/HistorySidebar.tsx
@@ -7,10 +7,11 @@ import { useTranslation } from 'react-i18next';
 
 interface HistorySidebarProps {
     ticketId: string;
+    open: boolean;
+    setOpen: (open: boolean) => void;
 }
 
-const HistorySidebar: React.FC<HistorySidebarProps> = ({ ticketId }) => {
-    const [open, setOpen] = useState(false);
+const HistorySidebar: React.FC<HistorySidebarProps> = ({ ticketId, open, setOpen }) => {
     const [tab, setTab] = useState<'status' | 'assignment'>('status');
     const { t } = useTranslation();
 
@@ -43,7 +44,7 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ ticketId }) => {
                     </Button>
                 </div>
             )}
-            <Drawer anchor="right" open={open} onClose={handleClose}>
+            <Drawer anchor="right" open={open} onClose={handleClose} variant="persistent">
                 <Box sx={{ width: 400, position: 'relative', p: 2 }}>
                     <IconButton onClick={handleClose} sx={{ position: 'absolute', left: -40, top: 8 }}>
                         <ChevronLeftIcon />

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -90,5 +90,7 @@
   ,"Assigned On": "Assigned On"
   ,"Collapse": "Collapse"
   ,"On behalf of FCI User": "On behalf of FCI User"
+  ,"All": "All"
+  ,"Master": "Master"
   ,"Employee ID": "Employee ID"
 }

--- a/ui/src/locales/hi/translation.json
+++ b/ui/src/locales/hi/translation.json
@@ -90,5 +90,7 @@
   ,"Assigned On": "असाइन किया गया दिनांक"
   ,"Collapse": "बंद करें"
   ,"On behalf of FCI User": "एफसीआई उपयोगकर्ता की ओर से"
+  ,"All": "सभी"
+  ,"Master": "मास्टर"
   ,"Employee ID": "कर्मचारी आईडी"
 }

--- a/ui/src/pages/AllTickets.tsx
+++ b/ui/src/pages/AllTickets.tsx
@@ -7,7 +7,7 @@ import { useDebounce } from "../hooks/useDebounce";
 import { getTickets, searchTicketsPaginated } from "../services/TicketService";
 import { getStatuses } from "../services/StatusService";
 import PaginationControls from "../components/PaginationControls";
-import { Switch, FormControlLabel, IconButton } from '@mui/material';
+import { IconButton } from '@mui/material';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
 import { useNavigate } from "react-router-dom";
@@ -181,10 +181,14 @@ const AllTickets: React.FC = () => {
                     options={statusOptions.map(s => ({ label: s, value: s }))}
                     style={{ width: 180, marginRight: 8 }}
                 />
-                <FormControlLabel
-                    control={<Switch checked={masterOnly} onChange={(e) => setMasterOnly(e.target.checked)} />}
-                    label="Master"
-                    sx={{ mr: 2 }}
+                <ViewToggle
+                    value={masterOnly ? 'master' : 'all'}
+                    onChange={(val: string) => setMasterOnly(val === 'master')}
+                    options={[
+                        { label: t('All'), value: 'all' },
+                        { label: t('Master'), value: 'master' }
+                    ]}
+                    radio
                 />
                 <ViewToggle
                     value={viewMode}

--- a/ui/src/pages/TicketDetails.tsx
+++ b/ui/src/pages/TicketDetails.tsx
@@ -51,6 +51,7 @@ const TicketDetails: React.FC = () => {
     const { register, handleSubmit, control, setValue, formState: { errors } } = useForm();
     const statusValue = useWatch({ control, name: 'status' });
     const [editing, setEditing] = useState<boolean>(false);
+    const [historyOpen, setHistoryOpen] = useState<boolean>(false);
 
     // API calls
     const getTicketHandler = (ticketId: any) => {
@@ -121,8 +122,9 @@ const TicketDetails: React.FC = () => {
     };
 
     return (
-        <div className="container">
-            <Title text={`${t('Ticket')} ${ticketId}: ${ticket?.subject}`} />
+        <div className="container" style={{ display: 'flex' }}>
+            <div style={{ flexGrow: 1, marginRight: historyOpen ? 400 : 0 }}>
+                <Title text={`${t('Ticket')} ${ticketId}: ${ticket?.subject}`} />
             {ticket && (
                 <div className="m-3 d-flex align-items-center">
                     <p className="mb-0 me-2">{t('Status')}: {ticket.status}</p>
@@ -135,9 +137,7 @@ const TicketDetails: React.FC = () => {
                 </div>
             )}
 
-            <HistorySidebar ticketId={ticketId as string} />
-            
-            <form onSubmit={handleSubmit(onSubmitUpdate)}>
+                <form onSubmit={handleSubmit(onSubmitUpdate)}>
                 <RequestDetails register={register} control={control} errors={errors} disableAll isFieldSetDisabled />
 
 
@@ -166,7 +166,9 @@ const TicketDetails: React.FC = () => {
                 />
             </form>
 
-            <CommentsSection ticketId={ticketId as string} />
+                <CommentsSection ticketId={ticketId as string} />
+            </div>
+            <HistorySidebar ticketId={ticketId as string} open={historyOpen} setOpen={setHistoryOpen} />
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- restrict ticket id path variable to avoid `/search` conflict
- convert history sidebar to persistent drawer with parent-controlled width
- switch `AllTickets` master toggle to a button toggle
- adjust ticket details layout for persistent history sidebar
- add `All` and `Master` translations

## Testing
- `npm test` *(fails: Cannot find module 'react-router-dom')*
- `./gradlew test` *(fails: cannot find Java installation)*

------
https://chatgpt.com/codex/tasks/task_e_6879bbf718908332aa196e65a8fa37c0