### PR TITLE
UI updates

### DIFF
--- a/ui/src/components/HistorySidebar.tsx
+++ b/ui/src/components/HistorySidebar.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Drawer, Tabs, Tab, Box, Button, IconButton } from '@mui/material';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import StatusHistory from './StatusHistory';
 import AssignmentHistory from './AssignmentHistory';
 import { useTranslation } from 'react-i18next';
@@ -44,7 +45,18 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ ticketId, open, setOpen
                     </Button>
                 </div>
             )}
-            <Drawer anchor="right" open={open} onClose={handleClose} variant="persistent">
+            {open && (
+                <IconButton onClick={handleClose} sx={{ position: 'fixed', right: 400, top: '50%', transform: 'translateY(-50%)', zIndex: 1300 }}>
+                    <ChevronRightIcon />
+                </IconButton>
+            )}
+            <Drawer
+                anchor="right"
+                open={open}
+                onClose={handleClose}
+                variant="persistent"
+                PaperProps={{ sx: { top: '70px', height: 'calc(100vh - 70px)' } }}
+            >
                 <Box sx={{ width: 400, position: 'relative', p: 2 }}>
                     <IconButton onClick={handleClose} sx={{ position: 'absolute', left: -40, top: 8 }}>
                         <ChevronLeftIcon />

--- a/ui/src/pages/AllTickets.tsx
+++ b/ui/src/pages/AllTickets.tsx
@@ -7,7 +7,7 @@ import { useDebounce } from "../hooks/useDebounce";
 import { getTickets, searchTicketsPaginated } from "../services/TicketService";
 import { getStatuses } from "../services/StatusService";
 import PaginationControls from "../components/PaginationControls";
-import { IconButton } from '@mui/material';
+import { IconButton, Chip } from '@mui/material';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
 import { useNavigate } from "react-router-dom";
@@ -181,14 +181,12 @@ const AllTickets: React.FC = () => {
                     options={statusOptions.map(s => ({ label: s, value: s }))}
                     style={{ width: 180, marginRight: 8 }}
                 />
-                <ViewToggle
-                    value={masterOnly ? 'master' : 'all'}
-                    onChange={(val: string) => setMasterOnly(val === 'master')}
-                    options={[
-                        { label: t('All'), value: 'all' },
-                        { label: t('Master'), value: 'master' }
-                    ]}
-                    radio
+                <Chip
+                    label={t('Master')}
+                    color={masterOnly ? 'primary' : 'default'}
+                    variant={masterOnly ? 'filled' : 'outlined'}
+                    onClick={() => setMasterOnly(prev => !prev)}
+                    sx={{ mr: 1 }}
                 />
                 <ViewToggle
                     value={viewMode}


### PR DESCRIPTION
## Summary
- adjust HistorySidebar position and collapse behavior
- show user levels and usernames in assignee dropdown
- tweak master filter UI in All Tickets page

## Testing
- `./gradlew test` *(fails: jitpack.io blocked)*
- `npm test -- -u` *(fails: react-scripts not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6879df84003c833299015f98e4f4cc9c