### PR TITLE
Align permissions with frontend structure

### DIFF
--- a/api/src/main/java/com/example/api/permissions/RolePermission.java
+++ b/api/src/main/java/com/example/api/permissions/RolePermission.java
@@ -8,6 +8,16 @@ import java.util.Map;
 @Getter
 @Setter
 public class RolePermission {
-    private Map<String, Map<String, Object>> sidebar;
-    private Map<String, Map<String, Object>> forms;
+    /**
+     * Structure containing sidebar permissions. The values can be booleans or
+     * nested objects depending on the JSON configuration, so we keep them as
+     * generic {@link Object}.
+     */
+    private Map<String, Object> sidebar;
+
+    /**
+     * Pages (previously forms) permissions. The structure can be deeply nested
+     * therefore we use a generic map.
+     */
+    private Map<String, Object> pages;
 }

--- a/api/src/main/resources/config/permissions.json
+++ b/api/src/main/resources/config/permissions.json
@@ -2,165 +2,160 @@
   "roles": {
     "USER": {
       "sidebar": {
-        "tickets": { "show": true },
-        "create-ticket": { "show": true },
-        "faq": { "show": true }
+        "myTickets": true,
+        "raiseTickets": true,
+        "knowledgeBase": true,
+        "faq": true,
+        "categoriesMaster": false,
+        "escalationMaster": false
       },
-      "forms": {
-        "RequestDetails": {
-          "view": true,
-          "create": true,
-          "update": false,
-          "fields": {
-            "ticketId": false,
-            "reportedDate": true,
-            "mode": true
-          }
+      "pages": {
+        "myTickets": {
+          "searchBar": true,
+          "statusFilter": true,
+          "masterFilterToggle": true,
+          "gridTableViewToggle": true,
+          "table": {
+            "masterTag": true,
+            "pagination": true,
+            "pageSize": true,
+            "columns": {
+              "ticketId": true,
+              "requestorName": true,
+              "email": true,
+              "mobile": true,
+              "category": true,
+              "subCategory": true,
+              "priority": true,
+              "assignee": true,
+              "status": true,
+              "action": true
+            }
+          },
+          "grid": true
         },
-        "RequestorDetails": {
-          "view": true,
-          "create": true,
-          "update": false,
-          "fields": {
-            "employeeId": false,
+        "ticketForm": {
+          "requestDetails": {
+            "ticketId": true,
+            "mode": true,
+            "reportedDate": true
+          },
+          "requestorDetails": {
             "userId": true,
             "requestorName": true,
             "emailId": true,
-            "mobileNo": true,
+            "phoneNumber": true,
             "stakeholder": true,
-            "role": false,
-            "office": false
-          }
-        },
-        "TicketDetails": {
-          "view": true,
-          "create": true,
-          "update": false,
-          "fields": {
-            "assignedToLevel": false,
-            "assignedTo": false,
+            "role": true,
+            "office": true,
+            "onBehalfOfFciUser": true
+          },
+          "ticketDetails": {
+            "editButton": false,
+            "assignedToLevel": true,
+            "assignedTo": true,
             "category": true,
             "subCategory": true,
             "priority": true,
-            "severity": false,
-            "recommendedSeverity": false,
+            "severityFields": {
+              "severity": true,
+              "selectedImpact": true,
+              "recommendedSeverity": false
+            },
             "impact": true,
-            "isMaster": true,
+            "isMasterCheckbox": true,
             "subject": true,
             "description": true,
             "attachment": true,
-            "status": false,
-            "assignFurther": false
+            "status": true,
+            "assignFurtherCheckbox": false,
+            "assignToLevelDropdown": false,
+            "assignToDropdown": false
+          },
+          "comments": {
+            "postComment": true,
+            "editButton": false,
+            "deleteButton": false
           }
         }
       }
     },
     "ADMIN": {
       "sidebar": {
-        "tickets": { "show": true },
-        "create-ticket": { "show": true },
-        "knowledge-base": { "show": true },
-        "categories-master": { "show": true },
-        "escalation-master": { "show": true }
+        "myTickets": true,
+        "raiseTickets": true,
+        "knowledgeBase": true,
+        "faq": true,
+        "categoriesMaster": true,
+        "escalationMaster": true
       },
-      "forms": {
-        "RequestDetails": {
-          "view": true,
-          "create": true,
-          "update": true,
-          "fields": {
-            "ticketId": true,
-            "reportedDate": true,
-            "mode": true
-          }
+      "pages": {
+        "myTickets": {
+          "searchBar": true,
+          "statusFilter": true,
+          "masterFilterToggle": true,
+          "gridTableViewToggle": true,
+          "table": {
+            "masterTag": true,
+            "pagination": true,
+            "pageSize": true,
+            "columns": {
+              "ticketId": true,
+              "requestorName": true,
+              "email": true,
+              "mobile": true,
+              "category": true,
+              "subCategory": true,
+              "priority": true,
+              "assignee": true,
+              "status": true,
+              "action": true
+            }
+          },
+          "grid": true
         },
-        "RequestorDetails": {
-          "view": true,
-          "create": true,
-          "update": true,
-          "fields": {
+        "ticketForm": {
+          "requestDetails": {
+            "ticketId": true,
+            "mode": true,
+            "reportedDate": true
+          },
+          "requestorDetails": {
             "userId": true,
             "requestorName": true,
             "emailId": true,
-            "mobileNo": true,
+            "phoneNumber": true,
             "stakeholder": true,
             "role": true,
-            "office": true
-          }
-        },
-        "TicketDetails": {
-          "view": true,
-          "create": true,
-          "update": true,
-          "fields": {
+            "office": true,
+            "onBehalfOfFciUser": true
+          },
+          "ticketDetails": {
+            "editButton": true,
             "assignedToLevel": true,
             "assignedTo": true,
             "category": true,
             "subCategory": true,
             "priority": true,
-            "severity": true,
-            "recommendedSeverity": true,
+            "severityFields": {
+              "severity": true,
+              "selectedImpact": true,
+              "recommendedSeverity": true
+            },
             "impact": true,
-            "isMaster": true,
+            "isMasterCheckbox": true,
             "subject": true,
             "description": true,
             "attachment": true,
             "status": true,
-            "assignFurther": true
-          }
-        }
-      }
-    },
-    "HELPDESK": {
-      "sidebar": {
-        "tickets": { "show": true },
-        "create-ticket": { "show": true },
-        "knowledge-base": { "show": true }
-      },
-      "forms": {
-        "RequestDetails": {
-          "view": true,
-          "create": true,
-          "update": true,
-          "fields": {
-            "ticketId": true,
-            "reportedDate": true,
-            "mode": true
-          }
-        },
-        "RequestorDetails": {
-          "view": true,
-          "create": true,
-          "update": true,
-          "fields": {
-            "userId": true,
-            "requestorName": true,
-            "emailId": true,
-            "mobileNo": true,
-            "stakeholder": true,
-            "role": true,
-            "office": true
-          }
-        },
-        "TicketDetails": {
-          "view": true,
-          "create": true,
-          "update": true,
-          "fields": {
-            "assignedToLevel": true,
-            "assignedTo": true,
-            "category": true,
-            "subCategory": true,
-            "priority": true,
-            "severity": true,
-            "recommendedSeverity": true,
-            "impact": true,
-            "isMaster": true,
-            "subject": true,
-            "description": true,
-            "attachment": true,
-            "status": true,
-            "assignFurther": true
+            "assignFurtherCheckbox": true,
+            "assignToLevelDropdown": true,
+            "assignToDropdown": true
+          },
+          "comments": {
+            "postComment": true,
+            "editButton": true,
+            "deleteButton": true
           }
         }
       }


### PR DESCRIPTION
## Summary
- update RolePermission to support generic sidebar and page structures
- enhance PermissionService merge logic for nested maps
- replace old permissions.json with new page-based layout

## Testing
- `./gradlew test --no-daemon` *(fails: Could not resolve com.github.typesense due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687a09d825688332a55ae05743f09140