### PR TITLE
Add DB based permission management

### DIFF
--- a/api/src/main/java/com/example/api/controller/PermissionController.java
+++ b/api/src/main/java/com/example/api/controller/PermissionController.java
@@ -1,0 +1,26 @@
+package com.example.api.controller;
+
+import com.example.api.permissions.RolePermission;
+import com.example.api.service.PermissionService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/permissions")
+@CrossOrigin(origins = "http://localhost:3000")
+public class PermissionController {
+    private final PermissionService permissionService;
+
+    public PermissionController(PermissionService permissionService) {
+        this.permissionService = permissionService;
+    }
+
+    @PutMapping("/{role}")
+    public ResponseEntity<Void> updatePermission(@PathVariable String role,
+                                                 @RequestBody RolePermission permission) throws IOException {
+        permissionService.updateRolePermissions(role, permission);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/api/src/main/java/com/example/api/models/RolePermissionConfig.java
+++ b/api/src/main/java/com/example/api/models/RolePermissionConfig.java
@@ -1,0 +1,23 @@
+package com.example.api.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "role_permission_config")
+@Getter
+@Setter
+public class RolePermissionConfig {
+    @Id
+    @Column(name = "role", length = 100)
+    private String role;
+
+    @Lob
+    @Column(name = "permissions", columnDefinition = "TEXT")
+    private String permissions;
+}

--- a/api/src/main/java/com/example/api/repository/RolePermissionConfigRepository.java
+++ b/api/src/main/java/com/example/api/repository/RolePermissionConfigRepository.java
@@ -1,0 +1,7 @@
+package com.example.api.repository;
+
+import com.example.api.models.RolePermissionConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RolePermissionConfigRepository extends JpaRepository<RolePermissionConfig, String> {
+}


### PR DESCRIPTION
## Summary
- store role permissions in `role_permission_config` table
- load permission JSON from DB instead of resource file
- expose endpoint to update role permissions

## Testing
- `./gradlew test` *(fails: Could not resolve typesense-java from jitpack)*

------
https://chatgpt.com/codex/tasks/task_e_687a26d886dc83328a2288d756170171