### PR TITLE
Implement permissions config update API

### DIFF
--- a/api/src/main/java/com/example/api/controller/PermissionController.java
+++ b/api/src/main/java/com/example/api/controller/PermissionController.java
@@ -1,6 +1,8 @@
 package com.example.api.controller;
 
+import com.example.api.dto.PermissionsConfigDto;
 import com.example.api.permissions.RolePermission;
+import com.example.api.permissions.PermissionsConfig;
 import com.example.api.service.PermissionService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +17,14 @@ public class PermissionController {
 
     public PermissionController(PermissionService permissionService) {
         this.permissionService = permissionService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> overwritePermissions(@RequestBody PermissionsConfigDto dto) throws IOException {
+        PermissionsConfig config = new PermissionsConfig();
+        config.setRoles(dto.getRoles());
+        permissionService.overwritePermissions(config);
+        return ResponseEntity.ok().build();
     }
 
     @PutMapping("/{role}")

--- a/api/src/main/java/com/example/api/dto/PermissionsConfigDto.java
+++ b/api/src/main/java/com/example/api/dto/PermissionsConfigDto.java
@@ -1,0 +1,13 @@
+package com.example.api.dto;
+
+import com.example.api.permissions.RolePermission;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@Setter
+public class PermissionsConfigDto {
+    private Map<String, RolePermission> roles;
+}

--- a/api/src/main/java/com/example/api/service/PermissionService.java
+++ b/api/src/main/java/com/example/api/service/PermissionService.java
@@ -49,6 +49,21 @@ public class PermissionService {
         config.getRoles().put(role, permission);
     }
 
+    public void overwritePermissions(PermissionsConfig permissions) throws IOException {
+        repository.deleteAll();
+        if (permissions != null && permissions.getRoles() != null) {
+            for (Map.Entry<String, RolePermission> entry : permissions.getRoles().entrySet()) {
+                String json = objectMapper.writeValueAsString(entry.getValue());
+                RolePermissionConfig rpc = new RolePermissionConfig();
+                rpc.setRole(entry.getKey());
+                rpc.setPermissions(json);
+                repository.save(rpc);
+            }
+        }
+
+        loadPermissions();
+    }
+
     private List<RolePermission> getRolePermissions(List<String> roles) {
         List<RolePermission> list = new ArrayList<>();
         if (config == null || config.getRoles() == null) {

--- a/ui/src/services/PermissionService.ts
+++ b/ui/src/services/PermissionService.ts
@@ -1,0 +1,6 @@
+import axios from 'axios';
+import { BASE_URL } from './api';
+
+export function savePermissions(config: any) {
+    return axios.post(`${BASE_URL}/permissions`, config);
+}


### PR DESCRIPTION
## Summary
- add `PermissionsConfigDto` to wrap role permissions map
- allow overwriting all role permissions in `PermissionService`
- expose new `/permissions` POST endpoint
- add front-end service helper for saving permissions

## Testing
- `./gradlew test` *(fails: could not resolve com.github.typesense:typesense-java)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a34032c4c8332b5a37137ae0ed9f5