### PR TITLE
Add Permissions Manager

### DIFF
--- a/api/src/main/java/com/example/api/controller/PermissionController.java
+++ b/api/src/main/java/com/example/api/controller/PermissionController.java
@@ -19,6 +19,22 @@ public class PermissionController {
         this.permissionService = permissionService;
     }
 
+    @GetMapping
+    public ResponseEntity<PermissionsConfig> getAllPermissions() {
+        PermissionsConfig cfg = new PermissionsConfig();
+        cfg.setRoles(permissionService.getAllRolePermissions());
+        return ResponseEntity.ok(cfg);
+    }
+
+    @GetMapping("/{role}")
+    public ResponseEntity<RolePermission> getRolePermission(@PathVariable String role) {
+        RolePermission perm = permissionService.getRolePermission(role);
+        if (perm == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(perm);
+    }
+
     @PostMapping
     public ResponseEntity<Void> overwritePermissions(@RequestBody PermissionsConfigDto dto) throws IOException {
         PermissionsConfig config = new PermissionsConfig();

--- a/api/src/main/java/com/example/api/service/PermissionService.java
+++ b/api/src/main/java/com/example/api/service/PermissionService.java
@@ -64,6 +64,20 @@ public class PermissionService {
         loadPermissions();
     }
 
+    public Map<String, RolePermission> getAllRolePermissions() {
+        if (config == null || config.getRoles() == null) {
+            return Collections.emptyMap();
+        }
+        return config.getRoles();
+    }
+
+    public RolePermission getRolePermission(String role) {
+        if (config == null || config.getRoles() == null) {
+            return null;
+        }
+        return config.getRoles().get(role);
+    }
+
     private List<RolePermission> getRolePermissions(List<String> roles) {
         List<RolePermission> list = new ArrayList<>();
         if (config == null || config.getRoles() == null) {

--- a/api/src/main/resources/config/permissions.json
+++ b/api/src/main/resources/config/permissions.json
@@ -7,7 +7,8 @@
         "knowledgeBase": { "show": false },
         "faq": { "show": true },
         "categoriesMaster": { "show": true },
-        "escalationMaster": { "show": true }
+        "escalationMaster": { "show": true },
+        "permissionsManager": { "show": false }
       },
       "pages": {
         "myTickets": {
@@ -87,7 +88,8 @@
         "knowledgeBase": { "show": false },
         "faq": { "show": true },
         "categoriesMaster": { "show": true },
-        "escalationMaster": { "show": true }
+        "escalationMaster": { "show": true },
+        "permissionsManager": { "show": true }
       },
       "pages": {
         "myTickets": {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -6,6 +6,8 @@ import KnowledgeBase from './pages/KnowledgeBase';
 import TicketDetails from './pages/TicketDetails';
 import CategoriesMaster from './pages/CategoriesMaster';
 import EscalationMaster from './pages/EscalationMaster';
+import PermissionsManager from './pages/PermissionsManager';
+import RoleDetails from './pages/RoleDetails';
 import SidebarLayout from './components/Layout/SidebarLayout';
 import Login from './pages/Login';
 
@@ -21,6 +23,8 @@ function App() {
         <Route path="knowledge-base" element={<KnowledgeBase />} />
         <Route path="categories-master" element={<CategoriesMaster />} />
         <Route path="escalation-master" element={<EscalationMaster />} />
+        <Route path="permissions" element={<PermissionsManager />} />
+        <Route path="permissions/:roleId" element={<RoleDetails />} />
       </Route>
     </Routes>
   );

--- a/ui/src/components/Layout/Sidebar.tsx
+++ b/ui/src/components/Layout/Sidebar.tsx
@@ -13,6 +13,7 @@ import LibraryBooksIcon from "@mui/icons-material/LibraryBooks";
 import CategoryIcon from "@mui/icons-material/Category";
 import { checkSidebarAccess } from "../../utils/permissions";
 import SupervisorAccountIcon from "@mui/icons-material/SupervisorAccount";
+import LockIcon from '@mui/icons-material/Lock';
 import { useTheme } from "@mui/material/styles";
 
 const menuItems = [
@@ -45,6 +46,12 @@ const menuItems = [
     label: "Escalation Master",
     to: "/escalation-master",
     icon: <SupervisorAccountIcon />,
+  },
+  {
+    key: "permissionsManager",
+    label: "Permissions Manager",
+    to: "/permissions",
+    icon: <LockIcon />,
   },
 ];
 

--- a/ui/src/components/Permissions/PermissionTree.tsx
+++ b/ui/src/components/Permissions/PermissionTree.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { Checkbox, Collapse, FormControlLabel, IconButton } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+
+interface TreeProps {
+    data: any;
+    path?: string[];
+    onChange: (data: any) => void;
+}
+
+const setValue = (obj: any, path: string[], value: any) => {
+    if (path.length === 1) {
+        return { ...obj, [path[0]]: value };
+    }
+    const [first, ...rest] = path;
+    return {
+        ...obj,
+        [first]: setValue(obj[first] ?? {}, rest, value)
+    };
+};
+
+const Node: React.FC<{ label: string; value: any; path: string[]; onChange: (path: string[], value: any) => void }> = ({ label, value, path, onChange }) => {
+    const [open, setOpen] = useState(true);
+    const isObject = value && typeof value === 'object' && !Array.isArray(value);
+
+    if (isObject) {
+        return (
+            <div style={{ marginLeft: 16 }}>
+                <div style={{ display: 'flex', alignItems: 'center' }}>
+                    <IconButton size="small" onClick={() => setOpen(o => !o)}>
+                        {open ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+                    </IconButton>
+                    <span>{label}</span>
+                </div>
+                <Collapse in={open} timeout="auto" unmountOnExit>
+                    {Object.entries(value).map(([k, v]) => (
+                        <Node key={k} label={k} value={v} path={[...path, k]} onChange={onChange} />
+                    ))}
+                </Collapse>
+            </div>
+        );
+    }
+
+    return (
+        <FormControlLabel
+            style={{ marginLeft: 16 }}
+            control={<Checkbox checked={Boolean(value)} onChange={e => onChange(path, e.target.checked)} />}
+            label={label}
+        />
+    );
+};
+
+const PermissionTree: React.FC<TreeProps> = ({ data, path = [], onChange }) => {
+    const handleChange = (p: string[], value: any) => {
+        onChange(setValue(data, p.slice(path.length), value));
+    };
+
+    return (
+        <div>
+            {Object.entries(data).map(([k, v]) => (
+                <Node key={k} label={k} value={v} path={[...path, k]} onChange={handleChange} />
+            ))}
+        </div>
+    );
+};
+
+export default PermissionTree;

--- a/ui/src/pages/PermissionsManager.tsx
+++ b/ui/src/pages/PermissionsManager.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useState } from 'react';
+import { Button } from '@mui/material';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import { useApi } from '../hooks/useApi';
+import { getAllPermissions, updateRolePermission } from '../services/PermissionService';
+import ViewToggle from '../components/UI/ViewToggle';
+import GenericTable from '../components/UI/GenericTable';
+import Title from '../components/Title';
+import { useNavigate } from 'react-router-dom';
+
+const PermissionsManager: React.FC = () => {
+    const { data, apiHandler } = useApi<any>();
+    const [view, setView] = useState<'table' | 'grid'>('table');
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        apiHandler(() => getAllPermissions());
+    }, []);
+
+    const roles = data?.roles ? Object.keys(data.roles) : [];
+
+    const handleCreate = () => {
+        const role = prompt('Role name');
+        if (role) {
+            updateRolePermission(role, { sidebar: {}, pages: {} }).then(() => navigate(`/permissions/${role}`));
+        }
+    };
+
+    const columns = [
+        { title: 'Role', dataIndex: 'role', key: 'role' },
+        { title: 'Created By', key: 'cb', render: () => '-' },
+        { title: 'Created On', key: 'co', render: () => '-' },
+        { title: 'Updated By', key: 'ub', render: () => '-' },
+        { title: 'Updated On', key: 'uo', render: () => '-' },
+        {
+            title: 'Action',
+            key: 'action',
+            render: (_: any, r: any) => (
+                <VisibilityIcon sx={{ cursor: 'pointer', color: 'grey.600' }} onClick={() => navigate(`/permissions/${r.role}`)} />
+            )
+        }
+    ];
+
+    return (
+        <div className="container">
+            <Title textKey="Permissions Manager" />
+            <div className="d-flex justify-content-between mb-3">
+                <Button variant="contained" onClick={handleCreate}>Create Role</Button>
+                <ViewToggle value={view} onChange={setView} options={[{ icon: 'grid', value: 'grid' }, { icon: 'table', value: 'table' }]} />
+            </div>
+            {view === 'table' ? (
+                <GenericTable dataSource={roles.map(r => ({ role: r }))} columns={columns as any} rowKey="role" pagination={false} />
+            ) : (
+                <div className="row">
+                    {roles.map(r => (
+                        <div className="col-md-3 mb-3" key={r}>
+                            <div className="card p-3" style={{ cursor: 'pointer' }} onClick={() => navigate(`/permissions/${r}`)}>
+                                <b>{r}</b>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default PermissionsManager;

--- a/ui/src/pages/RoleDetails.tsx
+++ b/ui/src/pages/RoleDetails.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useApi } from '../hooks/useApi';
+import { getRolePermission, updateRolePermission } from '../services/PermissionService';
+import Title from '../components/Title';
+import PermissionTree from '../components/Permissions/PermissionTree';
+import { Button } from '@mui/material';
+
+const RoleDetails: React.FC = () => {
+    const { roleId } = useParams<{ roleId: string }>();
+    const { data, apiHandler } = useApi<any>();
+    const [perm, setPerm] = useState<any>(null);
+
+    useEffect(() => {
+        if (roleId) {
+            apiHandler(() => getRolePermission(roleId));
+        }
+    }, [roleId]);
+
+    useEffect(() => {
+        if (data) setPerm(data);
+    }, [data]);
+
+    const handleSubmit = () => {
+        if (roleId) {
+            updateRolePermission(roleId, perm);
+        }
+    };
+
+    if (!roleId) return null;
+
+    return (
+        <div className="container">
+            <Title textKey={`Role: ${roleId}`} />
+            {perm && <PermissionTree data={perm} onChange={setPerm} />}
+            <Button variant="contained" className="mt-3" onClick={handleSubmit}>Save</Button>
+        </div>
+    );
+};
+
+export default RoleDetails;

--- a/ui/src/services/PermissionService.ts
+++ b/ui/src/services/PermissionService.ts
@@ -4,3 +4,15 @@ import { BASE_URL } from './api';
 export function savePermissions(config: any) {
     return axios.post(`${BASE_URL}/permissions`, config);
 }
+
+export function getAllPermissions() {
+    return axios.get(`${BASE_URL}/permissions`);
+}
+
+export function getRolePermission(role: string) {
+    return axios.get(`${BASE_URL}/permissions/${role}`);
+}
+
+export function updateRolePermission(role: string, perm: any) {
+    return axios.put(`${BASE_URL}/permissions/${role}`, perm);
+}


### PR DESCRIPTION
## Summary
- add endpoints to read role permissions
- store permissionsManager sidebar toggle in permissions config
- create recursive permission tree component
- add permissions manager pages
- allow admin menu access to manager

## Testing
- `./api/gradlew -p api test` *(fails: Cannot find Java installation)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d67124f9c833294ea2a23ef50122b