### PR TITLE
Update PermissionTree and RoleDetails

### DIFF
--- a/ui/src/components/Permissions/PermissionTree.tsx
+++ b/ui/src/components/Permissions/PermissionTree.tsx
@@ -21,7 +21,8 @@ const setValue = (obj: any, path: string[], value: any): object => {
 };
 
 const Node: React.FC<{ label: string; value: any; path: string[]; onChange: (path: string[], value: any) => void }> = ({ label, value, path, onChange }) => {
-    const [open, setOpen] = useState(true);
+    const defaultOpen = path.length === 1 && (label === 'pages' || label === 'sidebar');
+    const [open, setOpen] = useState(defaultOpen);
     const isObject = value && typeof value === 'object' && !Array.isArray(value);
 
     if (isObject) {
@@ -43,11 +44,14 @@ const Node: React.FC<{ label: string; value: any; path: string[]; onChange: (pat
     }
 
     return (
-        <FormControlLabel
-            style={{ marginLeft: 16 }}
-            control={<Checkbox checked={Boolean(value)} onChange={e => onChange(path, e.target.checked)} />}
-            label={label}
-        />
+        <div style={{ display: 'flex', alignItems: 'center', marginLeft: 16 }}>
+            <Checkbox
+                size="small"
+                checked={Boolean(value)}
+                onChange={e => onChange(path, e.target.checked)}
+            />
+            <span>{label}</span>
+        </div>
     );
 };
 

--- a/ui/src/pages/RoleDetails.tsx
+++ b/ui/src/pages/RoleDetails.tsx
@@ -5,11 +5,13 @@ import { getRolePermission, updateRolePermission } from '../services/PermissionS
 import Title from '../components/Title';
 import PermissionTree from '../components/Permissions/PermissionTree';
 import { Button } from '@mui/material';
+import { useSnackbar } from '../context/SnackbarContext';
 
 const RoleDetails: React.FC = () => {
     const { roleId } = useParams<{ roleId: string }>();
     const { data, apiHandler } = useApi<any>();
     const [perm, setPerm] = useState<any>(null);
+    const { showMessage } = useSnackbar();
 
     useEffect(() => {
         if (roleId) {
@@ -23,7 +25,9 @@ const RoleDetails: React.FC = () => {
 
     const handleSubmit = () => {
         if (roleId) {
-            updateRolePermission(roleId, perm);
+            updateRolePermission(roleId, perm).then(() => {
+                showMessage('Permissions updated successfully', 'success');
+            });
         }
     };
 


### PR DESCRIPTION
## Summary
- tweak PermissionTree layout for checkboxes
- default collapse all nodes except pages and sidebar
- show success snackbar when saving permissions

## Testing
- `npm test -- -w 1` *(fails: Cannot find module 'react-router-dom')*
- `./gradlew test` *(fails: Could not resolve com.github.typesense:typesense-java:0.2.0)*

------
https://chatgpt.com/codex/tasks/task_e_687e237bee1c8332ba6b87185ab77abb