### PR TITLE
Implement conditional permissions for MyTickets table

### DIFF
--- a/api/src/main/resources/config/permissions.json
+++ b/api/src/main/resources/config/permissions.json
@@ -12,28 +12,38 @@
       },
       "pages": {
         "myTickets": {
-          "searchBar": true,
-          "statusFilter": true,
-          "masterFilterToggle": true,
-          "gridTableViewToggle": true,
-          "table": {
-            "masterTag": true,
-            "pagination": true,
-            "pageSize": true,
-            "columns": {
-              "ticketId": true,
-              "requestorName": true,
-              "email": true,
-              "mobile": true,
-              "category": true,
-              "subCategory": true,
-              "priority": true,
-              "assignee": true,
-              "status": true,
-              "action": true
-            }
-          },
-          "grid": true
+          "metadata": { "name": "My Tickets", "fields": "section" },
+          "children": {
+            "searchBar": { "metadata": { "name": "Search Bar", "fields": "input" }, "show": true },
+            "statusFilter": { "metadata": { "name": "Status Filter", "fields": "input" }, "show": true },
+            "masterFilterToggle": { "metadata": { "name": "Master Filter Toggle", "fields": "button" }, "show": true },
+            "gridTableViewToggle": { "metadata": { "name": "Grid/Table Toggle", "fields": "button" }, "show": true },
+            "table": {
+              "metadata": { "name": "Tickets Table", "fields": "table" },
+              "show": true,
+              "children": {
+                "masterTag": { "metadata": { "name": "Master Tag", "fields": "section" }, "show": true },
+                "pagination": { "metadata": { "name": "Pagination", "fields": "section" }, "show": true },
+                "pageSize": { "metadata": { "name": "Page Size", "fields": "input" }, "show": true },
+                "columns": {
+                  "metadata": { "name": "Columns", "fields": "section" },
+                  "children": {
+                    "ticketId": { "metadata": { "name": "Ticket Id", "fields": "column" }, "show": true },
+                    "requestorName": { "metadata": { "name": "Requestor Name", "fields": "column" }, "show": true },
+                    "email": { "metadata": { "name": "Email", "fields": "column" }, "show": true },
+                    "mobile": { "metadata": { "name": "Mobile", "fields": "column" }, "show": true },
+                    "category": { "metadata": { "name": "Category", "fields": "column" }, "show": true },
+                    "subCategory": { "metadata": { "name": "Sub-Category", "fields": "column" }, "show": true },
+                    "priority": { "metadata": { "name": "Priority", "fields": "column" }, "show": true },
+                    "assignee": { "metadata": { "name": "Assignee", "fields": "column" }, "show": true },
+                    "status": { "metadata": { "name": "Status", "fields": "column" }, "show": true },
+                    "action": { "metadata": { "name": "Action", "fields": "column" }, "show": true }
+                  }
+                }
+              }
+            },
+            "grid": { "metadata": { "name": "Grid View", "fields": "section" }, "show": true }
+          }
         },
         "ticketForm": {
           "requestDetails": {
@@ -93,28 +103,38 @@
       },
       "pages": {
         "myTickets": {
-          "searchBar": true,
-          "statusFilter": true,
-          "masterFilterToggle": true,
-          "gridTableViewToggle": true,
-          "table": {
-            "masterTag": true,
-            "pagination": true,
-            "pageSize": true,
-            "columns": {
-              "ticketId": true,
-              "requestorName": true,
-              "email": true,
-              "mobile": true,
-              "category": true,
-              "subCategory": true,
-              "priority": true,
-              "assignee": true,
-              "status": true,
-              "action": true
-            }
-          },
-          "grid": true
+          "metadata": { "name": "My Tickets", "fields": "section" },
+          "children": {
+            "searchBar": { "metadata": { "name": "Search Bar", "fields": "input" }, "show": true },
+            "statusFilter": { "metadata": { "name": "Status Filter", "fields": "input" }, "show": true },
+            "masterFilterToggle": { "metadata": { "name": "Master Filter Toggle", "fields": "button" }, "show": true },
+            "gridTableViewToggle": { "metadata": { "name": "Grid/Table Toggle", "fields": "button" }, "show": true },
+            "table": {
+              "metadata": { "name": "Tickets Table", "fields": "table" },
+              "show": true,
+              "children": {
+                "masterTag": { "metadata": { "name": "Master Tag", "fields": "section" }, "show": true },
+                "pagination": { "metadata": { "name": "Pagination", "fields": "section" }, "show": true },
+                "pageSize": { "metadata": { "name": "Page Size", "fields": "input" }, "show": true },
+                "columns": {
+                  "metadata": { "name": "Columns", "fields": "section" },
+                  "children": {
+                    "ticketId": { "metadata": { "name": "Ticket Id", "fields": "column" }, "show": true },
+                    "requestorName": { "metadata": { "name": "Requestor Name", "fields": "column" }, "show": true },
+                    "email": { "metadata": { "name": "Email", "fields": "column" }, "show": true },
+                    "mobile": { "metadata": { "name": "Mobile", "fields": "column" }, "show": true },
+                    "category": { "metadata": { "name": "Category", "fields": "column" }, "show": true },
+                    "subCategory": { "metadata": { "name": "Sub-Category", "fields": "column" }, "show": true },
+                    "priority": { "metadata": { "name": "Priority", "fields": "column" }, "show": true },
+                    "assignee": { "metadata": { "name": "Assignee", "fields": "column" }, "show": true },
+                    "status": { "metadata": { "name": "Status", "fields": "column" }, "show": true },
+                    "action": { "metadata": { "name": "Action", "fields": "column" }, "show": true }
+                  }
+                }
+              }
+            },
+            "grid": { "metadata": { "name": "Grid View", "fields": "section" }, "show": true }
+          }
         },
         "ticketForm": {
           "requestDetails": {

--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -4,6 +4,7 @@ import GenericTable from '../UI/GenericTable';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import MasterIcon from '../UI/Icons/MasterIcon';
 import AssigneeDropdown from './AssigneeDropdown';
+import { checkMyTicketsColumnAccess } from '../../utils/permissions';
 
 export interface TicketRow {
     id: string;
@@ -31,7 +32,7 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onRowClick }) => {
             {
                 title: t('Ticket Id'),
                 dataIndex: 'id',
-                key: 'id',
+                key: 'ticketId',
                 render: (_: any, record: TicketRow) => (
                     <div className="d-flex align-items-center">
                         {record.id}
@@ -41,7 +42,7 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onRowClick }) => {
             },
             {
                 title: t('Requestor Name'),
-                key: 'name',
+                key: 'requestorName',
                 render: (_: any, record: TicketRow) => record.requestorName || '-',
             },
             {
@@ -70,7 +71,7 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onRowClick }) => {
                 key: 'action',
                 render: (_: any, record: TicketRow) => <VisibilityIcon onClick={() => onRowClick(record.id)} fontSize="small" sx={{ color: 'grey.600', cursor: 'pointer' }} />,
             },
-        ],
+        ].filter(col => col.key && checkMyTicketsColumnAccess(col.key.toString())),
         [t]
     );
 

--- a/ui/src/components/Permissions/PermissionTree.tsx
+++ b/ui/src/components/Permissions/PermissionTree.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Checkbox, Collapse, FormControlLabel, IconButton } from '@mui/material';
+import { Checkbox, Collapse, IconButton } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 
@@ -23,11 +23,12 @@ const setValue = (obj: any, path: string[], value: any): object => {
 const Node: React.FC<{ label: string; value: any; path: string[]; onChange: (path: string[], value: any) => void }> = ({ label, value, path, onChange }) => {
     const defaultOpen = path.length === 1 && (label === 'pages' || label === 'sidebar');
     const [open, setOpen] = useState(defaultOpen);
-    const isObject = value && typeof value === 'object' && !Array.isArray(value);
+    const hasChildren = value && typeof value === 'object' && value.children;
+    const nodeLabel = value?.metadata?.name || label;
+    const show = Boolean(value?.show);
 
-    if (isObject) {
-        const filteredEntries = Object.entries(value).filter(([k]) => k !== 'show');
-
+    if (hasChildren) {
+        const entries = Object.entries(value.children);
         return (
             <div style={{ marginLeft: 16 }}>
                 <div className='border-bottom' style={{ display: 'flex', alignItems: 'center' }}>
@@ -36,14 +37,14 @@ const Node: React.FC<{ label: string; value: any; path: string[]; onChange: (pat
                     </IconButton>
                     <Checkbox
                         size="small"
-                        checked={Boolean(value?.show ?? false)}
-                        onChange={e => onChange([...path, "show"], e.target.checked)}
+                        checked={show}
+                        onChange={e => onChange([...path, 'show'], e.target.checked)}
                     />
-                    <span>{label}</span>
+                    <span>{nodeLabel}</span>
                 </div>
                 <Collapse in={open} timeout="auto" unmountOnExit>
-                    {filteredEntries.map(([k, v]) => (
-                        <Node key={k} label={k} value={v} path={[...path, k]} onChange={onChange} />
+                    {entries.map(([k, v]) => (
+                        <Node key={k} label={k} value={v} path={[...path, 'children', k]} onChange={onChange} />
                     ))}
                 </Collapse>
             </div>
@@ -54,10 +55,10 @@ const Node: React.FC<{ label: string; value: any; path: string[]; onChange: (pat
         <div className='border-bottom' style={{ display: 'flex', alignItems: 'center', marginLeft: 16 }}>
             <Checkbox
                 size="small"
-                checked={Boolean(value)}
-                onChange={e => onChange(path, e.target.checked)}
+                checked={show}
+                onChange={e => onChange([...path, 'show'], e.target.checked)}
             />
-            <span>{label}</span>
+            <span>{nodeLabel}</span>
         </div>
     );
 };

--- a/ui/src/pages/AllTickets.tsx
+++ b/ui/src/pages/AllTickets.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from "react-i18next";
 import MasterIcon from "../components/UI/Icons/MasterIcon";
 import TicketsTable from "../components/AllTickets/TicketsTable";
 import TicketCard from "../components/AllTickets/TicketCard";
+import { checkMyTicketsAccess } from "../utils/permissions";
 import AssigneeDropdown from "../components/AllTickets/AssigneeDropdown";
 import ViewToggle from "../components/UI/ViewToggle";
 import GenericInput from "../components/UI/Input/GenericInput";
@@ -56,6 +57,7 @@ const AllTickets: React.FC = () => {
     const [masterOnly, setMasterOnly] = useState(false);
     const [statusOptions, setStatusOptions] = useState<string[]>([]);
     const { t } = useTranslation();
+    const showTable = checkMyTicketsAccess('table');
 
     const priorityConfig: Record<string, { color: string; count: number }> = {
         Low: { color: 'success.light', count: 1 },
@@ -199,7 +201,7 @@ const AllTickets: React.FC = () => {
             </div>
             {pending && <p>{t('Loading...')}</p>}
             {error && <p className="text-danger">{t('Error loading tickets')}</p>}
-            {!pending && viewMode === 'table' && (
+            {!pending && viewMode === 'table' && showTable && (
                 <div>
                     <TicketsTable tickets={filtered} onRowClick={(id: any) => navigate(`/tickets/${id}`)} />
                     <div className="d-flex justify-content-between align-items-center mt-3">

--- a/ui/src/utils/permissions.ts
+++ b/ui/src/utils/permissions.ts
@@ -36,3 +36,15 @@ export function checkFieldAccess(section: string, field: string): boolean {
   if (!fields) return false;
   return !!fields[field];
 }
+
+export function checkMyTicketsAccess(key: string): boolean {
+  const perms = getUserPermissions() as RolePermission | null;
+  return perms?.pages?.myTickets?.children?.[key]?.show ?? false;
+}
+
+export function checkMyTicketsColumnAccess(column: string): boolean {
+  const perms = getUserPermissions() as RolePermission | null;
+  return (
+    perms?.pages?.myTickets?.children?.table?.children?.columns?.children?.[column]?.show ?? false
+  );
+}


### PR DESCRIPTION
## Summary
- refactor permission structure with metadata and children
- update PermissionTree component to handle new structure
- add access check helpers for MyTickets and columns
- show table in MyTickets only when permitted
- filter table columns based on column permissions

## Testing
- `npm test --silent` *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_687f6203c8a08332b15ef06feb2609f3