### PR TITLE
Add developer mode toggle and JSON permission editor

### DIFF
--- a/api/src/main/java/com/example/api/controller/PermissionController.java
+++ b/api/src/main/java/com/example/api/controller/PermissionController.java
@@ -49,4 +49,10 @@ public class PermissionController {
         permissionService.updateRolePermissions(role, permission);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/load")
+    public ResponseEntity<Void> loadPermissions() throws IOException {
+        permissionService.loadPermissions();
+        return ResponseEntity.ok().build();
+    }
 }

--- a/ui/src/components/Layout/Header.tsx
+++ b/ui/src/components/Layout/Header.tsx
@@ -5,6 +5,7 @@ import Avatar from "@mui/material/Avatar";
 import { getCurrentUserDetails } from "../../config/config";
 import { useTheme } from "@mui/material/styles";
 import { LanguageContext } from "../../context/LanguageContext";
+import { DevModeContext } from "../../context/DevModeContext";
 
 interface HeaderProps {
   collapsed: boolean;
@@ -14,6 +15,7 @@ interface HeaderProps {
 const Header: React.FC<HeaderProps> = ({ collapsed, toggleSidebar }) => {
   const { toggle, mode } = useContext(ThemeModeContext);
   const { toggleLanguage } = useContext(LanguageContext);
+  const { toggleDevMode, devMode } = useContext(DevModeContext);
   const theme = useTheme();
   const user = getCurrentUserDetails();
   const initials = user.name
@@ -80,6 +82,13 @@ const Header: React.FC<HeaderProps> = ({ collapsed, toggleSidebar }) => {
           }}
           icon="translate"
           onClick={toggleLanguage}
+        />
+        <CustomIconButton
+          style={{
+            color: devMode ? theme.palette.warning.main : iconColor,
+          }}
+          icon="code"
+          onClick={toggleDevMode}
         />
         <Avatar
           sx={{

--- a/ui/src/components/Permissions/JsonEditModal.tsx
+++ b/ui/src/components/Permissions/JsonEditModal.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { Modal, Box, Button } from '@mui/material';
+import ReactJson from 'react-json-view';
+
+interface JsonEditModalProps {
+  open: boolean;
+  data: any;
+  onSubmit: (data: any) => void;
+  onCancel: () => void;
+}
+
+const JsonEditModal: React.FC<JsonEditModalProps> = ({ open, data, onSubmit, onCancel }) => {
+  const [json, setJson] = useState<any>(data);
+
+  const handleChange = (e: any) => {
+    setJson(e.updated_src);
+  };
+
+  return (
+    <Modal open={open} onClose={onCancel}>
+      <Box sx={{ bgcolor: 'background.paper', p: 2, maxHeight: '80vh', overflow: 'auto', maxWidth: '80vw', margin: '5% auto' }}>
+        <ReactJson src={json} onAdd={handleChange} onEdit={handleChange} onDelete={handleChange} displayDataTypes={false} />
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
+          <Button variant="contained" onClick={() => onSubmit(json)}>Submit</Button>
+          <Button variant="outlined" onClick={onCancel} sx={{ ml: 1 }}>Cancel</Button>
+        </Box>
+      </Box>
+    </Modal>
+  );
+};
+
+export default JsonEditModal;

--- a/ui/src/components/UI/IconButton/CustomIconButton.tsx
+++ b/ui/src/components/UI/IconButton/CustomIconButton.tsx
@@ -13,6 +13,7 @@ import TranslateIcon from '@mui/icons-material/Translate';
 import TimelineIcon from '@mui/icons-material/Timeline';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import CodeIcon from '@mui/icons-material/Code';
 
 // Define the icon map
 const iconMap = {
@@ -28,7 +29,8 @@ const iconMap = {
     translate: TranslateIcon,
     timeline: TimelineIcon,
     arrowdown: KeyboardArrowDownIcon,
-    arrowup: KeyboardArrowUpIcon
+    arrowup: KeyboardArrowUpIcon,
+    code: CodeIcon
 };
 
 // Valid keys for the icon map

--- a/ui/src/context/DevModeContext.tsx
+++ b/ui/src/context/DevModeContext.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, useState, useEffect } from 'react';
+
+interface DevModeContextProps {
+  devMode: boolean;
+  toggleDevMode: () => void;
+}
+
+export const DevModeContext = createContext<DevModeContextProps>({
+  devMode: false,
+  toggleDevMode: () => {},
+});
+
+const DevModeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [devMode, setDevMode] = useState<boolean>(() => {
+    const stored = sessionStorage.getItem('dev');
+    return stored === 'true';
+  });
+
+  useEffect(() => {
+    sessionStorage.setItem('dev', devMode ? 'true' : 'false');
+  }, [devMode]);
+
+  const toggleDevMode = () => setDevMode((prev) => !prev);
+
+  return (
+    <DevModeContext.Provider value={{ devMode, toggleDevMode }}>
+      {children}
+    </DevModeContext.Provider>
+  );
+};
+
+export default DevModeProvider;

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -11,6 +11,7 @@ import reportWebVitals from "./reportWebVitals";
 import { SnackbarProvider } from "./context/SnackbarContext";
 import CustomThemeProvider from "./context/ThemeContext";
 import LanguageProvider from "./context/LanguageContext";
+import DevModeProvider from "./context/DevModeContext";
 import "./i18n";
 
 const root = ReactDOM.createRoot(
@@ -21,9 +22,11 @@ root.render(
     <BrowserRouter>
       <LanguageProvider>
         <CustomThemeProvider>
-          <SnackbarProvider>
-            <App />
-          </SnackbarProvider>
+          <DevModeProvider>
+            <SnackbarProvider>
+              <App />
+            </SnackbarProvider>
+          </DevModeProvider>
         </CustomThemeProvider>
       </LanguageProvider>
     </BrowserRouter>

--- a/ui/src/pages/RoleDetails.tsx
+++ b/ui/src/pages/RoleDetails.tsx
@@ -1,17 +1,21 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import { useParams } from 'react-router-dom';
 import { useApi } from '../hooks/useApi';
-import { getRolePermission, updateRolePermission } from '../services/PermissionService';
+import { getRolePermission, updateRolePermission, loadPermissions } from '../services/PermissionService';
 import Title from '../components/Title';
 import PermissionTree from '../components/Permissions/PermissionTree';
-import { Button } from '@mui/material';
+import JsonEditModal from '../components/Permissions/JsonEditModal';
+import { Button, Chip } from '@mui/material';
 import { useSnackbar } from '../context/SnackbarContext';
+import { DevModeContext } from '../context/DevModeContext';
 
 const RoleDetails: React.FC = () => {
     const { roleId } = useParams<{ roleId: string }>();
     const { data, apiHandler } = useApi<any>();
     const [perm, setPerm] = useState<any>(null);
     const { showMessage } = useSnackbar();
+    const { devMode } = useContext(DevModeContext);
+    const [openJson, setOpenJson] = useState(false);
 
     useEffect(() => {
         if (roleId) {
@@ -27,6 +31,7 @@ const RoleDetails: React.FC = () => {
         if (roleId) {
             updateRolePermission(roleId, perm).then(() => {
                 showMessage('Permissions updated successfully', 'success');
+                loadPermissions();
             });
         }
     };
@@ -36,8 +41,14 @@ const RoleDetails: React.FC = () => {
     return (
         <div className="container">
             <Title textKey={`Role: ${roleId}`} />
+            {devMode && (
+                <Chip label="JSON" size="small" onClick={() => setOpenJson(true)} sx={{ mb: 1 }} />
+            )}
             {perm && <PermissionTree data={perm} onChange={setPerm} />}
             <Button variant="contained" className="mt-3" onClick={handleSubmit}>Save</Button>
+            {devMode && (
+                <JsonEditModal open={openJson} data={perm} onCancel={() => setOpenJson(false)} onSubmit={(p) => { setPerm(p); setOpenJson(false); handleSubmit(); }} />
+            )}
         </div>
     );
 };

--- a/ui/src/services/PermissionService.ts
+++ b/ui/src/services/PermissionService.ts
@@ -16,3 +16,7 @@ export function getRolePermission(role: string) {
 export function updateRolePermission(role: string, perm: any) {
     return axios.put(`${BASE_URL}/permissions/${role}`, perm);
 }
+
+export function loadPermissions() {
+    return axios.post(`${BASE_URL}/permissions/load`);
+}


### PR DESCRIPTION
## Summary
- add developer mode context with session storage support
- extend icon map with `code` icon
- toggle developer mode from header via new button
- add JSON editor modal for role permissions when dev mode is active
- update permission service with `load` endpoint and expose in API
- create backend endpoint to reload permissions

## Testing
- `./gradlew test` *(fails: Could not resolve dependency from jitpack.io)*
- `npm install` *(fails: dependency resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_687f743c1e1c8332ba87ad1e18f3a5e9