### PR TITLE
Replace jsoneditor-react with Monaco editor

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -27,7 +27,6 @@
         "bcryptjs": "^2.4.3",
         "bootstrap": "^5.3.6",
         "i18next": "^25.2.1",
-        "jsoneditor-react": "^3.1.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.56.4",
@@ -12348,19 +12347,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsoneditor-react": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/jsoneditor-react/-/jsoneditor-react-3.1.2.tgz",
-      "integrity": "sha512-XqU8BMdIhrlS5HUnn7rGhgZw315bdJGQrf6NG5UH40FSw2xNirQrxnM05aeAplHkp8FNkzN2WX0tfvEWdl2UUA==",
-      "license": "MIT",
-      "dependencies": {
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "jsoneditor": "^7.0.0 || ^8.0.0 || ^9.0.0",
-        "react": "16 || 17"
       }
     },
     "node_modules/jsonfile": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -22,7 +22,6 @@
     "bcryptjs": "^2.4.3",
     "bootstrap": "^5.3.6",
     "i18next": "^25.2.1",
-    "jsoneditor-react": "^3.1.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.56.4",

--- a/ui/src/components/Permissions/JsonEditModal.tsx
+++ b/ui/src/components/Permissions/JsonEditModal.tsx
@@ -1,7 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Modal, Box, Button } from '@mui/material';
-import { JsonEditor as Editor } from 'jsoneditor-react';
-import 'jsoneditor-react/es/editor.min.css';
+import Editor from '@monaco-editor/react';
 
 interface JsonEditModalProps {
   open: boolean;
@@ -11,18 +10,39 @@ interface JsonEditModalProps {
 }
 
 const JsonEditModal: React.FC<JsonEditModalProps> = ({ open, data, onSubmit, onCancel }) => {
-  const [json, setJson] = useState<any>(data);
+  const [jsonString, setJsonString] = useState<string>(JSON.stringify(data, null, 2));
 
-  const handleChange = (value: any) => {
-    setJson(value);
+  useEffect(() => {
+    setJsonString(JSON.stringify(data, null, 2));
+  }, [data]);
+
+  const handleChange = (value?: string) => {
+    if (value !== undefined) {
+      setJsonString(value);
+    }
+  };
+
+  const handleSubmit = () => {
+    try {
+      const parsed = JSON.parse(jsonString);
+      onSubmit(parsed);
+    } catch (e) {
+      alert('Invalid JSON');
+    }
   };
 
   return (
     <Modal open={open} onClose={onCancel}>
       <Box sx={{ bgcolor: 'background.paper', p: 2, maxHeight: '80vh', overflow: 'auto', maxWidth: '80vw', margin: '5% auto' }}>
-        <Editor value={json} onChange={handleChange} mode="tree" modes={["tree", "code"]} />
+        <Editor
+          height="60vh"
+          language="json"
+          value={jsonString}
+          onChange={handleChange}
+          options={{ minimap: { enabled: false } }}
+        />
         <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
-          <Button variant="contained" onClick={() => onSubmit(json)}>Submit</Button>
+          <Button variant="contained" onClick={handleSubmit}>Submit</Button>
           <Button variant="outlined" onClick={onCancel} sx={{ ml: 1 }}>Cancel</Button>
         </Box>
       </Box>


### PR DESCRIPTION
## Summary
- swap out `jsoneditor-react` for Monaco-based JSON editor
- drop `jsoneditor-react` from dependencies

## Testing
- `npm install --legacy-peer-deps`
- `CI=true npm test --silent` *(fails: Cannot find module 'react-router-dom')*
- `./gradlew test` *(fails: cannot find Java installation)*

------
https://chatgpt.com/codex/tasks/task_e_68806db1f4548332b77b32132acd841b