### PR TITLE
Fix dev mode cleanup and restore permission dropdown

### DIFF
--- a/ui/src/components/Permissions/PermissionTree.tsx
+++ b/ui/src/components/Permissions/PermissionTree.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import { Checkbox, Collapse, IconButton, TextField } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
@@ -42,6 +42,17 @@ const Node: React.FC<{ label: string; value: any; path: string[]; onChange: (pat
     const [adding, setAdding] = useState(false);
     const [newChild, setNewChild] = useState('');
     const [addedChildren, setAddedChildren] = useState(false);
+
+    useEffect(() => {
+        if (!devMode && adding) {
+            if (addedChildren) {
+                onChange([...path, 'children'], undefined, true);
+                setAddedChildren(false);
+            }
+            setAdding(false);
+            setNewChild('');
+        }
+    }, [devMode]);
 
     if (label === "show" || label === "metadata") return null;
 

--- a/ui/src/pages/RoleMaster.tsx
+++ b/ui/src/pages/RoleMaster.tsx
@@ -29,6 +29,7 @@ const RoleMaster: React.FC = () => {
     const [creating, setCreating] = useState(false);
     const [roleName, setRoleName] = useState('');
     const [selectedPerms, setSelectedPerms] = useState<string[]>([]);
+    const [prevPerms, setPrevPerms] = useState<string[]>([]);
     const [openCustom, setOpenCustom] = useState(false);
     const [customPerm, setCustomPerm] = useState<any>(null);
     const [selectedRows, setSelectedRows] = useState<React.Key[]>([]);
@@ -50,6 +51,7 @@ const RoleMaster: React.FC = () => {
         const value = Array.isArray(val) ? val : [val];
         if (value.includes('Custom')) {
             if (!selectedPerms.includes('Custom')) {
+                setPrevPerms(selectedPerms.length ? selectedPerms : ['User']);
                 setOpenCustom(true);
             }
             setSelectedPerms(['Custom']);
@@ -79,6 +81,14 @@ const RoleMaster: React.FC = () => {
         setRoleName('');
         setSelectedPerms([]);
         setCustomPerm(null);
+    };
+
+    const handleCustomClose = () => {
+        setOpenCustom(false);
+        if (selectedPerms.includes('Custom')) {
+            const fallback = prevPerms.length ? prevPerms : ['User'];
+            setSelectedPerms(fallback);
+        }
     };
 
     const handleDelete = (id: string) => {
@@ -168,7 +178,7 @@ const RoleMaster: React.FC = () => {
                 roles={roles}
                 permissions={data?.roles || {}}
                 title="Custom Permissions"
-                onClose={() => setOpenCustom(false)}
+                onClose={handleCustomClose}
                 onSubmit={(perm) => {
                     setCustomPerm(perm);
                     if (!selectedPerms.includes('Custom')) setSelectedPerms(p => [...p, 'Custom']);


### PR DESCRIPTION
## Summary
- reset new permission input if dev mode is disabled
- remember previous permission selection when choosing `Custom`
- restore previous permissions when custom modal is dismissed

## Testing
- `npm run build`
- `CI=true npm test --silent` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_688873531a10833298674cd1620160b0