### PR TITLE
Enhance role metadata handling

### DIFF
--- a/api/src/main/java/com/example/api/controller/RoleController.java
+++ b/api/src/main/java/com/example/api/controller/RoleController.java
@@ -28,6 +28,13 @@ public class RoleController {
         return ResponseEntity.ok(roleService.addRole(roleDto));
     }
 
+    @PutMapping("/{role}")
+    public ResponseEntity<Void> updateRole(@PathVariable String role, @RequestBody RoleDto roleDto) {
+        roleDto.setRole(role);
+        roleService.updateRole(roleDto);
+        return ResponseEntity.ok().build();
+    }
+
     @DeleteMapping("/{role}")
     public ResponseEntity<Void> deleteRole(@PathVariable String role,
                                            @RequestParam(required = false, defaultValue = "false") boolean hard) {

--- a/api/src/main/java/com/example/api/service/RoleService.java
+++ b/api/src/main/java/com/example/api/service/RoleService.java
@@ -60,6 +60,9 @@ public class RoleService {
         LocalDateTime now = LocalDateTime.now();
         role.setCreatedOn(now);
         role.setCreatedBy(roleDto.getCreatedBy());
+        role.setUpdatedOn(now);
+        // updatedBy will be same as createdBy at creation
+        role.setUpdatedBy(roleDto.getUpdatedBy() != null ? roleDto.getUpdatedBy() : roleDto.getCreatedBy());
 
         Role addedRole = roleRepository.save(role);
         return DtoMapper.toRoleDto(addedRole);
@@ -76,5 +79,13 @@ public class RoleService {
                 });
             }
         }
+    }
+
+    public void updateRole(RoleDto dto) {
+        roleRepository.findById(dto.getRole()).ifPresent(role -> {
+            role.setUpdatedBy(dto.getUpdatedBy());
+            role.setUpdatedOn(LocalDateTime.now());
+            roleRepository.save(role);
+        });
     }
 }

--- a/ui/src/pages/RoleDetails.tsx
+++ b/ui/src/pages/RoleDetails.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { useParams } from 'react-router-dom';
 import { useApi } from '../hooks/useApi';
-import { getRolePermission, updateRolePermission, loadPermissions } from '../services/RoleService';
+import { getRolePermission, updateRolePermission, updateRole, loadPermissions } from '../services/RoleService';
+import { getCurrentUserDetails } from '../config/config';
 import Title from '../components/Title';
 import PermissionTree from '../components/Permissions/PermissionTree';
 import JsonEditModal from '../components/Permissions/JsonEditModal';
@@ -30,8 +31,11 @@ const RoleDetails: React.FC = () => {
     function handleSubmit(this: any) {
         if (roleId) {
             updateRolePermission(roleId, this ?? perm).then(() => {
-                showMessage('Permissions updated successfully', 'success');
-                loadPermissions();
+                const user = getCurrentUserDetails();
+                updateRole(roleId, { updatedBy: user?.userId }).then(() => {
+                    showMessage('Permissions updated successfully', 'success');
+                    loadPermissions();
+                });
             });
         }
     };

--- a/ui/src/pages/RoleMaster.tsx
+++ b/ui/src/pages/RoleMaster.tsx
@@ -3,6 +3,7 @@ import { Button, Autocomplete, TextField, Chip } from '@mui/material';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import { useApi } from '../hooks/useApi';
 import { addRole, getAllPermissions, loadPermissions, getAllRoles, deleteRoles, deleteRole } from '../services/RoleService';
+import { getCurrentUserDetails } from '../config/config';
 import ViewToggle from '../components/UI/ViewToggle';
 import GenericTable from '../components/UI/GenericTable';
 import Title from '../components/Title';
@@ -71,7 +72,8 @@ const RoleMaster: React.FC = () => {
         if (!roleName) return;
         const permissions = customPerm ||  null;
         const list = selectedPerms.filter(p => p !== 'Custom');
-        const payload = { role: roleName, permissions, permissionsList: list ?? [] };
+        const user = getCurrentUserDetails();
+        const payload = { role: roleName, permissions, permissionsList: list ?? [], createdBy: user?.userId, updatedBy: user?.userId };
         addRole(payload)
             .then(() => loadPermissions())
             .then(() => getAllRolesApiHandler(() => getAllRoles()))
@@ -93,15 +95,19 @@ const RoleMaster: React.FC = () => {
     };
 
     const handleDelete = (id: string) => {
-        deleteRole(id, devMode).then(() => getAllRolesApiHandler(() => getAllRoles()));
+        if (window.confirm('Delete this role?')) {
+            deleteRole(id, devMode).then(() => getAllRolesApiHandler(() => getAllRoles()));
+        }
     };
 
     const handleMultiDelete = () => {
         if (selectedRows.length) {
-            deleteRoles(selectedRows as string[], devMode).then(() => {
-                setSelectedRows([]);
-                getAllRolesApiHandler(() => getAllRoles());
-            });
+            if (window.confirm('Delete selected roles?')) {
+                deleteRoles(selectedRows as string[], devMode).then(() => {
+                    setSelectedRows([]);
+                    getAllRolesApiHandler(() => getAllRoles());
+                });
+            }
         }
     };
 

--- a/ui/src/services/RoleService.ts
+++ b/ui/src/services/RoleService.ts
@@ -25,6 +25,10 @@ export function updateRolePermission(role: string, perm: any) {
     return axios.put(`${BASE_URL}/permissions/${role}`, perm);
 }
 
+export function updateRole(role: string, body: any) {
+    return axios.put(`${BASE_URL}/roles/${role}`, body);
+}
+
 export function loadPermissions() {
     return axios.post(`${BASE_URL}/permissions/load`);
 }


### PR DESCRIPTION
## Summary
- store `updatedOn` and `updatedBy` when creating roles
- add API endpoint to update a role's metadata
- call updateRole API from permission page
- set creator info when adding a role and confirm before deleting

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68888e43ae548332b690fe56d9a54dcc