### PR TITLE
Enable inline editing of role name

### DIFF
--- a/api/src/main/java/com/example/api/controller/RoleController.java
+++ b/api/src/main/java/com/example/api/controller/RoleController.java
@@ -35,6 +35,12 @@ public class RoleController {
         return ResponseEntity.ok().build();
     }
 
+    @PutMapping("/{role}/rename")
+    public ResponseEntity<Void> renameRole(@PathVariable String role, @RequestBody RoleDto roleDto) {
+        roleService.renameRole(role, roleDto.getRole(), roleDto.getUpdatedBy());
+        return ResponseEntity.ok().build();
+    }
+
     @DeleteMapping("/{role}")
     public ResponseEntity<Void> deleteRole(@PathVariable String role,
                                            @RequestParam(required = false, defaultValue = "false") boolean hard) {

--- a/api/src/main/java/com/example/api/repository/RoleRepository.java
+++ b/api/src/main/java/com/example/api/repository/RoleRepository.java
@@ -2,8 +2,20 @@ package com.example.api.repository;
 
 import com.example.api.models.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 public interface RoleRepository extends JpaRepository<Role, String> {
     List<Role> findByIsDeletedFalse();
+
+    @Modifying
+    @Transactional
+    @Query(value = "UPDATE role_permission_config SET role = :newRole, updated_by = :updatedBy, updated_on = :updatedOn WHERE role = :oldRole", nativeQuery = true)
+    void renameRole(@Param("oldRole") String oldRole,
+                    @Param("newRole") String newRole,
+                    @Param("updatedBy") String updatedBy,
+                    @Param("updatedOn") java.time.LocalDateTime updatedOn);
 }

--- a/api/src/main/java/com/example/api/service/RoleService.java
+++ b/api/src/main/java/com/example/api/service/RoleService.java
@@ -88,4 +88,12 @@ public class RoleService {
             roleRepository.save(role);
         });
     }
+
+    public void renameRole(String oldRole, String newRole, String updatedBy) {
+        roleRepository.renameRole(oldRole, newRole, updatedBy, LocalDateTime.now());
+        try {
+            permissionService.loadPermissions();
+        } catch (Exception ignored) {
+        }
+    }
 }

--- a/ui/src/pages/RoleDetails.tsx
+++ b/ui/src/pages/RoleDetails.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useState, useContext } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { useApi } from '../hooks/useApi';
-import { getRolePermission, updateRolePermission, updateRole, loadPermissions } from '../services/RoleService';
+import { getRolePermission, updateRolePermission, updateRole, loadPermissions, renameRole } from '../services/RoleService';
 import { getCurrentUserDetails } from '../config/config';
 import Title from '../components/Title';
 import PermissionTree from '../components/Permissions/PermissionTree';
 import JsonEditModal from '../components/Permissions/JsonEditModal';
-import { Button, Chip } from '@mui/material';
+import { Button, Chip, TextField } from '@mui/material';
+import CustomIconButton from '../components/UI/IconButton/CustomIconButton';
 import { useSnackbar } from '../context/SnackbarContext';
 import { DevModeContext } from '../context/DevModeContext';
 
@@ -17,10 +18,14 @@ const RoleDetails: React.FC = () => {
     const { showMessage } = useSnackbar();
     const { devMode } = useContext(DevModeContext);
     const [openJson, setOpenJson] = useState(false);
+    const [editing, setEditing] = useState(false);
+    const [roleName, setRoleName] = useState(roleId || '');
+    const navigate = useNavigate();
 
     useEffect(() => {
         if (roleId) {
             apiHandler(() => getRolePermission(roleId));
+            setRoleName(roleId);
         }
     }, [roleId]);
 
@@ -46,11 +51,38 @@ const RoleDetails: React.FC = () => {
         handleSubmit.call(json);
     }
 
+    const submitRename = () => {
+        if (!roleId || !roleName || roleId === roleName) { setEditing(false); return; }
+        const user = getCurrentUserDetails();
+        renameRole(roleId, roleName, user?.userId).then(() => {
+            showMessage('Role updated successfully', 'success');
+            navigate(`/role-master/${roleName}`);
+        });
+    };
+
+    const cancelRename = () => {
+        setRoleName(roleId || '');
+        setEditing(false);
+    };
+
     if (!roleId) return null;
 
     return (
         <div className="container">
-            <Title textKey={`Role: ${roleId}`} />
+            <div className="d-flex align-items-center mb-3">
+                {editing ? (
+                    <>
+                        <TextField value={roleName} onChange={e => setRoleName(e.target.value)} size="small" className="me-2" />
+                        <CustomIconButton icon="check" onClick={submitRename} style={{ minWidth: 0, padding: 2 }} />
+                        <CustomIconButton icon="close" onClick={cancelRename} style={{ minWidth: 0, padding: 2 }} />
+                    </>
+                ) : (
+                    <>
+                        <Title textKey={`Role: ${roleName}`} />
+                        <CustomIconButton icon="edit" onClick={() => setEditing(true)} style={{ minWidth: 0, padding: 2 }} />
+                    </>
+                )}
+            </div>
             {devMode && (
                 <Chip label="JSON" size="small" onClick={() => setOpenJson(true)} sx={{ mb: 1 }} />
             )}

--- a/ui/src/services/RoleService.ts
+++ b/ui/src/services/RoleService.ts
@@ -29,6 +29,10 @@ export function updateRole(role: string, body: any) {
     return axios.put(`${BASE_URL}/roles/${role}`, body);
 }
 
+export function renameRole(oldRole: string, newRole: string, updatedBy: string) {
+    return axios.put(`${BASE_URL}/roles/${oldRole}/rename`, { role: newRole, updatedBy });
+}
+
 export function loadPermissions() {
     return axios.post(`${BASE_URL}/permissions/load`);
 }


### PR DESCRIPTION
## Summary
- support renaming role via backend API
- add repository method for renaming role
- expose rename endpoint in `RoleController`
- add `renameRole` service to UI and implement inline editing in `RoleDetails`

## Testing
- `npm test --prefix ui --silent --yes` *(fails: Cannot find module 'react-router-dom')*
- `./gradlew test` *(fails: blocked downloading from jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_6888a2543fc4833286a74c78e20e1c38