### PR TITLE
Handle open and assigned status on ticket creation

### DIFF
--- a/api/src/main/java/com/example/api/enums/TicketStatus.java
+++ b/api/src/main/java/com/example/api/enums/TicketStatus.java
@@ -1,6 +1,8 @@
 package com.example.api.enums;
 
 public enum TicketStatus {
+    OPEN,
+    ASSIGNED,
     PENDING,
     CLOSED,
     ON_HOLD,


### PR DESCRIPTION
## Summary
- add `OPEN` and `ASSIGNED` to `TicketStatus`
- record creation status changes in `TicketService`
- create assignment and status history entries when needed

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6889a79ddedc8332a0e5b299a5bdabb5