### PR TITLE
Implement status workflow APIs and update history records

### DIFF
--- a/api/src/main/java/com/example/api/controller/TicketStatusWorkflowController.java
+++ b/api/src/main/java/com/example/api/controller/TicketStatusWorkflowController.java
@@ -1,0 +1,30 @@
+package com.example.api.controller;
+
+import com.example.api.models.StatusMaster;
+import com.example.api.models.TicketStatusWorkflow;
+import com.example.api.service.TicketStatusWorkflowService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/status-workflow")
+@CrossOrigin(origins = "http://localhost:3000")
+public class TicketStatusWorkflowController {
+    private final TicketStatusWorkflowService service;
+
+    public TicketStatusWorkflowController(TicketStatusWorkflowService service) {
+        this.service = service;
+    }
+
+    @GetMapping("/status/{statusId}")
+    public ResponseEntity<List<StatusMaster>> getNextStatuses(@PathVariable String statusId) {
+        return ResponseEntity.ok(service.getNextStatusesByCurrentStatus(statusId));
+    }
+
+    @GetMapping("/mappings")
+    public ResponseEntity<List<TicketStatusWorkflow>> getMappings() {
+        return ResponseEntity.ok(service.getAllMappings());
+    }
+}

--- a/api/src/main/java/com/example/api/dto/StatusHistoryDto.java
+++ b/api/src/main/java/com/example/api/dto/StatusHistoryDto.java
@@ -1,8 +1,5 @@
 package com.example.api.dto;
 
-import com.example.api.enums.TicketStatus;
-import com.example.api.models.Ticket;
-import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -14,8 +11,8 @@ public class StatusHistoryDto {
     private String id;
     private String ticketId;
     private String updatedBy;
-    private TicketStatus previousStatus;
-    private TicketStatus currentStatus;
+    private String previousStatus;
+    private String currentStatus;
     private LocalDateTime timestamp;
     private Boolean slaFlag;
 }

--- a/api/src/main/java/com/example/api/models/StatusHistory.java
+++ b/api/src/main/java/com/example/api/models/StatusHistory.java
@@ -1,6 +1,5 @@
 package com.example.api.models;
 
-import com.example.api.enums.TicketStatus;
 import jakarta.persistence.*;
 import lombok.Data;
 
@@ -22,13 +21,11 @@ public class StatusHistory {
     @Column(name = "updated_by")
     private String updatedBy;
 
-    @Enumerated(EnumType.STRING)
     @Column(name = "previous_status")
-    private TicketStatus previousStatus;
+    private String previousStatus;
 
-    @Enumerated(EnumType.STRING)
     @Column(name = "current_status")
-    private TicketStatus currentStatus;
+    private String currentStatus;
 
     @Column(name = "timestamp")
     private LocalDateTime timestamp;

--- a/api/src/main/java/com/example/api/models/TicketStatusWorkflow.java
+++ b/api/src/main/java/com/example/api/models/TicketStatusWorkflow.java
@@ -1,0 +1,24 @@
+package com.example.api.models;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "ticket_status_workflow")
+@Getter
+@Setter
+public class TicketStatusWorkflow {
+    @Id
+    @Column(name = "TSW_Id")
+    private Integer id;
+
+    @Column(name = "TSW_Action")
+    private String action;
+
+    @Column(name = "TSW_Current_Status")
+    private Integer currentStatus;
+
+    @Column(name = "TSW_Next_Status")
+    private Integer nextStatus;
+}

--- a/api/src/main/java/com/example/api/repository/StatusMasterRepository.java
+++ b/api/src/main/java/com/example/api/repository/StatusMasterRepository.java
@@ -4,4 +4,5 @@ import com.example.api.models.StatusMaster;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StatusMasterRepository extends JpaRepository<StatusMaster, String> {
+    StatusMaster findByStatusCode(String statusCode);
 }

--- a/api/src/main/java/com/example/api/repository/TicketStatusWorkflowRepository.java
+++ b/api/src/main/java/com/example/api/repository/TicketStatusWorkflowRepository.java
@@ -1,0 +1,12 @@
+package com.example.api.repository;
+
+import com.example.api.models.TicketStatusWorkflow;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TicketStatusWorkflowRepository extends JpaRepository<TicketStatusWorkflow, Integer> {
+    List<TicketStatusWorkflow> findByCurrentStatus(Integer currentStatus);
+}

--- a/api/src/main/java/com/example/api/service/StatusHistoryService.java
+++ b/api/src/main/java/com/example/api/service/StatusHistoryService.java
@@ -1,7 +1,6 @@
 package com.example.api.service;
 
 import com.example.api.dto.StatusHistoryDto;
-import com.example.api.enums.TicketStatus;
 import com.example.api.mapper.DtoMapper;
 import com.example.api.models.StatusHistory;
 import com.example.api.models.Ticket;
@@ -23,7 +22,7 @@ public class StatusHistoryService {
         this.ticketRepository = ticketRepository;
     }
 
-    public StatusHistory addHistory(String ticketId, String updatedBy, TicketStatus previousStatus, TicketStatus currentStatus, Boolean slaFlag) {
+    public StatusHistory addHistory(String ticketId, String updatedBy, String previousStatus, String currentStatus, Boolean slaFlag) {
         Ticket ticket = ticketRepository.findById(ticketId).orElseThrow();
         StatusHistory history = new StatusHistory();
         history.setTicket(ticket);

--- a/api/src/main/java/com/example/api/service/TicketStatusWorkflowService.java
+++ b/api/src/main/java/com/example/api/service/TicketStatusWorkflowService.java
@@ -1,0 +1,48 @@
+package com.example.api.service;
+
+import com.example.api.models.StatusMaster;
+import com.example.api.models.TicketStatusWorkflow;
+import com.example.api.repository.StatusMasterRepository;
+import com.example.api.repository.TicketStatusWorkflowRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class TicketStatusWorkflowService {
+    private final TicketStatusWorkflowRepository workflowRepository;
+    private final StatusMasterRepository statusMasterRepository;
+
+    public TicketStatusWorkflowService(TicketStatusWorkflowRepository workflowRepository,
+                                       StatusMasterRepository statusMasterRepository) {
+        this.workflowRepository = workflowRepository;
+        this.statusMasterRepository = statusMasterRepository;
+    }
+
+    public List<StatusMaster> getNextStatusesByCurrentStatus(String statusId) {
+        Integer id = Integer.valueOf(statusId);
+        List<Integer> nextIds = workflowRepository.findByCurrentStatus(id)
+                .stream()
+                .map(TicketStatusWorkflow::getNextStatus)
+                .collect(Collectors.toList());
+        return statusMasterRepository.findAllById(
+                nextIds.stream().map(Object::toString).collect(Collectors.toList()));
+    }
+
+    public List<TicketStatusWorkflow> getAllMappings() {
+        return workflowRepository.findAll();
+    }
+
+    public String getStatusIdByCode(String statusCode) {
+        Optional<StatusMaster> sm = statusMasterRepository.findByStatusCode(statusCode);
+        return sm.map(StatusMaster::getStatusId).orElse(null);
+    }
+
+    public boolean getSlaFlagByStatusId(String statusId) {
+        return statusMasterRepository.findById(statusId)
+                .map(StatusMaster::getSlaFlag)
+                .orElse(false);
+    }
+}


### PR DESCRIPTION
## Summary
- add TicketStatusWorkflow entity, repo, service and controller
- expose endpoint to fetch next statuses and all mappings
- store status IDs instead of codes in status history
- retrieve SLA flag from `status_master`

## Testing
- `./gradlew test --no-daemon` *(fails: Could not resolve dependencies due to SSL issues)*

------
https://chatgpt.com/codex/tasks/task_e_688af9ace434833286e14b0089b74096