### PR TITLE
Introduce Status entity for tickets

### DIFF
--- a/api/src/main/java/com/example/api/controller/TicketController.java
+++ b/api/src/main/java/com/example/api/controller/TicketController.java
@@ -64,11 +64,11 @@ public class TicketController {
     @GetMapping("/search")
     public ResponseEntity<PaginationResponse<TicketDto>> searchTickets(
             @RequestParam String query,
-            @RequestParam(required = false) TicketStatus status,
+            @RequestParam(required = false, name = "status") String statusName,
             @RequestParam(required = false) Boolean master,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
-        Page<TicketDto> p = ticketService.searchTickets(query, status, master, PageRequest.of(page, size));
+        Page<TicketDto> p = ticketService.searchTickets(query, statusName, master, PageRequest.of(page, size));
         PaginationResponse<TicketDto> resp = new PaginationResponse<>(p.getContent(), p.getNumber(), p.getSize(), p.getTotalElements(), p.getTotalPages());
         return ResponseEntity.ok(resp);
     }

--- a/api/src/main/java/com/example/api/dto/TicketDto.java
+++ b/api/src/main/java/com/example/api/dto/TicketDto.java
@@ -32,6 +32,7 @@ public class TicketDto {
     private String impact;
     private String severityRecommendedBy;
     private TicketStatus status;
+    private String statusId;
     private String attachmentPath;
     private String assignToLevel;
     private String assignTo;

--- a/api/src/main/java/com/example/api/mapper/DtoMapper.java
+++ b/api/src/main/java/com/example/api/mapper/DtoMapper.java
@@ -56,7 +56,8 @@ public class DtoMapper {
         dto.setRecommendedSeverity(ticket.getRecommendedSeverity());
         dto.setImpact(ticket.getImpact());
         dto.setSeverityRecommendedBy(ticket.getSeverityRecommendedBy());
-        dto.setStatus(ticket.getStatus());
+        dto.setStatus(ticket.getTicketStatus());
+        dto.setStatusId(ticket.getStatus() != null ? ticket.getStatus().getStatusId() : null);
         dto.setAttachmentPath(ticket.getAttachmentPath());
         dto.setAssignedToLevel(ticket.getAssignedToLevel());
         dto.setAssignedTo(ticket.getAssignedTo());

--- a/api/src/main/java/com/example/api/models/Ticket.java
+++ b/api/src/main/java/com/example/api/models/Ticket.java
@@ -4,6 +4,7 @@ import com.example.api.enums.Mode;
 import com.example.api.enums.Priority;
 import com.example.api.enums.Severity;
 import com.example.api.enums.TicketStatus;
+import com.example.api.models.Status;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.Data;
@@ -53,7 +54,8 @@ public class Ticket {
     @Column(name = "severity_recommended_by")
     private String severityRecommendedBy;
     @Enumerated(EnumType.STRING)
-    private TicketStatus status;
+    @Column(name = "status")
+    private TicketStatus ticketStatus;
     @Column(name="attachment_path")
     private String attachmentPath;
 
@@ -71,4 +73,8 @@ public class Ticket {
     private String masterId;
     @Column(name = "last_modified")
     private LocalDateTime lastModified;
+
+    @ManyToOne
+    @JoinColumn(name = "status_id", referencedColumnName = "status_id")
+    private Status status;
 }

--- a/api/src/main/java/com/example/api/repository/TicketRepository.java
+++ b/api/src/main/java/com/example/api/repository/TicketRepository.java
@@ -18,6 +18,6 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
 
     public List<Ticket> findByLastModifiedAfter(LocalDateTime lastSyncedTime);
 
-    @Query("SELECT t FROM Ticket t WHERE (:status IS NULL OR t.status = :status) AND (:master IS NULL OR t.isMaster = :master) AND (LOWER(t.requestorName) LIKE LOWER(CONCAT('%', :query, '%')) OR LOWER(t.category) LIKE LOWER(CONCAT('%', :query, '%')) OR LOWER(t.subCategory) LIKE LOWER(CONCAT('%', :query, '%')) OR LOWER(t.subject) LIKE LOWER(CONCAT('%', :query, '%')) OR LOWER(t.id) LIKE LOWER(CONCAT('%', :query, '%')) )")
-    Page<Ticket> searchTickets(@Param("query") String query, @Param("status") TicketStatus status, @Param("master") Boolean master, Pageable pageable);
+    @Query("SELECT t FROM Ticket t LEFT JOIN t.status s WHERE (:statusName IS NULL OR s.statusName = :statusName) AND (:master IS NULL OR t.isMaster = :master) AND (LOWER(t.requestorName) LIKE LOWER(CONCAT('%', :query, '%')) OR LOWER(t.category) LIKE LOWER(CONCAT('%', :query, '%')) OR LOWER(t.subCategory) LIKE LOWER(CONCAT('%', :query, '%')) OR LOWER(t.subject) LIKE LOWER(CONCAT('%', :query, '%')) OR LOWER(t.id) LIKE LOWER(CONCAT('%', :query, '%')) )")
+    Page<Ticket> searchTickets(@Param("query") String query, @Param("statusName") String statusName, @Param("master") Boolean master, Pageable pageable);
 }

--- a/api/src/main/java/com/example/api/service/TicketStatusWorkflowService.java
+++ b/api/src/main/java/com/example/api/service/TicketStatusWorkflowService.java
@@ -45,4 +45,10 @@ public class TicketStatusWorkflowService {
                 .map(Status::getSlaFlag)
                 .orElse(false);
     }
+
+    public String getStatusCodeById(String statusId) {
+        return statusMasterRepository.findById(statusId)
+                .map(Status::getStatusCode)
+                .orElse(null);
+    }
 }

--- a/db/ticketing_system_dump.sql
+++ b/db/ticketing_system_dump.sql
@@ -555,6 +555,7 @@ CREATE TABLE `tickets` (
   `master_id` varchar(36) DEFAULT NULL,
   `last_modified` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `status` varchar(20) DEFAULT NULL,
+  `status_id` varchar(36) DEFAULT NULL,
   `assigned_to_level` varchar(20) DEFAULT NULL,
   `assigned_to` varchar(100) DEFAULT NULL,
   `assigned_by` varchar(50) DEFAULT NULL,

--- a/ui/src/components/RaiseTicket/TicketDetails.tsx
+++ b/ui/src/components/RaiseTicket/TicketDetails.tsx
@@ -304,7 +304,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, errors
                 {showStatus && (
                     <div className="col-md-12 mb-3 px-4">
                         <GenericDropdownController
-                            name="status"
+                            name="statusId"
                             control={control}
                             label="Update Status"
                             options={statusOptions}

--- a/ui/src/pages/AllTickets.tsx
+++ b/ui/src/pages/AllTickets.tsx
@@ -24,16 +24,6 @@ import DropdownController from "../components/UI/Dropdown/DropdownController";
 import { DropdownOption } from "../components/UI/Dropdown/GenericDropdown";
 import { Ticket } from "../types";
 
-const statusOptions = [
-    { name: "All", id: "ALL" },
-    { name: "Pending", id: "PENDING" },
-    { name: "On Hold", id: "ON_HOLD" },
-    { name: "Closed", id: "CLOSED" },
-    { name: "Reopened", id: "REOPENED" },
-    { name: "Resolved", id: "RESOLVED" },
-    { name: "Assign Further", id: "ASSIGN_FURTHER" }
-];
-
 
 const getDropdownOptions = <T,>(arr: any, labelKey: keyof T, valueKey: keyof T): DropdownOption[] =>
     Array.isArray(arr)
@@ -53,9 +43,9 @@ const AllTickets: React.FC = () => {
     const [page, setPage] = useState(1);
     const [pageSize, setPageSize] = useState(5);
     const [totalPages, setTotalPages] = useState(1);
-    const [statusFilter, setStatusFilter] = useState("ALL");
+    const [statusFilter, setStatusFilter] = useState("All");
     const [masterOnly, setMasterOnly] = useState(false);
-    const [statusOptions, setStatusOptions] = useState<string[]>([]);
+    const [statusOptions, setStatusOptions] = useState<any[]>([{ statusName: 'All', statusNameValue: 'All' }]);
     const { t } = useTranslation();
     const showTable = checkMyTicketsAccess('table');
 
@@ -66,7 +56,7 @@ const AllTickets: React.FC = () => {
         Critical: { color: 'error.dark', count: 4 }
     };
 
-    const statusFilterOptions: DropdownOption[] = getDropdownOptions(statusOptions, "name", "id")
+    const statusFilterOptions: DropdownOption[] = getDropdownOptions(statusOptions, "statusName", "statusNameValue")
 
     const debouncedSearch = useDebounce(search, 300);
 
@@ -76,7 +66,7 @@ const AllTickets: React.FC = () => {
 
     useEffect(() => {
         if (Array.isArray(statusList)) {
-            setStatusOptions(['ALL', ...statusList]);
+            setStatusOptions([{ statusName: 'All', statusNameValue: 'All' }, ...statusList.map((s: any) => ({ ...s, statusNameValue: s.statusName }))]);
         }
     }, [statusList]);
 
@@ -84,7 +74,7 @@ const AllTickets: React.FC = () => {
         apiHandler(() =>
             searchTicketsPaginated(
                 debouncedSearch,
-                statusFilter === 'ALL' ? undefined : statusFilter,
+                statusFilter === 'All' ? undefined : statusFilter,
                 masterOnly ? true : undefined,
                 page - 1,
                 pageSize
@@ -180,7 +170,7 @@ const AllTickets: React.FC = () => {
                     label="Status"
                     value={statusFilter}
                     onChange={setStatusFilter}
-                    options={statusOptions.map(s => ({ label: s, value: s }))}
+                    options={statusFilterOptions}
                     style={{ width: 180, marginRight: 8 }}
                 />
                 <Chip

--- a/ui/src/pages/TicketDetails.tsx
+++ b/ui/src/pages/TicketDetails.tsx
@@ -14,6 +14,7 @@ import HistorySidebar from "../components/HistorySidebar";
 import { useTranslation } from "react-i18next";
 import { useSnackbar } from "../context/SnackbarContext";
 import { checkFieldAccess } from "../utils/permissions";
+import { getStatusList } from "../utils/Utils";
 
 interface Ticket {
     id: string;
@@ -33,6 +34,7 @@ interface Ticket {
     impact?: string;
     severityRecommendedBy?: string;
     status: string;
+    statusId?: string;
     assignToLevel?: string;
     assignTo?: string;
     assignedToLevel?: string;
@@ -47,7 +49,7 @@ const TicketDetails: React.FC = () => {
     const { t } = useTranslation();
 
     const { register, handleSubmit, control, setValue, formState: { errors } } = useForm();
-    const statusValue = useWatch({ control, name: 'status' });
+    const statusValue = useWatch({ control, name: 'statusId' });
     const [editing, setEditing] = useState<boolean>(false);
     const [historyOpen, setHistoryOpen] = useState<boolean>(false);
 
@@ -79,7 +81,7 @@ const TicketDetails: React.FC = () => {
             setValue("UserId", ticket.UserId);
             setValue("stakeholder", ticket.stakeholder);
             setValue("requestorName", ticket.requestorName);
-            setValue("status", ticket.status);
+            setValue("statusId", ticket.statusId);
             setValue("category", ticket.category);
             setValue("subCategory", ticket.subCategory);
             setValue("priority", ticket.priority);
@@ -100,8 +102,10 @@ const TicketDetails: React.FC = () => {
 
     const handleReopenToggle = (e: any) => {
         const checked = e.target.checked;
-        if (checked) setValue("status", "REOPENED");
-        else if (ticket) setValue("status", ticket.status);
+        const list = getStatusList();
+        const reopen = list?.find((s: any) => s.statusCode === 'REOPENED')?.statusId;
+        if (checked && reopen) setValue("statusId", reopen);
+        else if (ticket) setValue("statusId", ticket.statusId);
     };
 
     // Reset fields back to the original data
@@ -114,7 +118,7 @@ const TicketDetails: React.FC = () => {
         setValue("impact", ticket.impact);
         setValue("severityRecommendedBy", ticket.severityRecommendedBy);
         setValue("description", ticket.description);
-        setValue("status", ticket.status);
+        setValue("statusId", ticket.statusId);
         setValue("assignedToLevel", ticket.assignToLevel);
         setValue("assignedTo", ticket.assignTo);
     };
@@ -130,7 +134,7 @@ const TicketDetails: React.FC = () => {
                 <div className="m-3 d-flex align-items-center">
                     <p className="mb-0 me-2">{t('Status')}: {ticket.status}</p>
                     <Switch
-                        checked={statusValue === 'REOPENED'}
+                        checked={statusValue === getStatusList()?.find((s: any) => s.statusCode === 'REOPENED')?.statusId}
                         onChange={handleReopenToggle}
                         size="small"
                     />

--- a/ui/src/services/StatusService.ts
+++ b/ui/src/services/StatusService.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { BASE_URL } from './api';
+import { getStatusList, setStatusList } from '../utils/Utils';
 
 let statusCache: any[] | null = null;
 
@@ -7,8 +8,14 @@ export function getStatuses() {
     if (statusCache) {
         return Promise.resolve({ data: statusCache } as any);
     }
+    const stored = getStatusList();
+    if (stored) {
+        statusCache = stored;
+        return Promise.resolve({ data: stored } as any);
+    }
     return axios.get(`${BASE_URL}/ticket-statuses`).then(res => {
         statusCache = res.data;
+        setStatusList(res.data);
         return res;
     });
 }

--- a/ui/src/services/TicketService.ts
+++ b/ui/src/services/TicketService.ts
@@ -46,9 +46,9 @@ export function deleteComment(commentId: string) {
     return axios.delete(`${BASE_URL}/tickets/comments/${commentId}`);
 }
 
-export function searchTicketsPaginated(query: string, status?: string, master?: boolean, page: number = 0, size: number = 5) {
+export function searchTicketsPaginated(query: string, statusName?: string, master?: boolean, page: number = 0, size: number = 5) {
     const params = new URLSearchParams({ query, page: String(page), size: String(size) });
-    if (status) params.append('status', status);
+    if (statusName) params.append('status', statusName);
     if (master !== undefined) params.append('master', String(master));
     return axios.get(`${BASE_URL}/tickets/search?${params.toString()}`);
 }

--- a/ui/src/utils/Utils.ts
+++ b/ui/src/utils/Utils.ts
@@ -9,6 +9,7 @@ export interface UserDetails {
 
 const USER_KEY = 'userDetails';
 const PERM_KEY = 'userPermissions';
+const STATUS_LIST_KEY = 'statusList';
 
 export function setUserDetails(details: UserDetails) {
   sessionStorage.setItem(USER_KEY, JSON.stringify(details));
@@ -31,4 +32,13 @@ export function getUserPermissions(): any {
 export function clearSession() {
   sessionStorage.removeItem(USER_KEY);
   sessionStorage.removeItem(PERM_KEY);
+}
+
+export function setStatusList(list: any[]) {
+  sessionStorage.setItem(STATUS_LIST_KEY, JSON.stringify(list));
+}
+
+export function getStatusList(): any[] | null {
+  const data = sessionStorage.getItem(STATUS_LIST_KEY);
+  return data ? JSON.parse(data) : null;
 }


### PR DESCRIPTION
## Summary
- model ticket status as a `Status` entity instead of a plain ID
- expose status ID via mapper and use status name for filtering
- update service logic and repository queries for the new relationship
- pass status name in frontend search requests

## Testing
- `./gradlew test` *(failed: Cannot find a Java installation)*
- `npm test --silent` *(failed: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b1ec5bee08332b6ee626e241a8fb2