### PR TITLE
feat: cache ticket statuses

### DIFF
--- a/ui/src/components/RaiseTicket/TicketDetails.tsx
+++ b/ui/src/components/RaiseTicket/TicketDetails.tsx
@@ -10,7 +10,7 @@ import React, { useEffect, useState } from "react";
 import { Checkbox, FormControlLabel } from "@mui/material";
 import { getAllUsersByLevel, getAllLevels } from "../../services/LevelService";
 import { getCategories, getSubCategories } from "../../services/CategoryService";
-import { getNextStatusListByStatusId, getStatuses } from "../../services/StatusService";
+import { getNextStatusListByStatusId } from "../../services/StatusService";
 import { getCurrentUserDetails } from "../../config/config";
 import { checkFieldAccess } from "../../utils/permissions";
 import { getPriorities } from "../../services/PriorityService";
@@ -48,7 +48,6 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
     const { data: allUsersByLevel, pending, error, apiHandler: getAllUsersByLevelHandler } = useApi();
     const { data: allCategories, pending: isCategoriesLoading, error: categoriesError, apiHandler: getCategoriesApiHandler } = useApi();
     const { data: allSubCategories, pending: isSubCategoriesLoading, error: subCategoriesError, apiHandler: getSubCategoriesApiHandler } = useApi();
-    const { data: statusList, apiHandler: getStatusApiHandler } = useApi<any>();
     const { data: nextStatusListByStatusIdData, apiHandler: getNextStatusListByStatusIdApiHandler } = useApi<any>();
     const { data: priorityList, apiHandler: getPriorityApiHandler } = useApi<any>();
     const { data: severityList, apiHandler: getSeverityApiHandler } = useApi<any>();
@@ -108,9 +107,6 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
         getCategoriesApiHandler(() => getCategories())
     }, [])
 
-    useEffect(() => {
-        getStatusApiHandler(() => getStatuses())
-    }, [])
 
     // useEffect(() => {
     //     setValue && nextStatusListByStatusIdData && setValue("statusId", nextStatusListByStatusIdData[0]?.currentStatus);

--- a/ui/src/services/StatusService.ts
+++ b/ui/src/services/StatusService.ts
@@ -1,28 +1,8 @@
 import axios from 'axios';
 import { BASE_URL } from './api';
-import { getStatusList, setStatusList } from '../utils/Utils';
-
-let statusCache: any[] | null = null;
 
 export function getStatusListFromApi() {
-    return axios.get(`${BASE_URL}/ticket-statuses`)
-}
-
-export function getStatuses() {
-    debugger
-    if (statusCache) {
-        return Promise.resolve({ data: statusCache, source: 'cache' } as any);
-    }
-    const stored = getStatusList();
-    if (stored) {
-        statusCache = stored;
-        return Promise.resolve({ data: stored, source: 'cache' } as any);
-    }
-    return getStatusListFromApi().then(res => {
-        statusCache = res.data.body.data;
-        setStatusList(res.data.body.data);
-        return res;
-    });
+    return axios.get(`${BASE_URL}/ticket-statuses`);
 }
 
 export function getNextStatusListByStatusId(statusId: string) {

--- a/ui/src/utils/Utils.ts
+++ b/ui/src/utils/Utils.ts
@@ -52,19 +52,18 @@ export function getStatusNameById(statusId: string): any | null {
   return statusList ? statusList?.find(status => status.statusId === statusId)?.statusName : null;
 }
 
-export async function getStatuses() {
-    debugger
+export async function getStatuses(): Promise<any[]> {
     if (statusCache) {
-        return { data: statusCache, source: 'cache' };
+        return statusCache;
     }
     const stored = getStatusList();
     if (stored) {
         statusCache = stored;
-        return { data: stored, source: 'cache' };
+        return stored;
     }
-    return getStatusListFromApi().then(res => {
-        statusCache = res.data.body.data;
-        setStatusList(res.data.body.data);
-        return res;
-    });
+    const res = await getStatusListFromApi();
+    const list = res.data.body.data;
+    statusCache = list;
+    setStatusList(list);
+    return list;
 }


### PR DESCRIPTION
## Summary
- add `getStatuses` util that caches status list in session storage
- simplify StatusService to basic API wrappers
- load statuses on AllTickets page from util and populate dropdown

## Testing
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_689192e72db88332822ae5bd024ceb44