### PR TITLE
Record status history on ticket actions and show action tooltips

### DIFF
--- a/api/src/main/java/com/example/api/service/TicketService.java
+++ b/api/src/main/java/com/example/api/service/TicketService.java
@@ -215,13 +215,15 @@ public class TicketService {
                 statusHistoryService.addHistory(id, updatedBy, prevId, assignedId, slaAssigned);
                 previousStatus = TicketStatus.ASSIGNED;
                 previousStatusId = assignedId;
-                }
+            }
+        }
+        // ensure status history is recorded whenever status changes via actions
+        if (updatedStatusId == null && updatedStatus != null) {
+            updatedStatusId = workflowService.getStatusIdByCode(updatedStatus.name());
         }
         if (updatedStatusId != null && !updatedStatusId.equals(previousStatusId)) {
-            String prevId = previousStatusId;
-            String currId = updatedStatusId;
-            boolean slaCurr = workflowService.getSlaFlagByStatusId(currId);
-            statusHistoryService.addHistory(id, updatedBy, prevId, currId, slaCurr);
+            boolean slaCurr = workflowService.getSlaFlagByStatusId(updatedStatusId);
+            statusHistoryService.addHistory(id, updatedBy, previousStatusId, updatedStatusId, slaCurr);
         }
         return mapWithStatusId(saved);
     }

--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -7,7 +7,7 @@ import AssigneeDropdown from './AssigneeDropdown';
 import { checkMyTicketsColumnAccess } from '../../utils/permissions';
 import { getStatusNameById } from '../../utils/Utils';
 import CustomIconButton, { IconComponent } from '../UI/IconButton/CustomIconButton';
-import { Menu, MenuItem, IconButton, ListItemIcon } from '@mui/material';
+import { Menu, MenuItem, IconButton, ListItemIcon, Tooltip } from '@mui/material';
 import { updateTicket } from '../../services/TicketService';
 import { useApi } from '../../hooks/useApi';
 import { getCurrentUserDetails } from '../../config/config';
@@ -155,13 +155,14 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onRowClick, search
                             />
                             {recordActions.length <= 2 ? (
                                 recordActions.map(a => (
-                                    <IconButton
-                                        key={a.id}
-                                        size="small"
-                                        onClick={() => handleActionClick(a, record.id)}
-                                    >
-                                        {getActionIcon(a.action)}
-                                    </IconButton>
+                                    <Tooltip key={a.id} title={a.action} placement="top">
+                                        <IconButton
+                                            size="small"
+                                            onClick={() => handleActionClick(a, record.id)}
+                                        >
+                                            {getActionIcon(a.action)}
+                                        </IconButton>
+                                    </Tooltip>
                                 ))
                             ) : (
                                 <CustomIconButton onClick={(event) => openMenu(event, record)} icon='moreVert' />


### PR DESCRIPTION
## Summary
- ensure backend records status history whenever a ticket's action changes its status
- show action icons directly when <=2 actions and add tooltips with action names

## Testing
- `./gradlew test` *(fails: Could not get resource 'https://jitpack.io/com/github/typesense/typesense-java/0.2.0/typesense-java-0.2.0.jar'.)*
- `npm test --silent` *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_6891e3c0a94883329c5e82afe68a1a39