### PR TITLE
Add role-based status workflow mapping and assignee icon

### DIFF
--- a/api/src/main/java/com/example/api/controller/TicketStatusWorkflowController.java
+++ b/api/src/main/java/com/example/api/controller/TicketStatusWorkflowController.java
@@ -25,4 +25,9 @@ public class TicketStatusWorkflowController {
     public ResponseEntity<Map<String, List<TicketStatusWorkflow>>> getMappings() {
         return ResponseEntity.ok(service.getAllMappings());
     }
+
+    @PostMapping("/mappings")
+    public ResponseEntity<Map<String, List<TicketStatusWorkflow>>> getMappingsByRole(@RequestBody List<String> roles) {
+        return ResponseEntity.ok(service.getMappingsByRoles(roles));
+    }
 }

--- a/api/src/main/java/com/example/api/models/Role.java
+++ b/api/src/main/java/com/example/api/models/Role.java
@@ -5,7 +5,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -23,6 +22,9 @@ public class Role {
     @Lob
     @Column(name = "permissions", columnDefinition = "json")
     private String permissions;
+
+    @Column(name = "allowed_status_actions_ids")
+    private String allowedStatusActionsIds;
 
     @Column(name = "created_by")
     private String createdBy;

--- a/api/src/main/java/com/example/api/service/TicketStatusWorkflowService.java
+++ b/api/src/main/java/com/example/api/service/TicketStatusWorkflowService.java
@@ -2,25 +2,32 @@ package com.example.api.service;
 
 import com.example.api.models.Status;
 import com.example.api.models.TicketStatusWorkflow;
+import com.example.api.models.Role;
 import com.example.api.repository.StatusMasterRepository;
 import com.example.api.repository.TicketStatusWorkflowRepository;
+import com.example.api.repository.RoleRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
 public class TicketStatusWorkflowService {
     private final TicketStatusWorkflowRepository workflowRepository;
     private final StatusMasterRepository statusMasterRepository;
+    private final RoleRepository roleRepository;
 
     public TicketStatusWorkflowService(TicketStatusWorkflowRepository workflowRepository,
-                                       StatusMasterRepository statusMasterRepository) {
+                                       StatusMasterRepository statusMasterRepository,
+                                       RoleRepository roleRepository) {
         this.workflowRepository = workflowRepository;
         this.statusMasterRepository = statusMasterRepository;
+        this.roleRepository = roleRepository;
     }
 
     public List<TicketStatusWorkflow> getNextStatusesByCurrentStatus(String statusId) {
@@ -36,6 +43,29 @@ public class TicketStatusWorkflowService {
 
     public Map<String, List<TicketStatusWorkflow>> getAllMappings() {
         return workflowRepository.findAll().stream()
+                .collect(Collectors.groupingBy(tsw -> String.valueOf(tsw.getCurrentStatus())));
+    }
+
+    public Map<String, List<TicketStatusWorkflow>> getMappingsByRoles(List<String> roles) {
+        Set<Integer> ids = new HashSet<>();
+        if (roles == null || roles.isEmpty()) {
+            return Map.of();
+        }
+        for (Role role : roleRepository.findAllById(roles)) {
+            String allowed = role.getAllowedStatusActionsIds();
+            if (allowed != null && !allowed.isBlank()) {
+                for (String s : allowed.split("\\|")) {
+                    if (!s.isBlank()) {
+                        try {
+                            ids.add(Integer.parseInt(s.trim()));
+                        } catch (NumberFormatException ignored) {
+                        }
+                    }
+                }
+            }
+        }
+        List<TicketStatusWorkflow> workflows = workflowRepository.findAllById(ids);
+        return workflows.stream()
                 .collect(Collectors.groupingBy(tsw -> String.valueOf(tsw.getCurrentStatus())));
     }
 

--- a/ui/src/components/AllTickets/AssigneeDropdown.tsx
+++ b/ui/src/components/AllTickets/AssigneeDropdown.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { Menu, Box, TextField, Chip, List, ListItemButton } from '@mui/material';
+import { Menu, Box, TextField, Chip, List, ListItemButton, IconButton } from '@mui/material';
 import { getAllLevels, getAllUsersByLevel } from '../../services/LevelService';
 import { getAllUsers } from '../../services/UserService';
 import { updateTicket } from '../../services/TicketService';
 import UserAvatar from '../UI/UserAvatar/UserAvatar';
 import { useApi } from '../../hooks/useApi';
 import { getCurrentUserDetails } from '../../config/config';
+import PersonAddAltIcon from '@mui/icons-material/PersonAddAlt';
 
 interface AssigneeDropdownProps {
     ticketId: string;
@@ -67,7 +68,13 @@ const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ ticketId, assigneeN
 
     return (
         <>
-            <UserAvatar name={assigneeName || ''} onClick={(e) => setAnchorEl(e.currentTarget)} />
+            {assigneeName ? (
+                <UserAvatar name={assigneeName} onClick={(e) => setAnchorEl(e.currentTarget)} />
+            ) : (
+                <IconButton size="small" onClick={(e) => setAnchorEl(e.currentTarget)}>
+                    <PersonAddAltIcon fontSize="small" />
+                </IconButton>
+            )}
             <Menu anchorEl={anchorEl} open={open} onClose={() => setAnchorEl(null)}>
                 <Box sx={{ p: 1, width: 350 }}>
                     <TextField value={search} onChange={e => setSearch(e.target.value)} placeholder="Search" size="small" fullWidth />

--- a/ui/src/pages/AllTickets.tsx
+++ b/ui/src/pages/AllTickets.tsx
@@ -19,6 +19,7 @@ import DropdownController from "../components/UI/Dropdown/DropdownController";
 import { DropdownOption } from "../components/UI/Dropdown/GenericDropdown";
 import { Ticket, TicketStatusWorkflow } from "../types";
 import { getStatusWorkflowMappings } from "../services/StatusService";
+import { getCurrentUserDetails } from "../config/config";
 import { useNavigate } from "react-router-dom";
 
 
@@ -97,7 +98,8 @@ const AllTickets: React.FC = () => {
 
     useEffect(() => {
         getStatuses().then(setStatusList);
-        workflowApiHandler(() => getStatusWorkflowMappings());
+        const roles = getCurrentUserDetails()?.role || [];
+        workflowApiHandler(() => getStatusWorkflowMappings(roles));
     }, []);
 
     useEffect(() => {

--- a/ui/src/services/StatusService.ts
+++ b/ui/src/services/StatusService.ts
@@ -9,6 +9,6 @@ export function getNextStatusListByStatusId(statusId: string) {
     return axios.get(`${BASE_URL}/status-workflow/status/${statusId}`);
 }
 
-export function getStatusWorkflowMappings() {
-    return axios.get(`${BASE_URL}/status-workflow/mappings`);
+export function getStatusWorkflowMappings(roles: string[]) {
+    return axios.post(`${BASE_URL}/status-workflow/mappings`, roles);
 }


### PR DESCRIPTION
## Summary
- show PersonAddAlt icon when a ticket has no assignee and open dropdown on click
- fetch status workflow mappings via POST with roles and filter actions allowed for those roles
- add allowed_status_actions_ids to role entity and map workflow actions by role

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts: not found)*
- `./gradlew test` *(fails: Could not download typesense-java-0.2.0.jar, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68933be586f88332a43b822ee88d52b5