### PR TITLE
feat: map allowed status action ids

### DIFF
--- a/api/src/main/java/com/example/api/dto/RoleDto.java
+++ b/api/src/main/java/com/example/api/dto/RoleDto.java
@@ -20,5 +20,6 @@ public class RoleDto {
     private String updatedBy;
     private RolePermission permissions;
     private String[] permissionsList;
+    private String allowedStatusActionIds;
     private boolean isDeleted;
 }

--- a/api/src/main/java/com/example/api/mapper/DtoMapper.java
+++ b/api/src/main/java/com/example/api/mapper/DtoMapper.java
@@ -76,6 +76,7 @@ public class DtoMapper {
         dto.setCreatedOn(role.getCreatedOn());
         dto.setUpdatedBy(role.getUpdatedBy());
         dto.setUpdatedOn(role.getUpdatedOn());
+        dto.setAllowedStatusActionIds(role.getAllowedStatusActionIds());
         dto.setDeleted(role.isDeleted());
         return dto;
     }

--- a/api/src/main/java/com/example/api/models/Role.java
+++ b/api/src/main/java/com/example/api/models/Role.java
@@ -23,8 +23,8 @@ public class Role {
     @Column(name = "permissions", columnDefinition = "json")
     private String permissions;
 
-    @Column(name = "allowed_status_actions_ids")
-    private String allowedStatusActionsIds;
+    @Column(name = "allowed_status_action_ids")
+    private String allowedStatusActionIds;
 
     @Column(name = "created_by")
     private String createdBy;

--- a/api/src/main/java/com/example/api/service/RoleService.java
+++ b/api/src/main/java/com/example/api/service/RoleService.java
@@ -57,6 +57,7 @@ public class RoleService {
         Role role = new Role();
         role.setRole(roleDto.getRole());
         role.setPermissions(json);
+        role.setAllowedStatusActionIds(roleDto.getAllowedStatusActionIds());
         LocalDateTime now = LocalDateTime.now();
         role.setCreatedOn(now);
         role.setCreatedBy(roleDto.getCreatedBy());
@@ -85,6 +86,7 @@ public class RoleService {
         roleRepository.findById(dto.getRole()).ifPresent(role -> {
             role.setUpdatedBy(dto.getUpdatedBy());
             role.setUpdatedOn(LocalDateTime.now());
+            role.setAllowedStatusActionIds(dto.getAllowedStatusActionIds());
             roleRepository.save(role);
         });
     }


### PR DESCRIPTION
## Summary
- include allowed_status_action_ids column in Role entity
- expose allowedStatusActionIds in RoleDto and mapping
- propagate allowed status action IDs in role service

## Testing
- `./gradlew test` *(fails: Could not download typesense-java-0.2.0.jar from jitpack, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_689344674c2083329e166e34a006e481