### PR TITLE
feat: add card actions and sidebar comments

### DIFF
--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -7,7 +7,7 @@ import AssigneeDropdown from './AssigneeDropdown';
 import { checkMyTicketsColumnAccess } from '../../utils/permissions';
 import { getStatusNameById } from '../../utils/Utils';
 import CustomIconButton, { IconComponent } from '../UI/IconButton/CustomIconButton';
-import { Menu, MenuItem, IconButton, ListItemIcon, Tooltip } from '@mui/material';
+import { Menu, MenuItem, ListItemIcon, Tooltip } from '@mui/material';
 import { updateTicket } from '../../services/TicketService';
 import { useApi } from '../../hooks/useApi';
 import { getCurrentUserDetails } from '../../config/config';
@@ -55,29 +55,29 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
     const getActionIcon = (action: string) => {
         switch (action) {
             case 'Assign':
-                return <IconComponent icon="personAddAlt" fontSize="small" />;
+                return { icon: 'personAddAlt' };
             case 'Resolve':
-                return <IconComponent icon="check" fontSize="small" />;
+                return { icon: 'check', className: 'icon-blue' };
             case 'Cancel/ Reject':
-                return <IconComponent icon="close" fontSize="small" />;
+                return { icon: 'close', className: 'icon-red' };
             case 'On Hold (Pending with Requester)':
             case 'On Hold (Pending with Service Provider)':
             case 'On Hold (Pending with FCI)':
-                return <IconComponent icon="pause" fontSize="small" />;
+                return { icon: 'pause', className: 'icon-yellow' };
             case 'Approve Escalation':
-                return <IconComponent icon="moving" fontSize="small" />;
+                return { icon: 'moving' };
             case 'Recommend Escalation':
-                return <IconComponent icon="northEast" fontSize="small" />;
+                return { icon: 'northEast' };
             case 'Close':
-                return <IconComponent icon="doneAll" fontSize="small" className='text-success' />;
+                return { icon: 'doneAll', className: 'icon-green' };
             case 'Reopen':
-                return <IconComponent icon="replay" fontSize="small" />;
+                return { icon: 'replay' };
             case 'Start':
-                return <IconComponent icon="playArrow" fontSize="small" />;
+                return { icon: 'playArrow' };
             case 'Escalate':
-                return <IconComponent icon="arrowUpward" fontSize="small" />;
+                return { icon: 'arrowUpward' };
             default:
-                return <IconComponent icon="done" fontSize="small" />;
+                return { icon: 'done', className: 'icon-green' };
         }
     };
 
@@ -163,16 +163,19 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
                                 sx={{ color: 'grey.600', cursor: 'pointer' }}
                             />
                             {recordActions.length <= 2 ? (
-                                recordActions.map(a => (
-                                    <Tooltip key={a.id} title={a.action} placement="top">
-                                        <IconButton
-                                            size="small"
-                                            onClick={() => handleActionClick(a, record.id)}
-                                        >
-                                            {getActionIcon(a.action)}
-                                        </IconButton>
-                                    </Tooltip>
-                                ))
+                                recordActions.map(a => {
+                                    const { icon, className } = getActionIcon(a.action);
+                                    return (
+                                        <Tooltip key={a.id} title={a.action} placement="top">
+                                            <CustomIconButton
+                                                size="small"
+                                                onClick={() => handleActionClick(a, record.id)}
+                                                icon={icon}
+                                                className={className}
+                                            />
+                                        </Tooltip>
+                                    );
+                                })
                             ) : (
                                 <CustomIconButton onClick={(event) => openMenu(event, record)} icon='moreVert' />
                             )}
@@ -194,14 +197,17 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
                 rowClassName={(record: any) => record.id === refreshingTicketId ? 'refreshing-row' : ''}
             />
             <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
-                {actions.map(a => (
-                    <MenuItem key={a.id} onClick={() => handleActionClick(a)}>
-                        <ListItemIcon>
-                            {getActionIcon(a.action)}
-                        </ListItemIcon>
-                        {a.action}
-                    </MenuItem>
-                ))}
+                {actions.map(a => {
+                    const { icon, className } = getActionIcon(a.action);
+                    return (
+                        <MenuItem key={a.id} onClick={() => handleActionClick(a)}>
+                            <ListItemIcon>
+                                <IconComponent icon={icon} className={className} />
+                            </ListItemIcon>
+                            {a.action}
+                        </MenuItem>
+                    );
+                })}
             </Menu>
         </>
     );

--- a/ui/src/components/AllTickets/ViewTicket.tsx
+++ b/ui/src/components/AllTickets/ViewTicket.tsx
@@ -1,15 +1,18 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Typography, IconButton, TextField, MenuItem, Select, SelectChangeEvent, Paper, Drawer } from '@mui/material';
+import { Box, Typography, IconButton, TextField, MenuItem, Select, SelectChangeEvent, Drawer } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import CheckIcon from '@mui/icons-material/Check';
 import CloseIcon from '@mui/icons-material/Close';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import VisibilityIcon from '@mui/icons-material/Visibility';
 import UserAvatar from '../UI/UserAvatar/UserAvatar';
 import { useApi } from '../../hooks/useApi';
 import { getTicket, updateTicket } from '../../services/TicketService';
 import { getPriorities } from '../../services/PriorityService';
 import { getSeverities } from '../../services/SeverityService';
 import CustomIconButton from '../UI/IconButton/CustomIconButton';
+import CommentsSection from '../Comments/CommentsSection';
+import { useNavigate } from 'react-router-dom';
 
 interface ViewTicketProps {
   ticketId: string | null;
@@ -66,6 +69,7 @@ const ViewTicket: React.FC<ViewTicketProps> = ({ ticketId, open, onClose }) => {
     setEditing(false);
     onClose();
   };
+  const navigate = useNavigate();
 
   const cancelEditing = () => {
     setEditing(false);
@@ -125,9 +129,16 @@ const ViewTicket: React.FC<ViewTicketProps> = ({ ticketId, open, onClose }) => {
       variant="persistent"
       PaperProps={{ sx: { top: '70px', height: 'calc(100vh - 70px)' } }}
     >
-      <IconButton onClick={handleClose}>
-        <ChevronRightIcon />
-      </IconButton>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', px: 1, pt: 1 }}>
+        <IconButton onClick={handleClose}>
+          <ChevronRightIcon />
+        </IconButton>
+        {ticketId && (
+          <IconButton onClick={() => navigate(`/tickets/${ticketId}`)}>
+            <VisibilityIcon />
+          </IconButton>
+        )}
+      </Box>
       {ticket && (
         <Box sx={{ width: 400, position: 'relative', p: 2, display: 'flex', flexDirection: 'column', height: '100%' }}>
           <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
@@ -173,6 +184,7 @@ const ViewTicket: React.FC<ViewTicketProps> = ({ ticketId, open, onClose }) => {
               {renderSelect(recommendedSeverity, setRecommendedSeverity, severityOptions)}
             </Box>
           </Box>
+          <CommentsSection ticketId={ticketId as string} />
         </Box>
       )}
     </Drawer>

--- a/ui/src/fci-index.scss
+++ b/ui/src/fci-index.scss
@@ -14,6 +14,23 @@
   --fci-info-color: #1e88e5;
 }
 
+/* Utility classes for icon colors */
+.icon-green {
+  color: var(--fci-success-color);
+}
+
+.icon-red {
+  color: var(--fci-danger-color);
+}
+
+.icon-yellow {
+  color: var(--fci-warning-color);
+}
+
+.icon-blue {
+  color: var(--fci-info-color);
+}
+
 .generic-button {
   background-color: var(--fci-success-color) !important;
   height: 50px;

--- a/ui/src/pages/AllTickets.tsx
+++ b/ui/src/pages/AllTickets.tsx
@@ -186,7 +186,13 @@ const AllTickets: React.FC = () => {
                         <div className="row">
                             {filtered.map((t) => (
                                 <div className="col-md-4 mb-3" key={t.id}>
-                                    <TicketCard ticket={t} priorityConfig={priorityConfig} onClick={() => { setSelectedTicketId(t.id); setSidebarOpen(true); }} />
+                                    <TicketCard
+                                        ticket={t}
+                                        priorityConfig={priorityConfig}
+                                        statusWorkflows={workflowMap}
+                                        searchCurrentTicketsPaginatedApi={searchCurrentTicketsPaginatedApi}
+                                        onClick={() => { setSelectedTicketId(t.id); setSidebarOpen(true); }}
+                                    />
                                 </div>
                             ))}
                         </div>


### PR DESCRIPTION
## Summary
- show ticket actions on hover in grid cards with overflow menu
- add color utilities and apply to action icons
- reorganize ViewTicket header with link to ticket details and include comments

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*


------
https://chatgpt.com/codex/tasks/task_e_68943569bf0883328a3d4728851f884f