### PR TITLE
feat: improve role and ticket handling

### DIFF
--- a/api/src/main/java/com/example/api/Main.java
+++ b/api/src/main/java/com/example/api/Main.java
@@ -7,7 +7,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = "com.example")
 @ConfigurationPropertiesScan(basePackages = "com.example")
-//@EnableScheduling
+@EnableScheduling
 public class Main {
 
 	public static void main(String[] args) {

--- a/api/src/main/java/com/example/api/repository/TicketRepository.java
+++ b/api/src/main/java/com/example/api/repository/TicketRepository.java
@@ -18,6 +18,8 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
 
     public List<Ticket> findByLastModifiedAfter(LocalDateTime lastSyncedTime);
 
+    List<Ticket> findByTicketStatusAndLastModifiedBefore(TicketStatus ticketStatus, LocalDateTime time);
+
     @Query("SELECT t FROM Ticket t LEFT JOIN t.status s " +
             "WHERE (:statusId IS NULL OR s.statusId = :statusId) " +
             "AND (:master IS NULL OR t.isMaster = :master) " +

--- a/api/src/main/java/com/example/api/service/TicketStatusScheduler.java
+++ b/api/src/main/java/com/example/api/service/TicketStatusScheduler.java
@@ -1,0 +1,40 @@
+package com.example.api.service;
+
+import com.example.api.enums.TicketStatus;
+import com.example.api.models.Ticket;
+import com.example.api.repository.TicketRepository;
+import com.example.api.repository.StatusMasterRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+public class TicketStatusScheduler {
+    private final TicketRepository ticketRepository;
+    private final TicketStatusWorkflowService workflowService;
+    private final StatusMasterRepository statusMasterRepository;
+
+    public TicketStatusScheduler(TicketRepository ticketRepository,
+                                 TicketStatusWorkflowService workflowService,
+                                 StatusMasterRepository statusMasterRepository) {
+        this.ticketRepository = ticketRepository;
+        this.workflowService = workflowService;
+        this.statusMasterRepository = statusMasterRepository;
+    }
+
+    @Scheduled(cron = "0 0 * * * *")
+    public void closeResolvedTickets() {
+        LocalDateTime cutoff = LocalDateTime.now().minusHours(48);
+        List<Ticket> tickets = ticketRepository.findByTicketStatusAndLastModifiedBefore(TicketStatus.RESOLVED, cutoff);
+        String closedId = workflowService.getStatusIdByCode(TicketStatus.CLOSED.name());
+        for (Ticket t : tickets) {
+            t.setTicketStatus(TicketStatus.CLOSED);
+            if (closedId != null) {
+                statusMasterRepository.findById(closedId).ifPresent(t::setStatus);
+            }
+        }
+        ticketRepository.saveAll(tickets);
+    }
+}

--- a/ui/src/components/AllTickets/AssigneeDropdown.tsx
+++ b/ui/src/components/AllTickets/AssigneeDropdown.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Menu, Box, TextField, Chip, List, ListItemButton, IconButton } from '@mui/material';
+import { Menu, Box, TextField, Chip, List, ListItemButton, IconButton, Tooltip } from '@mui/material';
 import { getAllLevels, getAllUsersByLevel } from '../../services/LevelService';
 import { getAllUsers } from '../../services/UserService';
 import { updateTicket } from '../../services/TicketService';
@@ -69,7 +69,9 @@ const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ ticketId, assigneeN
     return (
         <>
             {assigneeName ? (
-                <UserAvatar name={assigneeName} onClick={(e) => setAnchorEl(e.currentTarget)} />
+                <Tooltip title={assigneeName}>
+                    <span><UserAvatar name={assigneeName} onClick={(e) => setAnchorEl(e.currentTarget)} /></span>
+                </Tooltip>
             ) : (
                 <IconButton size="small" onClick={(e) => setAnchorEl(e.currentTarget)}>
                     <PersonAddAltIcon fontSize="small" />

--- a/ui/src/components/AllTickets/TicketCard.tsx
+++ b/ui/src/components/AllTickets/TicketCard.tsx
@@ -139,7 +139,11 @@ const TicketCard: React.FC<TicketCardProps> = ({ ticket, priorityConfig, onClick
                 {allowAssigneeChange(ticket.statusId) ? (
                     <AssigneeDropdown ticketId={ticket.id} assigneeName={ticket.assignedTo} />
                 ) : (
-                    ticket.assignedTo ? <UserAvatar name={ticket.assignedTo} /> : null
+                    ticket.assignedTo ? (
+                        <Tooltip title={ticket.assignedTo}>
+                            <span><UserAvatar name={ticket.assignedTo} /></span>
+                        </Tooltip>
+                    ) : null
                 )}
             </Box>
             {hover && (

--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -146,7 +146,11 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
                             />
                         );
                     }
-                    return record.assignedTo ? <UserAvatar name={record.assignedTo} /> : '-';
+                    return record.assignedTo ? (
+                        <Tooltip title={record.assignedTo}>
+                            <span><UserAvatar name={record.assignedTo} /></span>
+                        </Tooltip>
+                    ) : '-';
                 }
             },
             { title: t('Status'), dataIndex: 'statusId', key: 'statusId', render: (v: any) => getStatusNameById(v) || '-' },

--- a/ui/src/components/PaginationControls.tsx
+++ b/ui/src/components/PaginationControls.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Pagination } from '@mui/material';
+import { Pagination, PaginationItem } from '@mui/material';
 
 interface PaginationControlsProps {
     page: number;
@@ -9,7 +9,30 @@ interface PaginationControlsProps {
 }
 
 const PaginationControls: React.FC<PaginationControlsProps> = ({ page, totalPages, onChange, className }) => (
-    <Pagination count={totalPages} page={page} onChange={onChange} className={className} color="primary" />
+    <Pagination
+        count={totalPages}
+        page={page}
+        onChange={onChange}
+        className={className}
+        color="primary"
+        boundaryCount={3}
+        siblingCount={0}
+        renderItem={(item) => {
+            if (item.type === 'page') {
+                if (item.page <= 3 || item.page === totalPages) {
+                    return <PaginationItem {...item} />;
+                }
+                if (item.page === 4) {
+                    return <PaginationItem {...item} type="end-ellipsis" />;
+                }
+                return null;
+            }
+            if (item.type === 'end-ellipsis' || item.type === 'start-ellipsis') {
+                return null;
+            }
+            return <PaginationItem {...item} />;
+        }}
+    />
 );
 
 export default PaginationControls;

--- a/ui/src/pages/AllTickets.tsx
+++ b/ui/src/pages/AllTickets.tsx
@@ -48,7 +48,8 @@ const AllTickets: React.FC = () => {
     const [filtered, setFiltered] = useState<Ticket[]>([]);
     const [page, setPage] = useState(1);
     const [tablePageSize, setTablePageSize] = useState(5);
-    const pageSize = viewMode === 'grid' ? 1 : tablePageSize;
+    const [gridPageSize, setGridPageSize] = useState(5);
+    const pageSize = viewMode === 'grid' ? gridPageSize : tablePageSize;
     const [totalPages, setTotalPages] = useState(1);
     const [statusFilter, setStatusFilter] = useState("All");
     const [masterOnly, setMasterOnly] = useState(false);
@@ -196,8 +197,27 @@ const AllTickets: React.FC = () => {
                                 </div>
                             ))}
                         </div>
-                        <div className="d-flex justify-content-center mt-3">
+                        <div className="d-flex justify-content-between align-items-center mt-3">
                             <PaginationControls page={page} totalPages={totalPages} onChange={(_, val) => setPage(val)} />
+                            <div className="d-flex align-items-center">
+                                <IconButton size="small" onClick={() => setGridPageSize(ps => ps > 1 ? ps - 1 : 1)}>
+                                    <ArrowDropDownIcon />
+                                </IconButton>
+                                <GenericInput
+                                    type="number"
+                                    value={gridPageSize}
+                                    onChange={(e) => {
+                                        const v = parseInt(e.target.value, 10);
+                                        if (!isNaN(v) && v > 0) setGridPageSize(v);
+                                    }}
+                                    size="small"
+                                    sx={{ width: 60, mx: 1 }}
+                                />
+                                <span>/ page</span>
+                                <IconButton size="small" onClick={() => setGridPageSize(ps => ps + 1)}>
+                                    <ArrowDropUpIcon />
+                                </IconButton>
+                            </div>
                         </div>
                     </div>
                 )}

--- a/ui/src/pages/RoleMaster.tsx
+++ b/ui/src/pages/RoleMaster.tsx
@@ -139,7 +139,14 @@ const RoleMaster: React.FC = () => {
         <div className="container">
             <Title textKey="Role Master" />
             <div className="d-flex justify-content-between mb-3">
-                <Button variant="contained" onClick={handleCreate}>Create Role</Button>
+                {creating ? (
+                    <div>
+                        <Button variant="contained" onClick={handleSubmit} className="me-2">Submit</Button>
+                        <Button variant="outlined" onClick={handleCancel}>Cancel</Button>
+                    </div>
+                ) : (
+                    <Button variant="contained" onClick={handleCreate}>Create Role</Button>
+                )}
                 <ViewToggle value={view} onChange={setView} options={[{ icon: 'grid', value: 'grid' }, { icon: 'table', value: 'table' }]} />
             </div>
             {creating && (
@@ -153,6 +160,7 @@ const RoleMaster: React.FC = () => {
                         />
                         <Autocomplete
                             multiple={!selectedPerms.includes('Custom')}
+                            disableCloseOnSelect={!selectedPerms.includes('Custom')}
                             options={["Custom", ...roles]}
                             value={selectedPerms.includes('Custom') ? 'Custom' : selectedPerms}
                             onChange={handlePermChange}
@@ -174,6 +182,7 @@ const RoleMaster: React.FC = () => {
                     </div>
                     <Autocomplete
                         multiple
+                        disableCloseOnSelect
                         options={statusActions || []}
                         value={(statusActions || []).filter((a: any) => selectedActionIds.includes(String(a.id)))}
                         onChange={(_, val) => setSelectedActionIds(val.map((a: any) => String(a.id)))}
@@ -186,10 +195,6 @@ const RoleMaster: React.FC = () => {
                         }
                         renderInput={(params) => <TextField {...params} label="Status Actions" />}
                     />
-                    <div className="mt-2">
-                        <Button variant="contained" onClick={handleSubmit} className="me-2">Submit</Button>
-                        <Button variant="outlined" onClick={handleCancel}>Cancel</Button>
-                    </div>
                 </div>
             )}
             {view === 'table' ? (


### PR DESCRIPTION
## Summary
- keep role creation dropdowns open for multiple selections and streamline create flow
- allow editing permitted status actions in role details
- add scheduled job to close resolved tickets after 48 hours
- refine ticket pagination and add page size controls
- show assignee name on avatar hover

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `./gradlew test` *(fails: could not download typesense-java jar)*

------
https://chatgpt.com/codex/tasks/task_e_6894994e7d2083329bceb3787032d8d2