### PR TITLE
Show requestor details tooltip with copy actions

### DIFF
--- a/ui/src/components/AllTickets/RequestorDetails.tsx
+++ b/ui/src/components/AllTickets/RequestorDetails.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { Box, Typography } from '@mui/material';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+
+interface RequestorDetailsProps {
+    email?: string;
+    phone?: string;
+}
+
+const RequestorDetails: React.FC<RequestorDetailsProps> = ({ email, phone }) => {
+    const [copied, setCopied] = useState<string | null>(null);
+
+    const handleCopy = (type: 'email' | 'phone', value?: string) => {
+        if (!value) return;
+        navigator.clipboard.writeText(value);
+        setCopied(type);
+        setTimeout(() => setCopied(null), 2000);
+    };
+
+    const renderRow = (label: string, value: string | undefined, type: 'email' | 'phone') => (
+        <Box sx={{ display: 'flex', alignItems: 'center', mb: 0.5 }}>
+            <ContentCopyIcon
+                fontSize="small"
+                sx={{ mr: 0.5, cursor: value ? 'pointer' : 'not-allowed' }}
+                onClick={() => handleCopy(type, value)}
+            />
+            <Typography variant="body2">{value || '-'}</Typography>
+            {copied === type && (
+                <Typography variant="caption" sx={{ ml: 0.5 }}>
+                    {label} copied
+                </Typography>
+            )}
+        </Box>
+    );
+
+    return (
+        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+            {renderRow('Email', email, 'email')}
+            {renderRow('Phone number', phone, 'phone')}
+        </Box>
+    );
+};
+
+export default RequestorDetails;

--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -13,6 +13,7 @@ import { useApi } from '../../hooks/useApi';
 import { getCurrentUserDetails } from '../../config/config';
 import { TicketStatusWorkflow } from '../../types';
 import UserAvatar from '../UI/UserAvatar/UserAvatar';
+import RequestorDetails from './RequestorDetails';
 
 export interface TicketRow {
     id: string;
@@ -118,17 +119,19 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
             {
                 title: t('Requestor Name'),
                 key: 'requestorName',
-                render: (_: any, record: TicketRow) => record.requestorName || '-',
-            },
-            {
-                title: t('Email'),
-                key: 'email',
-                render: (_: any, record: TicketRow) => record.requestorEmailId || '-',
-            },
-            {
-                title: t('Mobile'),
-                key: 'mobile',
-                render: (_: any, record: TicketRow) => record.requestorMobileNo || '-',
+                render: (_: any, record: TicketRow) =>
+                    record.requestorName ? (
+                        <Tooltip
+                            title={<RequestorDetails email={record.requestorEmailId} phone={record.requestorMobileNo} />}
+                            placement="top"
+                            arrow
+                            componentsProps={{ tooltip: { sx: { pointerEvents: 'auto' } } }}
+                        >
+                            <span>{record.requestorName}</span>
+                        </Tooltip>
+                    ) : (
+                        '-' as any
+                    ),
             },
             { title: t('Category'), dataIndex: 'category', key: 'category' },
             { title: t('Sub-Category'), dataIndex: 'subCategory', key: 'subCategory' },


### PR DESCRIPTION
## Summary
- remove email and mobile columns from AllTickets table
- display requestor details on hover with copy-to-clipboard for email and phone

## Testing
- `npm test -- --watchAll=false` (fails: Cannot find module 'react-router-dom' from 'src/App.tsx')

------
https://chatgpt.com/codex/tasks/task_e_68959d76b49883328dfcc6fda566cda8