### PR TITLE
Add status color and enhance ticket card UI

### DIFF
--- a/api/src/main/java/com/example/api/models/Status.java
+++ b/api/src/main/java/com/example/api/models/Status.java
@@ -24,4 +24,7 @@ public class Status {
     private Boolean slaFlag;
 
     private String description;
+
+    @Column(name = "color")
+    private String color;
 }

--- a/db/ticketing_system_dump.sql
+++ b/db/ticketing_system_dump.sql
@@ -382,6 +382,7 @@ CREATE TABLE `status_master` (
   `status_code` varchar(50) DEFAULT NULL,
   `sla_flag` tinyint(1) DEFAULT NULL,
   `description` varchar(255) DEFAULT NULL,
+  `color` varchar(7) DEFAULT NULL,
   PRIMARY KEY (`status_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -392,7 +393,18 @@ CREATE TABLE `status_master` (
 
 LOCK TABLES `status_master` WRITE;
 /*!40000 ALTER TABLE `status_master` DISABLE KEYS */;
-INSERT INTO `status_master` VALUES (1,'Open (New)','OPEN',0,'The ticket has been created but not yet assigned'),(2,'Assigned (In Progress)','ASSIGNED',1,'The ticket has been assigned to a support agent or team'),(3,'On Hold (Pending with Requester)','PENDING_WITH_REQUESTER',0,'Waiting for additional information from the requester'),(4,'On Hold (Pending with Service Provider)','PENDING_WITH_SERVICE_PROVIDER',1,'Waiting for additional information/ resolution from the third-party service provider'),(5,'On Hold (Pending with FCI)','PENDING_WITH_FCI',0,'Waiting for resolution from FCI or its empanelled vendors'),(6,'Awaiting Escalation Approval','AWAITING_ESCALATION_APPROVAL',0,'Resolution or action requires managerial approval before proceeding'),(7,'Resolved','RESOLVED',0,'The issue has been fixed, but the ticket remains open for confirmation from the requester'),(8,'Closed','CLOSED',0,'The ticket has been resolved and confirmed by the requester or automatically closed after a period of inactivity'),(9,'Cancelled','CANCELLED',0,'The ticket was withdrawn by the requester or deemed invalid'),(10,'Reopened','REOPENED',0,'A previously resolved ticket has been reopened due to recurrence or incomplete resolution'),(11,'Escalated','ESCALATED',0,'New severity can be recommended by some designated users');
+INSERT INTO `status_master` VALUES 
+(1,'Open (New)','OPEN',0,'The ticket has been created but not yet assigned','#2196F3'),
+(2,'Assigned (In Progress)','ASSIGNED',1,'The ticket has been assigned to a support agent or team','#9C27B0'),
+(3,'On Hold (Pending with Requester)','PENDING_WITH_REQUESTER',0,'Waiting for additional information from the requester','#FFC107'),
+(4,'On Hold (Pending with Service Provider)','PENDING_WITH_SERVICE_PROVIDER',1,'Waiting for additional information/ resolution from the third-party service provider','#FF9800'),
+(5,'On Hold (Pending with FCI)','PENDING_WITH_FCI',0,'Waiting for resolution from FCI or its empanelled vendors','#FFB74D'),
+(6,'Awaiting Escalation Approval','AWAITING_ESCALATION_APPROVAL',0,'Resolution or action requires managerial approval before proceeding','#E91E63'),
+(7,'Resolved','RESOLVED',0,'The issue has been fixed, but the ticket remains open for confirmation from the requester','#4CAF50'),
+(8,'Closed','CLOSED',0,'The ticket has been resolved and confirmed by the requester or automatically closed after a period of inactivity','#607D8B'),
+(9,'Cancelled','CANCELLED',0,'The ticket was withdrawn by the requester or deemed invalid','#F44336'),
+(10,'Reopened','REOPENED',0,'A previously resolved ticket has been reopened due to recurrence or incomplete resolution','#3F51B5'),
+(11,'Escalated','ESCALATED',0,'New severity can be recommended by some designated users','#FF5722');
 /*!40000 ALTER TABLE `status_master` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/ui/src/components/AllTickets/AssigneeDropdown.scss
+++ b/ui/src/components/AllTickets/AssigneeDropdown.scss
@@ -7,6 +7,10 @@
   transform: scale(1.1);
 }
 
+.assignee-btn.shadow {
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2) !important;
+}
+
 .assignee-btn::after {
   content: '';
   position: absolute;

--- a/ui/src/components/UI/Icons/MasterIcon.tsx
+++ b/ui/src/components/UI/Icons/MasterIcon.tsx
@@ -2,7 +2,7 @@ import { Avatar } from "@mui/material"
 
 const MasterIcon = () => {
     return (
-        <Avatar sx={{ bgcolor: 'darkgreen', width: 17, height: 17, ml: 0.5, fontSize: 10 }}>M</Avatar>
+        <Avatar sx={{ bgcolor: '#ff9800', width: 17, height: 17, ml: 0.5, fontSize: 10 }}>M</Avatar>
     )
 }
 

--- a/ui/src/utils/Utils.ts
+++ b/ui/src/utils/Utils.ts
@@ -52,6 +52,11 @@ export function getStatusNameById(statusId: string): any | null {
   return statusList ? statusList?.find(status => status.statusId === statusId)?.statusName : null;
 }
 
+export function getStatusColorById(statusId: string): string | null {
+  const statusList = getStatusList();
+  return statusList ? statusList?.find(status => status.statusId === statusId)?.color || null : null;
+}
+
 export async function getStatuses(): Promise<any[]> {
     if (statusCache) {
         return statusCache;


### PR DESCRIPTION
## Summary
- add `color` column to `status_master` and expose in Status entity
- apply status colors and progress bar in ticket card with right-aligned actions
- update UI styles: orange master icon and softer assignee shadow

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation matching 17)*
- `CI=true npm test` *(fails: useRoutes may be used only in the context of a <Router> component)*

------
https://chatgpt.com/codex/tasks/task_e_6895ab31ea7483328efe8dfed32fa7d3