### PR TITLE
Add reusable histories tabs

### DIFF
--- a/ui/src/components/AllTickets/ViewTicket.tsx
+++ b/ui/src/components/AllTickets/ViewTicket.tsx
@@ -1,8 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { Box, Typography, IconButton, TextField, MenuItem, Select, SelectChangeEvent, Drawer } from '@mui/material';
-import EditIcon from '@mui/icons-material/Edit';
-import CheckIcon from '@mui/icons-material/Check';
-import CloseIcon from '@mui/icons-material/Close';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import UserAvatar from '../UI/UserAvatar/UserAvatar';
@@ -13,6 +10,8 @@ import { getSeverities } from '../../services/SeverityService';
 import CustomIconButton from '../UI/IconButton/CustomIconButton';
 import CommentsSection from '../Comments/CommentsSection';
 import { useNavigate } from 'react-router-dom';
+import Histories from '../../pages/Histories';
+import { useTranslation } from 'react-i18next';
 
 interface ViewTicketProps {
   ticketId: string | null;
@@ -70,6 +69,7 @@ const ViewTicket: React.FC<ViewTicketProps> = ({ ticketId, open, onClose }) => {
     onClose();
   };
   const navigate = useNavigate();
+  const { t } = useTranslation();
 
   const cancelEditing = () => {
     setEditing(false);
@@ -184,6 +184,12 @@ const ViewTicket: React.FC<ViewTicketProps> = ({ ticketId, open, onClose }) => {
               {renderSelect(recommendedSeverity, setRecommendedSeverity, severityOptions)}
             </Box>
           </Box>
+          {ticketId && (
+            <Box component="fieldset" sx={{ mt: 2, borderColor: 'divider', borderRadius: 1 }}>
+              <legend>{t('History')}</legend>
+              <Histories ticketId={ticketId} />
+            </Box>
+          )}
           <CommentsSection ticketId={ticketId as string} />
         </Box>
       )}

--- a/ui/src/components/HistorySidebar.tsx
+++ b/ui/src/components/HistorySidebar.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from 'react';
-import { Drawer, Tabs, Tab, Box, Button, IconButton } from '@mui/material';
+import { Drawer, Box, Button, IconButton } from '@mui/material';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
-import StatusHistory from './StatusHistory';
-import AssignmentHistory from './AssignmentHistory';
 import { useTranslation } from 'react-i18next';
+import Histories from '../pages/Histories';
 
 interface HistorySidebarProps {
     ticketId: string;
@@ -61,15 +60,7 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ ticketId, open, setOpen
                     <IconButton onClick={handleClose} sx={{ position: 'absolute', left: -40, top: 8 }}>
                         <ChevronLeftIcon />
                     </IconButton>
-                    <Tabs value={tab} onChange={(_, v) => setTab(v)}>
-                        <Tab label={t('Status History')} value="status" />
-                        <Tab label={t('Assignment History')} value="assignment" />
-                    </Tabs>
-                    <Box sx={{ mt: 2 }}>
-                        {tab === 'status'
-                            ? <StatusHistory ticketId={ticketId} />
-                            : <AssignmentHistory ticketId={ticketId} />}
-                    </Box>
+                    <Histories ticketId={ticketId} currentTab={tab} onTabChange={(k) => setTab(k as 'status' | 'assignment')} />
                 </Box>
             </Drawer>
         </>

--- a/ui/src/components/UI/CustomTabsComponent.tsx
+++ b/ui/src/components/UI/CustomTabsComponent.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import { Tabs, Tab, Box } from '@mui/material';
+
+interface TabItem {
+    key: string;
+    tabTitle: string;
+    tabComponent: React.ReactNode;
+}
+
+interface CustomTabsComponentProps {
+    tabs: TabItem[];
+    currentTab?: string;
+    onTabChange?: (key: string) => void;
+}
+
+const CustomTabsComponent: React.FC<CustomTabsComponentProps> = ({ tabs, currentTab, onTabChange }) => {
+    const [value, setValue] = useState<string>(currentTab || tabs[0]?.key);
+
+    useEffect(() => {
+        if (currentTab) setValue(currentTab);
+    }, [currentTab]);
+
+    const handleChange = (_: React.SyntheticEvent, newValue: string) => {
+        setValue(newValue);
+        onTabChange?.(newValue);
+    };
+
+    const activeTab = currentTab ?? value;
+    const activeComponent = tabs.find(t => t.key === activeTab)?.tabComponent;
+
+    return (
+        <>
+            <Tabs value={activeTab} onChange={handleChange}>
+                {tabs.map(t => (
+                    <Tab key={t.key} label={t.tabTitle} value={t.key} />
+                ))}
+            </Tabs>
+            <Box sx={{ mt: 2 }}>
+                {activeComponent}
+            </Box>
+        </>
+    );
+};
+
+export default CustomTabsComponent;
+export type { TabItem };

--- a/ui/src/pages/Histories.tsx
+++ b/ui/src/pages/Histories.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import StatusHistory from '../components/StatusHistory';
+import AssignmentHistory from '../components/AssignmentHistory';
+import CustomTabsComponent from '../components/UI/CustomTabsComponent';
+import { useTranslation } from 'react-i18next';
+
+interface HistoriesProps {
+    ticketId: string;
+    currentTab?: string;
+    onTabChange?: (key: string) => void;
+}
+
+const Histories: React.FC<HistoriesProps> = ({ ticketId, currentTab, onTabChange }) => {
+    const { t } = useTranslation();
+
+    const tabs = [
+        { key: 'status', tabTitle: t('Status History'), tabComponent: <StatusHistory ticketId={ticketId} /> },
+        { key: 'assignment', tabTitle: t('Assignment History'), tabComponent: <AssignmentHistory ticketId={ticketId} /> },
+    ];
+
+    return (
+        <CustomTabsComponent tabs={tabs} currentTab={currentTab} onTabChange={onTabChange} />
+    );
+};
+
+export default Histories;


### PR DESCRIPTION
## Summary
- add generic `CustomTabsComponent` for rendering MUI tabs from data
- combine status and assignment history in new `Histories` component
- use tabbed histories in sidebar and ticket view sidebar

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*


------
https://chatgpt.com/codex/tasks/task_e_6895c8e688508332a21880922964a929