### PR TITLE
feat: add remarks workflow and history

### DIFF
--- a/api/src/main/java/com/example/api/dto/StatusHistoryDto.java
+++ b/api/src/main/java/com/example/api/dto/StatusHistoryDto.java
@@ -15,4 +15,5 @@ public class StatusHistoryDto {
     private String currentStatus;
     private LocalDateTime timestamp;
     private Boolean slaFlag;
+    private String remark;
 }

--- a/api/src/main/java/com/example/api/mapper/DtoMapper.java
+++ b/api/src/main/java/com/example/api/mapper/DtoMapper.java
@@ -104,6 +104,7 @@ public class DtoMapper {
         dto.setCurrentStatus(statusHistory.getCurrentStatus());
         dto.setTimestamp(statusHistory.getTimestamp());
         dto.setSlaFlag(statusHistory.getSlaFlag());
+        dto.setRemark(statusHistory.getRemark());
         return dto;
     }
 }

--- a/api/src/main/java/com/example/api/models/AssignmentHistory.java
+++ b/api/src/main/java/com/example/api/models/AssignmentHistory.java
@@ -25,4 +25,7 @@ public class AssignmentHistory {
 
     @Column(name = "timestamp")
     private LocalDateTime timestamp;
+
+    @Column(name = "remark")
+    private String remark;
 }

--- a/api/src/main/java/com/example/api/models/StatusHistory.java
+++ b/api/src/main/java/com/example/api/models/StatusHistory.java
@@ -32,4 +32,7 @@ public class StatusHistory {
 
     @Column(name = "sla_flag")
     private Boolean slaFlag;
+
+    @Column(name = "remark")
+    private String remark;
 }

--- a/api/src/main/java/com/example/api/models/Ticket.java
+++ b/api/src/main/java/com/example/api/models/Ticket.java
@@ -77,4 +77,7 @@ public class Ticket {
     @ManyToOne
     @JoinColumn(name = "status_id", referencedColumnName = "status_id")
     private Status status;
+
+    @Transient
+    private String remark;
 }

--- a/api/src/main/java/com/example/api/service/AssignmentHistoryService.java
+++ b/api/src/main/java/com/example/api/service/AssignmentHistoryService.java
@@ -16,13 +16,14 @@ public class AssignmentHistoryService {
     private final AssignmentHistoryRepository historyRepository;
     private final TicketRepository ticketRepository;
 
-    public AssignmentHistory addHistory(String ticketId, String assignedBy, String assignedTo) {
+    public AssignmentHistory addHistory(String ticketId, String assignedBy, String assignedTo, String remark) {
         Ticket ticket = ticketRepository.findById(ticketId).orElseThrow();
         AssignmentHistory history = new AssignmentHistory();
         history.setTicket(ticket);
         history.setAssignedBy(assignedBy);
         history.setAssignedTo(assignedTo);
         history.setTimestamp(LocalDateTime.now());
+        history.setRemark(remark);
         return historyRepository.save(history);
     }
 

--- a/api/src/main/java/com/example/api/service/StatusHistoryService.java
+++ b/api/src/main/java/com/example/api/service/StatusHistoryService.java
@@ -22,7 +22,7 @@ public class StatusHistoryService {
         this.ticketRepository = ticketRepository;
     }
 
-    public StatusHistory addHistory(String ticketId, String updatedBy, String previousStatus, String currentStatus, Boolean slaFlag) {
+    public StatusHistory addHistory(String ticketId, String updatedBy, String previousStatus, String currentStatus, Boolean slaFlag, String remark) {
         Ticket ticket = ticketRepository.findById(ticketId).orElseThrow();
         StatusHistory history = new StatusHistory();
         history.setTicket(ticket);
@@ -31,6 +31,7 @@ public class StatusHistoryService {
         history.setCurrentStatus(currentStatus);
         history.setTimestamp(LocalDateTime.now());
         history.setSlaFlag(slaFlag);
+        history.setRemark(remark);
         return historyRepository.save(history);
     }
 

--- a/db/ticketing_system_dump.sql
+++ b/db/ticketing_system_dump.sql
@@ -30,6 +30,7 @@ CREATE TABLE `assignment_history` (
   `assigned_by` varchar(100) NOT NULL,
   `assigned_to` varchar(100) NOT NULL,
   `timestamp` datetime DEFAULT CURRENT_TIMESTAMP,
+  `remark` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `fk_ticket_assignment_history` (`ticket_id`),
   CONSTRAINT `fk_ticket_assignment_history` FOREIGN KEY (`ticket_id`) REFERENCES `tickets` (`ticket_id`)
@@ -353,6 +354,7 @@ CREATE TABLE `status_history` (
   `current_status` varchar(50) DEFAULT NULL,
   `timestamp` datetime DEFAULT CURRENT_TIMESTAMP,
   `sla_flag` tinyint DEFAULT NULL,
+  `remark` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`status_history_id`),
   KEY `fk_ticket_status_history` (`ticket_id`),
   CONSTRAINT `fk_ticket_status_history` FOREIGN KEY (`ticket_id`) REFERENCES `tickets` (`ticket_id`)

--- a/ui/src/components/AllTickets/TicketCard.tsx
+++ b/ui/src/components/AllTickets/TicketCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Card, CardContent, Typography, Box, Tooltip, Menu, MenuItem, ListItemIcon, Chip } from '@mui/material';
+import { Card, CardContent, Typography, Box, Tooltip, Menu, MenuItem, ListItemIcon, Chip, TextField, Button } from '@mui/material';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import MasterIcon from '../UI/Icons/MasterIcon';
 import AssigneeDropdown from './AssigneeDropdown';
@@ -46,6 +46,9 @@ const TicketCard: React.FC<TicketCardProps> = ({ ticket, priorityConfig, onClick
     const [actions, setActions] = useState<TicketStatusWorkflow[]>([]);
     const { apiHandler: updateTicketApiHandler } = useApi<any>();
     const navigate = useNavigate();
+    const [showRemark, setShowRemark] = useState(false);
+    const [selectedAction, setSelectedAction] = useState<TicketStatusWorkflow | null>(null);
+    const [remark, setRemark] = useState('');
 
     const disallowed = ['Assign', 'Further Assign', 'Assign / Assign Further'];
 
@@ -97,12 +100,43 @@ const TicketCard: React.FC<TicketCardProps> = ({ ticket, priorityConfig, onClick
 
     const handleActionClick = (wf: TicketStatusWorkflow, e?: React.MouseEvent) => {
         e?.stopPropagation();
+        setSelectedAction(wf);
+        setShowRemark(true);
+        setRemark('');
+        handleClose();
+    };
+
+    const submitAction = () => {
+        if (!selectedAction) return;
         const id = ticket.id;
-        const payload = { status: { statusId: String(wf.nextStatus) }, assignedBy: getCurrentUserDetails()?.username } as any;
+        const payload = {
+            status: { statusId: String(selectedAction.nextStatus) },
+            assignedBy: getCurrentUserDetails()?.username,
+            remark
+        } as any;
         updateTicketApiHandler(() => updateTicket(id, payload)).then(() => {
             searchCurrentTicketsPaginatedApi(id);
         });
-        handleClose();
+        cancelAction();
+    };
+
+    const cancelAction = () => {
+        setShowRemark(false);
+        setSelectedAction(null);
+        setRemark('');
+    };
+
+    const getConfirmationText = (action: string) => {
+        switch (action) {
+            case 'Reopen':
+                return 'If you are sure you want to Reopen the ticket, please add a remark and submit';
+            case 'Resolve':
+                return 'If you are sure you want to Resolve the ticket, please add a remark and submit';
+            case 'Close':
+                return 'If you are sure you want to Close the ticket, please add a remark and submit';
+            default:
+                return `If you are sure you want to ${action} the ticket, please add a remark and submit`;
+        }
     };
 
     const recordActions = getAvailableActions(ticket.statusId);
@@ -205,6 +239,16 @@ const TicketCard: React.FC<TicketCardProps> = ({ ticket, priorityConfig, onClick
                     );
                 })}
             </Menu>
+            {showRemark && selectedAction && (
+                <Box sx={{ p: 1, borderTop: '1px solid', borderColor: 'grey.300', display: 'flex', flexDirection: 'column', gap: 1 }} onClick={(e)=>e.stopPropagation()}>
+                    <Typography variant="body2">{getConfirmationText(selectedAction.action)}</Typography>
+                    <TextField size="small" value={remark} onChange={(e) => setRemark(e.target.value)} />
+                    <Box sx={{ mt: 1, display: 'flex', gap: 1 }}>
+                        <Button variant="contained" size="small" onClick={submitAction}>Submit</Button>
+                        <Button variant="outlined" size="small" onClick={cancelAction}>Cancel</Button>
+                    </Box>
+                </Box>
+            )}
         </Card>
     );
 };

--- a/ui/src/components/AssignmentHistory/index.tsx
+++ b/ui/src/components/AssignmentHistory/index.tsx
@@ -12,6 +12,7 @@ interface HistoryEntry {
     assignedBy: string;
     assignedTo: string;
     timestamp: string;
+    remark?: string;
 }
 
 interface AssignmentHistoryProps {
@@ -38,6 +39,7 @@ const AssignmentHistory: React.FC<AssignmentHistoryProps> = ({ ticketId }) => {
             key: 'timestamp',
             render: (v: string) => new Date(v).toLocaleString(),
         },
+        { title: t('Remark'), dataIndex: 'remark', key: 'remark', render: (v: string) => v || '-' },
     ];
 
     const history = Array.isArray(data)
@@ -78,6 +80,7 @@ const AssignmentHistory: React.FC<AssignmentHistoryProps> = ({ ticketId }) => {
                                     <div style={{ fontSize: 12 }}>
                                         {new Date(h.timestamp).toLocaleString()} - {h.assignedBy}
                                     </div>
+                                    {h.remark && <div style={{ fontSize: 12 }}>{h.remark}</div>}
                                 </Paper>
                             </TimelineContent>
                         </TimelineItem>

--- a/ui/src/components/StatusHistory/index.tsx
+++ b/ui/src/components/StatusHistory/index.tsx
@@ -14,6 +14,7 @@ interface HistoryEntry {
     timestamp: string;
     previousStatus: string;
     currentStatus: string;
+    remark?: string;
 }
 
 interface StatusHistoryProps {
@@ -56,6 +57,7 @@ const StatusHistory: React.FC<StatusHistoryProps> = ({ ticketId }) => {
             key: 'currentStatus',
             render: (v: string) => (statusMap[v]?.replace(/_/g, ' ') || v?.replace(/_/g, ' '))
         },
+        { title: t('Remark'), dataIndex: 'remark', key: 'remark', render: (v: string) => v || '-' },
     ];
 
     const history = Array.isArray(data)
@@ -96,6 +98,7 @@ const StatusHistory: React.FC<StatusHistoryProps> = ({ ticketId }) => {
                                     <div style={{ fontSize: 12 }}>
                                         {new Date(h.timestamp).toLocaleString()} - {h.updatedBy}
                                     </div>
+                                    {h.remark && <div style={{ fontSize: 12 }}>{h.remark}</div>}
                                 </Paper>
                             </TimelineContent>
                         </TimelineItem>


### PR DESCRIPTION
## Summary
- expand ticket actions to capture remarks before submitting
- store remarks in status and assignment history records
- expose remarks in ticket history views

## Testing
- `JAVA_HOME=/usr/lib/jvm/jdk-17.0.2 ./gradlew test` *(fails: Could not resolve all files for configuration ':compileClasspath')*
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68976e70c1d08332b4ca2c94ac067374