### PR TITLE
refactor: externalize ticket update from ActionRemark

### DIFF
--- a/ui/src/components/AllTickets/ActionRemarkComponent.tsx
+++ b/ui/src/components/AllTickets/ActionRemarkComponent.tsx
@@ -1,15 +1,9 @@
 import React, { useState } from 'react';
 import { Box, TextField, Button, Typography } from '@mui/material';
-import { updateTicket } from '../../services/TicketService';
-import { useApi } from '../../hooks/useApi';
-import { getCurrentUserDetails } from '../../config/config';
-
 interface ActionRemarkProps {
-  ticket: any;
   actionName: string;
-  payload: Record<string, any>;
+  onSubmit: (remark: string) => void;
   onCancel: () => void;
-  onSuccess?: () => void;
 }
 
 const getConfirmationText = (action: string) => {
@@ -25,20 +19,15 @@ const getConfirmationText = (action: string) => {
   }
 };
 
-const ActionRemarkComponent: React.FC<ActionRemarkProps> = ({ ticket, actionName, payload, onCancel, onSuccess }) => {
+const ActionRemarkComponent: React.FC<ActionRemarkProps> = ({ actionName, onSubmit, onCancel }) => {
   const [remark, setRemark] = useState('');
-  const { apiHandler: updateTicketApiHandler } = useApi<any>();
 
   const submit = () => {
-    const id = ticket.id;
-    const reqPayload = {
-      ...payload,
-      remark,
-      assignedBy: getCurrentUserDetails()?.username,
-    } as any;
-    updateTicketApiHandler(() => updateTicket(id, reqPayload)).then(() => {
-      onSuccess && onSuccess();
-    });
+    onSubmit(remark);
+  };
+
+  const cancelRemark = () => {
+    setRemark('');
     onCancel();
   };
 
@@ -50,7 +39,7 @@ const ActionRemarkComponent: React.FC<ActionRemarkProps> = ({ ticket, actionName
         <Button variant="contained" size="small" onClick={submit}>
           Submit
         </Button>
-        <Button variant="outlined" size="small" onClick={onCancel}>
+        <Button variant="outlined" size="small" onClick={cancelRemark}>
           Cancel
         </Button>
       </Box>

--- a/ui/src/components/AllTickets/AssigneeDropdown.tsx
+++ b/ui/src/components/AllTickets/AssigneeDropdown.tsx
@@ -7,6 +7,8 @@ import { useApi } from '../../hooks/useApi';
 import PersonAddAltIcon from '@mui/icons-material/PersonAddAlt';
 import './AssigneeDropdown.scss';
 import ActionRemarkComponent from './ActionRemarkComponent';
+import { updateTicket } from '../../services/TicketService';
+import { getCurrentUserDetails } from '../../config/config';
 
 interface AssigneeDropdownProps {
     ticketId: string;
@@ -31,6 +33,7 @@ const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ ticketId, assigneeN
     const { data: levelsData, apiHandler: getLevelsApiHandler } = useApi<any>();
     const { data: usersData, apiHandler: getUsersByLevelApiHandler } = useApi<any>();
     const { data: allUsersData, apiHandler: getAllUsersApiHandler } = useApi<any>();
+    const { apiHandler: updateTicketApiHandler } = useApi<any>();
 
     // Fetch levels on mount
     useEffect(() => {
@@ -122,11 +125,18 @@ const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ ticketId, assigneeN
                     </List>
                     {showActionRemark && selectedUser && (
                         <ActionRemarkComponent
-                            ticket={{ id: ticketId }}
                             actionName="Assign"
-                            payload={{ assignedTo: selectedUser.username }}
                             onCancel={handleCancelRemark}
-                            onSuccess={handleSuccess}
+                            onSubmit={(remark) => {
+                                const payload = {
+                                    assignedTo: selectedUser.username,
+                                    remark,
+                                    assignedBy: getCurrentUserDetails()?.username,
+                                };
+                                updateTicketApiHandler(() => updateTicket(ticketId, payload)).then(() => {
+                                    handleSuccess();
+                                });
+                            }}
                         />
                     )}
                 </Box>


### PR DESCRIPTION
## Summary
- move updateTicket API call out of ActionRemark component
- allow ActionRemark to reset remark on cancel and report cancel via prop
- call updateTicket in card, table and assignee dropdown to refresh views

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_689c545bd77483329b36569fa0a1cc2d