### PR TITLE
feat: allow IconComponent style prop

### DIFF
--- a/ui/src/components/UI/IconButton/CustomIconButton.tsx
+++ b/ui/src/components/UI/IconButton/CustomIconButton.tsx
@@ -59,20 +59,22 @@ const iconMap = {
 // Valid keys for the icon map
 type IconKey = keyof typeof iconMap;
 
-interface CustomIconButtonProps extends IconButtonProps {
-    icon: string; // passed in as string, handled internally
-}
-
 // Helper component to render icon
-export const IconComponent: React.FC<{ icon: string; fontSize?: 'small' | 'medium' | 'large'; className?: string }> = ({
+export const IconComponent: React.FC<{
+    icon: string;
+    fontSize?: 'small' | 'medium' | 'large';
+    className?: string;
+    style?: React.CSSProperties;
+}> = ({
     icon,
     fontSize = 'small',
     className,
+    style,
 }) => {
     const key = icon as IconKey;
     const Icon = iconMap[key];
 
-    return Icon ? <Icon fontSize={fontSize} className={className} /> : null;
+    return Icon ? <Icon fontSize={fontSize} className={className} style={style} /> : null;
 };
 
 interface CustomIconButtonProps extends IconButtonProps {

--- a/ui/src/components/UI/Icons/PriorityIcon.tsx
+++ b/ui/src/components/UI/Icons/PriorityIcon.tsx
@@ -18,7 +18,13 @@ const PriorityIcon: React.FC<PriorityIconProps> = ({ level }) => {
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', lineHeight: 0 }}>
       {Array.from({ length: count }).map((_, i) => (
-        <IconComponent icon='arrowup' fontSize='small' className='priority-icon' key={i} />
+        <IconComponent
+          icon='arrowup'
+          fontSize='small'
+          className='priority-icon'
+          style={{ fontSize: 16, color, marginTop: i ? -4 : 0 }}
+          key={i}
+        />
         // <ArrowUpwardIcon key={i} sx={{ fontSize: 16, color, mt: i ? -0.5 : 0 }} />
       ))}
     </Box>


### PR DESCRIPTION
## Summary
- allow IconComponent to accept custom inline styles
- pass styling to PriorityIcon so priority arrows can be colored and spaced

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_689c7ab192988332aeb607c6d1974da4