### PR TITLE
feat: add ticket feedback flow

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,60 +1,61 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.0'
-	id 'io.spring.dependency-management' version '1.1.7'
+        id 'java'
+        id 'org.springframework.boot' version '3.5.0'
+        id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
-	sourceCompatibility = JavaVersion.VERSION_17
-	targetCompatibility = JavaVersion.VERSION_17
+        toolchain {
+                languageVersion = JavaLanguageVersion.of(17)
+        }
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+        compileOnly {
+                extendsFrom annotationProcessor
+        }
 }
 
 repositories {
-	mavenCentral()
-	maven { url 'https://jitpack.io'}
+        mavenCentral()
+        maven { url 'https://jitpack.io'}
 }
 
 ext {
-	set('springAiVersion', "1.0.0")
+        set('springAiVersion', "1.0.0")
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'com.github.typesense:typesense-java:0.2.0'
-	implementation 'org.springframework.boot:spring-boot-starter-freemarker'
-	implementation 'org.springframework.boot:spring-boot-starter-mail'
-	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-	implementation 'com.twilio.sdk:twilio:10.9.2'
-	implementation 'com.fasterxml.jackson.core:jackson-databind'
-//	implementation 'org.springframework.ai:spring-ai-starter-vector-store-typesense'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+        implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'com.github.typesense:typesense-java:0.2.0'
+        implementation 'org.springframework.boot:spring-boot-starter-freemarker'
+        implementation 'org.springframework.boot:spring-boot-starter-mail'
+        implementation 'org.springframework.boot:spring-boot-starter-websocket'
+        implementation 'com.twilio.sdk:twilio:10.9.2'
+        implementation 'com.fasterxml.jackson.core:jackson-databind'
+        implementation 'org.flywaydb:flyway-core'
+//      implementation 'org.springframework.ai:spring-ai-starter-vector-store-typesense'
+        compileOnly 'org.projectlombok:lombok'
+        developmentOnly 'org.springframework.boot:spring-boot-devtools'
         runtimeOnly 'com.mysql:mysql-connector-j'
         implementation 'org.springframework.security:spring-security-crypto'
         annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+        testImplementation 'org.springframework.boot:spring-boot-starter-test'
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 dependencyManagement {
-	imports {
-		mavenBom "org.springframework.ai:spring-ai-bom:${springAiVersion}"
-	}
+        imports {
+                mavenBom "org.springframework.ai:spring-ai-bom:${springAiVersion}"
+        }
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+        useJUnitPlatform()
 }

--- a/api/src/main/java/com/example/api/controller/TicketFeedbackController.java
+++ b/api/src/main/java/com/example/api/controller/TicketFeedbackController.java
@@ -1,0 +1,57 @@
+package com.example.api.controller;
+
+import com.example.api.dto.FeedbackFormDTO;
+import com.example.api.dto.SubmitFeedbackRequest;
+import com.example.api.dto.TicketFeedbackResponse;
+import com.example.api.enums.FeedbackStatus;
+import com.example.api.service.TicketFeedbackService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@RestController
+@RequestMapping
+@CrossOrigin(origins = "http://localhost:3000")
+public class TicketFeedbackController {
+    private final TicketFeedbackService feedbackService;
+
+    public TicketFeedbackController(TicketFeedbackService feedbackService) {
+        this.feedbackService = feedbackService;
+    }
+
+    @GetMapping("/tickets/{ticketId}/feedback/form")
+    public ResponseEntity<FeedbackFormDTO> getForm(@PathVariable String ticketId,
+                                                  @RequestHeader("X-USER-ID") String userId) {
+        return ResponseEntity.ok(feedbackService.getForm(ticketId, userId));
+    }
+
+    @PostMapping("/tickets/{ticketId}/feedback")
+    public ResponseEntity<TicketFeedbackResponse> submit(@PathVariable String ticketId,
+                                                         @RequestHeader("X-USER-ID") String userId,
+                                                         @RequestBody @Validated SubmitFeedbackRequest req) {
+        return ResponseEntity.ok(feedbackService.submit(ticketId, userId, req));
+    }
+
+    @GetMapping("/tickets/{ticketId}/feedback")
+    public ResponseEntity<TicketFeedbackResponse> getFeedback(@PathVariable String ticketId,
+                                                              @RequestHeader("X-USER-ID") String userId) {
+        return feedbackService.getFeedback(ticketId, userId)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/feedback")
+    public ResponseEntity<Page<?>> search(@RequestParam Optional<String> ticketId,
+                                          @RequestParam Optional<FeedbackStatus> status,
+                                          @RequestParam Optional<LocalDateTime> from,
+                                          @RequestParam Optional<LocalDateTime> to,
+                                          @RequestParam(defaultValue = "0") int page,
+                                          @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(feedbackService.search(ticketId, status, from, to, PageRequest.of(page, size)));
+    }
+}

--- a/api/src/main/java/com/example/api/dto/FeedbackFormDTO.java
+++ b/api/src/main/java/com/example/api/dto/FeedbackFormDTO.java
@@ -1,0 +1,8 @@
+package com.example.api.dto;
+
+import java.time.LocalDateTime;
+
+public record FeedbackFormDTO(
+        String ticketId,
+        LocalDateTime dateOfResolution
+) {}

--- a/api/src/main/java/com/example/api/dto/SubmitFeedbackRequest.java
+++ b/api/src/main/java/com/example/api/dto/SubmitFeedbackRequest.java
@@ -1,0 +1,13 @@
+package com.example.api.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+
+public record SubmitFeedbackRequest(
+        @Min(1) @Max(5) Integer overallSatisfaction,
+        @Min(1) @Max(5) Integer resolutionEffectiveness,
+        @Min(1) @Max(5) Integer communicationSupport,
+        @Min(1) @Max(5) Integer timeliness,
+        @Size(max = 4000) String comments
+) {}

--- a/api/src/main/java/com/example/api/dto/TicketDto.java
+++ b/api/src/main/java/com/example/api/dto/TicketDto.java
@@ -4,6 +4,7 @@ import com.example.api.enums.Mode;
 import com.example.api.enums.Priority;
 import com.example.api.enums.Severity;
 import com.example.api.enums.TicketStatus;
+import com.example.api.enums.FeedbackStatus;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
@@ -43,4 +44,6 @@ public class TicketDto {
     private boolean isMaster;
     private String masterId;
     private LocalDateTime lastModified;
+    private LocalDateTime resolvedAt;
+    private FeedbackStatus feedbackStatus;
 }

--- a/api/src/main/java/com/example/api/dto/TicketFeedbackResponse.java
+++ b/api/src/main/java/com/example/api/dto/TicketFeedbackResponse.java
@@ -1,0 +1,14 @@
+package com.example.api.dto;
+
+import java.time.LocalDateTime;
+
+public record TicketFeedbackResponse(
+        String ticketId,
+        Integer overallSatisfaction,
+        Integer resolutionEffectiveness,
+        Integer communicationSupport,
+        Integer timeliness,
+        String comments,
+        LocalDateTime submittedAt,
+        String submittedBy
+) {}

--- a/api/src/main/java/com/example/api/enums/FeedbackStatus.java
+++ b/api/src/main/java/com/example/api/enums/FeedbackStatus.java
@@ -1,0 +1,7 @@
+package com.example.api.enums;
+
+public enum FeedbackStatus {
+    PENDING,
+    PROVIDED,
+    NOT_PROVIDED
+}

--- a/api/src/main/java/com/example/api/mapper/DtoMapper.java
+++ b/api/src/main/java/com/example/api/mapper/DtoMapper.java
@@ -65,6 +65,8 @@ public class DtoMapper {
         dto.setMaster(ticket.isMaster());
         dto.setMasterId(ticket.getMasterId() != null ? String.valueOf(ticket.getMasterId()) : null);
         dto.setLastModified(ticket.getLastModified());
+        dto.setResolvedAt(ticket.getResolvedAt());
+        dto.setFeedbackStatus(ticket.getFeedbackStatus());
         return dto;
     }
 

--- a/api/src/main/java/com/example/api/models/Ticket.java
+++ b/api/src/main/java/com/example/api/models/Ticket.java
@@ -4,6 +4,7 @@ import com.example.api.enums.Mode;
 import com.example.api.enums.Priority;
 import com.example.api.enums.Severity;
 import com.example.api.enums.TicketStatus;
+import com.example.api.enums.FeedbackStatus;
 import com.example.api.models.Status;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
@@ -73,6 +74,13 @@ public class Ticket {
     private String masterId;
     @Column(name = "last_modified")
     private LocalDateTime lastModified;
+
+    @Column(name = "resolved_at")
+    private LocalDateTime resolvedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "feedback_status")
+    private FeedbackStatus feedbackStatus;
 
     @ManyToOne
     @JoinColumn(name = "status_id", referencedColumnName = "status_id")

--- a/api/src/main/java/com/example/api/models/TicketFeedback.java
+++ b/api/src/main/java/com/example/api/models/TicketFeedback.java
@@ -1,0 +1,42 @@
+package com.example.api.models;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "ticket_feedback")
+@Getter
+@Setter
+public class TicketFeedback {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "feedback_id")
+    private Long feedbackId;
+
+    @Column(name = "ticket_id", nullable = false)
+    private String ticketId;
+
+    @Column(name = "submitted_by")
+    private String submittedBy;
+
+    @Column(name = "submitted_at", nullable = false)
+    private LocalDateTime submittedAt = LocalDateTime.now();
+
+    @Column(name = "overall_satisfaction", nullable = false)
+    private Integer overallSatisfaction;
+
+    @Column(name = "resolution_effectiveness", nullable = false)
+    private Integer resolutionEffectiveness;
+
+    @Column(name = "communication_support", nullable = false)
+    private Integer communicationSupport;
+
+    @Column(name = "timeliness", nullable = false)
+    private Integer timeliness;
+
+    @Column(name = "comments", columnDefinition = "TEXT")
+    private String comments;
+}

--- a/api/src/main/java/com/example/api/repository/TicketFeedbackRepository.java
+++ b/api/src/main/java/com/example/api/repository/TicketFeedbackRepository.java
@@ -1,0 +1,13 @@
+package com.example.api.repository;
+
+import com.example.api.models.TicketFeedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface TicketFeedbackRepository extends JpaRepository<TicketFeedback, Long>, JpaSpecificationExecutor<TicketFeedback> {
+    Optional<TicketFeedback> findByTicketId(String ticketId);
+}

--- a/api/src/main/java/com/example/api/repository/TicketRepository.java
+++ b/api/src/main/java/com/example/api/repository/TicketRepository.java
@@ -20,6 +20,8 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
 
     List<Ticket> findByTicketStatusAndLastModifiedBefore(TicketStatus ticketStatus, LocalDateTime time);
 
+    List<Ticket> findByTicketStatusAndResolvedAtBefore(TicketStatus ticketStatus, LocalDateTime time);
+
     @Query("SELECT t FROM Ticket t LEFT JOIN t.status s " +
             "WHERE (:statusId IS NULL OR s.statusId = :statusId) " +
             "AND (:master IS NULL OR t.isMaster = :master) " +

--- a/api/src/main/java/com/example/api/service/TicketFeedbackService.java
+++ b/api/src/main/java/com/example/api/service/TicketFeedbackService.java
@@ -1,0 +1,129 @@
+package com.example.api.service;
+
+import com.example.api.dto.FeedbackFormDTO;
+import com.example.api.dto.SubmitFeedbackRequest;
+import com.example.api.dto.TicketFeedbackResponse;
+import com.example.api.enums.FeedbackStatus;
+import com.example.api.enums.TicketStatus;
+import com.example.api.models.Ticket;
+import com.example.api.models.TicketFeedback;
+import com.example.api.repository.TicketFeedbackRepository;
+import com.example.api.repository.TicketRepository;
+import com.example.api.repository.StatusMasterRepository;
+import com.example.api.service.TicketStatusWorkflowService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+public class TicketFeedbackService {
+    private final TicketRepository ticketRepository;
+    private final TicketFeedbackRepository feedbackRepository;
+    private final TicketStatusWorkflowService workflowService;
+    private final StatusMasterRepository statusMasterRepository;
+
+    public TicketFeedbackService(TicketRepository ticketRepository,
+                                 TicketFeedbackRepository feedbackRepository,
+                                 TicketStatusWorkflowService workflowService,
+                                 StatusMasterRepository statusMasterRepository) {
+        this.ticketRepository = ticketRepository;
+        this.feedbackRepository = feedbackRepository;
+        this.workflowService = workflowService;
+        this.statusMasterRepository = statusMasterRepository;
+    }
+
+    public FeedbackFormDTO getForm(String ticketId, String currentUserId) {
+        Ticket ticket = ticketRepository.findById(ticketId).orElseThrow();
+        if (!ticket.getUserId().equals(currentUserId)) {
+            throw new RuntimeException("Forbidden");
+        }
+        if (ticket.getTicketStatus() != TicketStatus.RESOLVED) {
+            throw new RuntimeException("Ticket not resolved");
+        }
+        if (ticket.getResolvedAt() == null ||
+                ticket.getResolvedAt().plusHours(72).isBefore(LocalDateTime.now())) {
+            throw new RuntimeException("Feedback window closed");
+        }
+        if (feedbackRepository.findByTicketId(ticketId).isPresent()) {
+            throw new RuntimeException("Feedback already submitted");
+        }
+        return new FeedbackFormDTO(ticketId, ticket.getResolvedAt());
+    }
+
+    public TicketFeedbackResponse submit(String ticketId, String currentUserId, SubmitFeedbackRequest req) {
+        Ticket ticket = ticketRepository.findById(ticketId).orElseThrow();
+        if (!ticket.getUserId().equals(currentUserId)) {
+            throw new RuntimeException("Forbidden");
+        }
+        if (feedbackRepository.findByTicketId(ticketId).isPresent()) {
+            throw new RuntimeException("Feedback already submitted");
+        }
+        TicketFeedback feedback = new TicketFeedback();
+        feedback.setTicketId(ticketId);
+        feedback.setSubmittedBy(currentUserId);
+        feedback.setOverallSatisfaction(req.overallSatisfaction());
+        feedback.setResolutionEffectiveness(req.resolutionEffectiveness());
+        feedback.setCommunicationSupport(req.communicationSupport());
+        feedback.setTimeliness(req.timeliness());
+        feedback.setComments(req.comments());
+        TicketFeedback saved = feedbackRepository.save(feedback);
+
+        ticket.setTicketStatus(TicketStatus.CLOSED);
+        ticket.setFeedbackStatus(FeedbackStatus.PROVIDED);
+        String closedId = workflowService.getStatusIdByCode(TicketStatus.CLOSED.name());
+        if (closedId != null) {
+            statusMasterRepository.findById(closedId).ifPresent(ticket::setStatus);
+        }
+        ticketRepository.save(ticket);
+        return new TicketFeedbackResponse(ticketId, saved.getOverallSatisfaction(),
+                saved.getResolutionEffectiveness(), saved.getCommunicationSupport(),
+                saved.getTimeliness(), saved.getComments(), saved.getSubmittedAt(), saved.getSubmittedBy());
+    }
+
+    public Optional<TicketFeedbackResponse> getFeedback(String ticketId, String currentUserId) {
+        Ticket ticket = ticketRepository.findById(ticketId).orElseThrow();
+        if (!ticket.getUserId().equals(currentUserId)) {
+            throw new RuntimeException("Forbidden");
+        }
+        return feedbackRepository.findByTicketId(ticketId)
+                .map(f -> new TicketFeedbackResponse(ticketId, f.getOverallSatisfaction(),
+                        f.getResolutionEffectiveness(), f.getCommunicationSupport(),
+                        f.getTimeliness(), f.getComments(), f.getSubmittedAt(), f.getSubmittedBy()));
+    }
+
+    public Page<TicketFeedback> search(Optional<String> ticketId, Optional<FeedbackStatus> status,
+                                       Optional<LocalDateTime> from, Optional<LocalDateTime> to, Pageable pageable) {
+        Specification<TicketFeedback> spec = Specification.where(null);
+        if (ticketId.isPresent()) {
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("ticketId"), ticketId.get()));
+        }
+        if (from.isPresent()) {
+            spec = spec.and((root, query, cb) -> cb.greaterThanOrEqualTo(root.get("submittedAt"), from.get()));
+        }
+        if (to.isPresent()) {
+            spec = spec.and((root, query, cb) -> cb.lessThanOrEqualTo(root.get("submittedAt"), to.get()));
+        }
+        return feedbackRepository.findAll(spec, pageable);
+    }
+
+    @Scheduled(fixedRate = 1800000)
+    public void autoCloseUnreviewed() {
+        LocalDateTime cutoff = LocalDateTime.now().minusHours(72);
+        for (Ticket t : ticketRepository.findByTicketStatusAndResolvedAtBefore(TicketStatus.RESOLVED, cutoff)) {
+            if (feedbackRepository.findByTicketId(t.getId()).isEmpty()) {
+                t.setTicketStatus(TicketStatus.CLOSED);
+                t.setFeedbackStatus(FeedbackStatus.NOT_PROVIDED);
+                String closedId = workflowService.getStatusIdByCode(TicketStatus.CLOSED.name());
+                if (closedId != null) {
+                    statusMasterRepository.findById(closedId).ifPresent(t::setStatus);
+                }
+                ticketRepository.save(t);
+            }
+        }
+    }
+}

--- a/api/src/main/java/com/example/api/service/TicketService.java
+++ b/api/src/main/java/com/example/api/service/TicketService.java
@@ -14,6 +14,7 @@ import com.example.api.service.AssignmentHistoryService;
 import com.example.api.service.StatusHistoryService;
 import com.example.api.service.TicketStatusWorkflowService;
 import com.example.api.enums.TicketStatus;
+import com.example.api.enums.FeedbackStatus;
 import com.example.api.typesense.TypesenseClient;
 import com.example.notification.enums.ChannelType;
 import com.example.notification.service.NotificationService;
@@ -188,6 +189,10 @@ public class TicketService {
         if (updated.getCategory() != null) existing.setCategory(updated.getCategory());
         if (updatedStatus != null) existing.setTicketStatus(updatedStatus);
         if (updatedStatusId != null) statusMasterRepository.findById(updatedStatusId).ifPresent(existing::setStatus);
+        if (updatedStatus == TicketStatus.RESOLVED && existing.getResolvedAt() == null) {
+            existing.setResolvedAt(LocalDateTime.now());
+            existing.setFeedbackStatus(FeedbackStatus.PENDING);
+        }
         if (updated.getSubCategory() != null) existing.setSubCategory(updated.getSubCategory());
         if (updated.getPriority() != null) existing.setPriority(updated.getPriority());
         if (updated.getSeverity() != null) existing.setSeverity(updated.getSeverity());

--- a/api/src/main/resources/db/migration/V1__ticket_feedback.sql
+++ b/api/src/main/resources/db/migration/V1__ticket_feedback.sql
@@ -1,0 +1,22 @@
+CREATE TABLE ticket_feedback (
+  feedback_id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  ticket_id VARCHAR(36) NOT NULL,
+  submitted_by VARCHAR(36) NULL,
+  submitted_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  overall_satisfaction TINYINT NOT NULL,
+  resolution_effectiveness TINYINT NOT NULL,
+  communication_support TINYINT NOT NULL,
+  timeliness TINYINT NOT NULL,
+  comments TEXT NULL,
+  CONSTRAINT fk_feedback_ticket
+    FOREIGN KEY (ticket_id) REFERENCES tickets(ticket_id)
+    ON DELETE CASCADE,
+  CONSTRAINT chk_feedback_range_overall              CHECK (overall_satisfaction BETWEEN 1 AND 5),
+  CONSTRAINT chk_feedback_range_resolution_effective CHECK (resolution_effectiveness BETWEEN 1 AND 5),
+  CONSTRAINT chk_feedback_range_comm_support         CHECK (communication_support BETWEEN 1 AND 5),
+  CONSTRAINT chk_feedback_range_timeliness           CHECK (timeliness BETWEEN 1 AND 5),
+  UNIQUE KEY uq_ticket_feedback_one_per_ticket (ticket_id)
+);
+
+ALTER TABLE tickets ADD COLUMN IF NOT EXISTS resolved_at DATETIME NULL;
+ALTER TABLE tickets ADD COLUMN IF NOT EXISTS feedback_status ENUM('PENDING','PROVIDED','NOT_PROVIDED') DEFAULT 'PENDING';

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -4,6 +4,7 @@ import RaiseTicket from './pages/RaiseTicket';
 import AllTickets from './pages/AllTickets';
 import KnowledgeBase from './pages/KnowledgeBase';
 import TicketDetails from './pages/TicketDetails';
+import CustomerSatisfactionForm from './pages/CustomerSatisfactionForm';
 import CategoriesMaster from './pages/CategoriesMaster';
 import EscalationMaster from './pages/EscalationMaster';
 import RoleMaster from './pages/RoleMaster';
@@ -20,6 +21,7 @@ function App() {
         <Route path="create-ticket" element={<RaiseTicket />} />
         <Route path="tickets" element={<AllTickets />} />
         <Route path="tickets/:ticketId" element={<TicketDetails />} />
+        <Route path="tickets/:ticketId/feedback" element={<CustomerSatisfactionForm />} />
         <Route path="knowledge-base" element={<KnowledgeBase />} />
         <Route path="categories-master" element={<CategoriesMaster />} />
         <Route path="escalation-master" element={<EscalationMaster />} />

--- a/ui/src/components/Feedback/StarRating.tsx
+++ b/ui/src/components/Feedback/StarRating.tsx
@@ -1,0 +1,31 @@
+import { Box, Rating, Typography } from '@mui/material';
+import React from 'react';
+
+const labels: Record<number, string> = {
+  1: 'Very Poor',
+  2: 'Poor',
+  3: 'Okay',
+  4: 'Good',
+  5: 'Excellent',
+};
+
+interface StarRatingProps {
+  label: string;
+  value: number | null;
+  onChange: (value: number) => void;
+}
+
+const StarRating: React.FC<StarRatingProps> = ({ label, value, onChange }) => {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', mt: 2 }}>
+      <Typography sx={{ width: 220 }}>{label}</Typography>
+      <Rating
+        value={value}
+        onChange={(_, newValue) => onChange(newValue || 0)}
+      />
+      {value !== null && <Box sx={{ ml: 2 }}>{labels[value]}</Box>}
+    </Box>
+  );
+};
+
+export default StarRating;

--- a/ui/src/pages/CustomerSatisfactionForm.tsx
+++ b/ui/src/pages/CustomerSatisfactionForm.tsx
@@ -1,0 +1,99 @@
+import { Card, Button, TextField, Typography } from '@mui/material';
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import StarRating from '../components/Feedback/StarRating';
+import { SubmitFeedbackRequest, submitFeedback, getFeedbackForm, getFeedback } from '../services/FeedbackService';
+import { useSnackbar } from '../context/SnackbarContext';
+
+const CustomerSatisfactionForm: React.FC = () => {
+  const { ticketId } = useParams();
+  const navigate = useNavigate();
+  const { showMessage } = useSnackbar();
+
+  const [formData, setFormData] = useState<SubmitFeedbackRequest>({
+    overallSatisfaction: 0,
+    resolutionEffectiveness: 0,
+    communicationSupport: 0,
+    timeliness: 0,
+    comments: ''
+  });
+  const [resolvedAt, setResolvedAt] = useState<string>('');
+  const [loading, setLoading] = useState(false);
+  const [viewMode, setViewMode] = useState(false);
+
+  useEffect(() => {
+    if (!ticketId) return;
+    getFeedback(ticketId).then(res => {
+      if (res.data) {
+        const f = res.data;
+        setFormData({
+          overallSatisfaction: f.overallSatisfaction,
+          resolutionEffectiveness: f.resolutionEffectiveness,
+          communicationSupport: f.communicationSupport,
+          timeliness: f.timeliness,
+          comments: f.comments
+        });
+        setResolvedAt(f.submittedAt);
+        setViewMode(true);
+      } else {
+        getFeedbackForm(ticketId).then(r => {
+          setResolvedAt(r.data.dateOfResolution);
+        });
+      }
+    }).catch(() => {
+      getFeedbackForm(ticketId!).then(r => setResolvedAt(r.data.dateOfResolution));
+    });
+  }, [ticketId]);
+
+  const handleChange = (field: keyof SubmitFeedbackRequest) => (value: number | React.ChangeEvent<HTMLInputElement>) => {
+    const val = typeof value === 'number' ? value : parseInt(value.target.value, 10);
+    setFormData(prev => ({ ...prev, [field]: val }));
+  };
+
+  const handleSubmit = () => {
+    if (!ticketId) return;
+    setLoading(true);
+    submitFeedback(ticketId, formData)
+      .then(() => {
+        showMessage('Feedback submitted', 'success');
+        navigate(`/tickets/${ticketId}`);
+      })
+      .finally(() => setLoading(false));
+  };
+
+  return (
+    <Card sx={{ p: 3, maxWidth: 600, margin: '20px auto' }}>
+      <Typography variant="h5" gutterBottom>
+        Customer Satisfaction Form
+      </Typography>
+      <Typography>Ticket ID: {ticketId}</Typography>
+      <Typography>Date of Resolution: {resolvedAt ? new Date(resolvedAt).toLocaleString() : ''}</Typography>
+      <StarRating label="Overall Satisfaction" value={formData.overallSatisfaction} onChange={handleChange('overallSatisfaction')} />
+      <StarRating label="Resolution Effectiveness" value={formData.resolutionEffectiveness} onChange={handleChange('resolutionEffectiveness')} />
+      <StarRating label="Communication and Support" value={formData.communicationSupport} onChange={handleChange('communicationSupport')} />
+      <StarRating label="Timeliness" value={formData.timeliness} onChange={handleChange('timeliness')} />
+      <TextField
+        label="Additional Comments/Feedback"
+        multiline
+        rows={4}
+        value={formData.comments}
+        onChange={handleChange('comments') as any}
+        fullWidth
+        sx={{ mt: 2 }}
+        disabled={viewMode}
+      />
+      <div style={{ marginTop: 16, display: 'flex', gap: 8 }}>
+        {!viewMode && (
+          <Button variant="contained" onClick={handleSubmit} disabled={loading}>
+            Submit
+          </Button>
+        )}
+        <Button variant="outlined" onClick={() => navigate(`/tickets/${ticketId}`)}>
+          Cancel
+        </Button>
+      </div>
+    </Card>
+  );
+};
+
+export default CustomerSatisfactionForm;

--- a/ui/src/pages/TicketDetails.tsx
+++ b/ui/src/pages/TicketDetails.tsx
@@ -11,6 +11,8 @@ import CustomIconButton from '../components/UI/IconButton/CustomIconButton';
 import Switch from "@mui/material/Switch";
 import CommentsSection from "../components/Comments/CommentsSection";
 import HistorySidebar from "../components/HistorySidebar";
+import Button from '@mui/material/Button';
+import { useNavigate } from 'react-router-dom';
 import { useTranslation } from "react-i18next";
 import { useSnackbar } from "../context/SnackbarContext";
 import { checkFieldAccess } from "../utils/permissions";
@@ -40,10 +42,13 @@ interface Ticket {
     assignTo?: string;
     assignedToLevel?: string;
     assignedTo?: string;
+    resolvedAt?: string;
+    feedbackStatus?: string;
 }
 
 const TicketDetails: React.FC = () => {
     const { ticketId } = useParams();
+    const navigate = useNavigate();
     const { data: ticket, apiHandler: getTicketApiHandler } = useApi<any>();
     const { apiHandler: updateTicketApiHandler } = useApi<any>();
     const { showMessage } = useSnackbar();
@@ -140,6 +145,16 @@ const TicketDetails: React.FC = () => {
                             size="small"
                         />
                         <span className="ms-1">{t('Reopen Ticket')}</span>
+                        {ticket.feedbackStatus === 'PENDING' && (
+                            <Button variant="outlined" size="small" className="ms-3" onClick={() => navigate(`/tickets/${ticketId}/feedback`)}>
+                                Submit Feedback
+                            </Button>
+                        )}
+                        {ticket.feedbackStatus === 'PROVIDED' && (
+                            <Button variant="outlined" size="small" className="ms-3" onClick={() => navigate(`/tickets/${ticketId}/feedback`)}>
+                                View Feedback
+                            </Button>
+                        )}
                     </div>
                 )}
 

--- a/ui/src/services/FeedbackService.ts
+++ b/ui/src/services/FeedbackService.ts
@@ -1,0 +1,22 @@
+import axios from 'axios';
+import { BASE_URL } from './api';
+
+export type SubmitFeedbackRequest = {
+  overallSatisfaction: number;
+  resolutionEffectiveness: number;
+  communicationSupport: number;
+  timeliness: number;
+  comments?: string;
+};
+
+export function getFeedbackForm(ticketId: string) {
+  return axios.get(`${BASE_URL}/tickets/${ticketId}/feedback/form`);
+}
+
+export function submitFeedback(ticketId: string, body: SubmitFeedbackRequest) {
+  return axios.post(`${BASE_URL}/tickets/${ticketId}/feedback`, body);
+}
+
+export function getFeedback(ticketId: string) {
+  return axios.get(`${BASE_URL}/tickets/${ticketId}/feedback`);
+}


### PR DESCRIPTION
## Summary
- add ticket feedback entity and CRUD API
- close resolved tickets without feedback after 72h
- implement frontend form for submitting/viewing feedback

## Testing
- `./gradlew test` (fails: Could not download typesense-java-0.2.0.jar, status code 403)
- `npm test -- --watchAll=false` (fails: Cannot find module 'react-router-dom')


------
https://chatgpt.com/codex/tasks/task_e_689d6e0312b08332bf6dac0ae218b35d