### PR TITLE
Display reported date in Raise Ticket header

### DIFF
--- a/ui/src/components/RaiseTicket/RequestDetails.tsx
+++ b/ui/src/components/RaiseTicket/RequestDetails.tsx
@@ -21,9 +21,9 @@ const modeOptions: DropdownOption[] = [
     { label: "Email", value: "Email" }
 ];
 
-const RequestDetails: React.FC<RequestDetailsProps> = ({ register, control, errors, setValue, disableAll = false, isFieldSetDisabled }) => {
+const RequestDetails: React.FC<RequestDetailsProps> = ({ register, control, errors, setValue, disableAll = false, isFieldSetDisabled, createMode }) => {
     const showTicketId = false; // Hide Ticket ID field in create form
-    const showReportedDate = checkFieldAccess('requestDetails', 'reportedDate');
+    const showReportedDate = checkFieldAccess('requestDetails', 'reportedDate') && !createMode;
     const showModeDropdown = checkFieldAccess('requestDetails', 'mode');
 
     const ticketId = useWatch({ control, name: 'ticketId' });
@@ -78,7 +78,6 @@ const RequestDetails: React.FC<RequestDetailsProps> = ({ register, control, erro
                             required
                             errors={errors}
                             label="Reported Date"
-                            defaultValue={new Date().toISOString().slice(0, 10)}
                             disabled
                         />
                     </div>

--- a/ui/src/components/Title.tsx
+++ b/ui/src/components/Title.tsx
@@ -4,15 +4,16 @@ import { useTranslation } from "react-i18next";
 interface TitleProps {
     text?: string;
     textKey?: string;
+    rightContent?: React.ReactNode;
 }
 
-const Title: React.FC<TitleProps> = ({ text, textKey }) => {
+const Title: React.FC<TitleProps> = ({ text, textKey, rightContent }) => {
     const { t } = useTranslation();
     const label = textKey ? t(textKey) : t(text ?? "");
     return (
         <div className="d-flex justify-content-between align-items-center mb-3">
             <h2 className="m-0">{label}</h2>
-            <div>{/* Global icons placeholder */}</div>
+            <div>{rightContent}</div>
         </div>
     );
 };

--- a/ui/src/pages/RaiseTicket.tsx
+++ b/ui/src/pages/RaiseTicket.tsx
@@ -3,7 +3,7 @@ import RequestDetails from "../components/RaiseTicket/RequestDetails";
 import RequestorDetails from "../components/RaiseTicket/RequestorDetails";
 import TicketDetails from "../components/RaiseTicket/TicketDetails";
 import SuccessfulModal from "../components/RaiseTicket/SuccessfulModal";
-import { useContext, useEffect, useState } from "react";
+import { useContext, useState } from "react";
 import Title from "../components/Title";
 import LinkToMasterTicketModal from "../components/RaiseTicket/LinkToMasterTicketModal";
 import GenericButton from "../components/UI/Button";
@@ -11,13 +11,16 @@ import { useApi } from "../hooks/useApi";
 import { addTicket } from "../services/TicketService";
 import { DevModeContext } from "../context/DevModeContext";
 import CustomIconButton from "../components/UI/IconButton/CustomIconButton";
+import { useTranslation } from "react-i18next";
 
 const RaiseTicket: React.FC<any> = () => {
     const { register, handleSubmit, control, setValue, getValues, formState: { errors } } = useForm();
+    const reportedDate = new Date().toISOString().slice(0, 10);
 
     const { data, pending, error, success, apiHandler } = useApi();
 
     const { devMode } = useContext(DevModeContext);
+    const { t } = useTranslation();
 
     const isMaster = useWatch({ control, name: 'isMaster' });
 
@@ -40,7 +43,7 @@ const RaiseTicket: React.FC<any> = () => {
             requestorEmailId: emailId,
             requestorMobileNo: mobileNo,
             stakeholder,
-            reportedDate: new Date().toISOString().slice(0, 10)
+            reportedDate
         };
 
         apiHandler(() => addTicket(payload))
@@ -56,7 +59,7 @@ const RaiseTicket: React.FC<any> = () => {
 
     return (
         <div className="container pb-5">
-            <Title text="Raise Ticket" />
+            <Title text="Raise Ticket" rightContent={<span>{t('Reported Date')}: {reportedDate}</span>} />
             {devMode && <CustomIconButton icon="listAlt" onClick={() => console.table(getValues())} />}
             <form onSubmit={handleSubmit(onSubmit)}>
                 {/* Request Details */}


### PR DESCRIPTION
## Summary
- Render reported date as text in the Raise Ticket page header
- Hide reported date input when creating a ticket while keeping it for other views
- Allow Title component to accept optional right-side content

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_68a3144d02f0833295c54b2502c79999