### PR TITLE
Use numeric role IDs for roles and permissions

### DIFF
--- a/api/src/main/java/com/example/api/controller/AuthController.java
+++ b/api/src/main/java/com/example/api/controller/AuthController.java
@@ -45,9 +45,13 @@ public class AuthController {
                     session.setAttribute("roles", emp.getRoles());
 
                     List<String> roles = emp.getRoles() == null ? List.of()
-                            : Arrays.asList(emp.getRoles().split("\\|")); // split roles into list
+                            : Arrays.asList(emp.getRoles().split("\\|"));
+                    List<Integer> roleIds = roles.stream()
+                            .filter(r -> !r.isBlank())
+                            .map(Integer::parseInt)
+                            .toList();
 
-                    RolePermission permissions = permissionService.mergeRolePermissions(roles);
+                    RolePermission permissions = permissionService.mergeRolePermissions(roleIds);
                     System.out.println("Perm: " + permissions);
 
                     return ResponseEntity.ok(Map.of(

--- a/api/src/main/java/com/example/api/controller/PermissionController.java
+++ b/api/src/main/java/com/example/api/controller/PermissionController.java
@@ -24,9 +24,9 @@ public class PermissionController {
         return ResponseEntity.ok(cfg);
     }
 
-    @GetMapping("/{role}")
-    public ResponseEntity<RolePermission> getRolePermission(@PathVariable String role) {
-        RolePermission perm = permissionService.getRolePermission(role);
+    @GetMapping("/{roleId}")
+    public ResponseEntity<RolePermission> getRolePermission(@PathVariable Integer roleId) {
+        RolePermission perm = permissionService.getRolePermission(roleId);
         if (perm == null) {
             return ResponseEntity.notFound().build();
         }
@@ -41,10 +41,10 @@ public class PermissionController {
         return ResponseEntity.ok().build();
     }
 
-    @PutMapping("/{role}")
-    public ResponseEntity<Void> updatePermission(@PathVariable String role,
+    @PutMapping("/{roleId}")
+    public ResponseEntity<Void> updatePermission(@PathVariable Integer roleId,
                                                  @RequestBody RolePermission permission) throws IOException {
-        permissionService.updateRolePermissions(role, permission);
+        permissionService.updateRolePermissions(roleId, permission);
         return ResponseEntity.ok().build();
     }
 

--- a/api/src/main/java/com/example/api/controller/RoleController.java
+++ b/api/src/main/java/com/example/api/controller/RoleController.java
@@ -28,28 +28,28 @@ public class RoleController {
         return ResponseEntity.ok(roleService.addRole(roleDto));
     }
 
-    @PutMapping("/{role}")
-    public ResponseEntity<Void> updateRole(@PathVariable String role, @RequestBody RoleDto roleDto) {
-        roleDto.setRole(role);
+    @PutMapping("/{roleId}")
+    public ResponseEntity<Void> updateRole(@PathVariable Integer roleId, @RequestBody RoleDto roleDto) {
+        roleDto.setRoleId(roleId);
         roleService.updateRole(roleDto);
         return ResponseEntity.ok().build();
     }
 
-    @PutMapping("/{role}/rename")
-    public ResponseEntity<Void> renameRole(@PathVariable String role, @RequestBody RoleDto roleDto) {
-        roleService.renameRole(role, roleDto.getRole(), roleDto.getUpdatedBy());
+    @PutMapping("/{roleId}/rename")
+    public ResponseEntity<Void> renameRole(@PathVariable Integer roleId, @RequestBody RoleDto roleDto) {
+        roleService.renameRole(roleId, roleDto.getRole(), roleDto.getUpdatedBy());
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping("/{role}")
-    public ResponseEntity<Void> deleteRole(@PathVariable String role,
+    @DeleteMapping("/{roleId}")
+    public ResponseEntity<Void> deleteRole(@PathVariable Integer roleId,
                                            @RequestParam(required = false, defaultValue = "false") boolean hard) {
-        roleService.deleteRoles(Collections.singletonList(role), hard);
+        roleService.deleteRoles(Collections.singletonList(roleId), hard);
         return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping
-    public ResponseEntity<Void> deleteRoles(@RequestParam List<String> ids,
+    public ResponseEntity<Void> deleteRoles(@RequestParam List<Integer> ids,
                                             @RequestParam(required = false, defaultValue = "false") boolean hard) {
         roleService.deleteRoles(ids, hard);
         return ResponseEntity.noContent().build();

--- a/api/src/main/java/com/example/api/controller/TicketStatusWorkflowController.java
+++ b/api/src/main/java/com/example/api/controller/TicketStatusWorkflowController.java
@@ -33,6 +33,7 @@ public class TicketStatusWorkflowController {
 
     @PostMapping("/mappings")
     public ResponseEntity<Map<String, List<TicketStatusWorkflow>>> getMappingsByRole(@RequestBody List<String> roles) {
-        return ResponseEntity.ok(service.getMappingsByRoles(roles));
+        List<Integer> ids = roles.stream().map(Integer::parseInt).toList();
+        return ResponseEntity.ok(service.getMappingsByRoles(ids));
     }
 }

--- a/api/src/main/java/com/example/api/dto/PermissionsConfigDto.java
+++ b/api/src/main/java/com/example/api/dto/PermissionsConfigDto.java
@@ -9,5 +9,5 @@ import java.util.Map;
 @Getter
 @Setter
 public class PermissionsConfigDto {
-    private Map<String, RolePermission> roles;
+    private Map<Integer, RolePermission> roles;
 }

--- a/api/src/main/java/com/example/api/dto/RoleDto.java
+++ b/api/src/main/java/com/example/api/dto/RoleDto.java
@@ -1,9 +1,6 @@
 package com.example.api.dto;
 
 import com.example.api.permissions.RolePermission;
-import jakarta.persistence.Column;
-import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -13,6 +10,7 @@ import java.util.Map;
 @Setter
 @Getter
 public class RoleDto {
+    private Integer roleId;
     private String role;
     private String createdBy;
     private LocalDateTime createdOn;

--- a/api/src/main/java/com/example/api/mapper/DtoMapper.java
+++ b/api/src/main/java/com/example/api/mapper/DtoMapper.java
@@ -74,6 +74,7 @@ public class DtoMapper {
     public static RoleDto toRoleDto(Role role) {
         if(role == null) return null;
         RoleDto dto = new RoleDto();
+        dto.setRoleId(role.getRoleId());
         dto.setRole(role.getRole());
         dto.setCreatedBy(role.getCreatedBy());
         dto.setCreatedOn(role.getCreatedOn());

--- a/api/src/main/java/com/example/api/models/Role.java
+++ b/api/src/main/java/com/example/api/models/Role.java
@@ -1,10 +1,6 @@
 package com.example.api.models;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -16,6 +12,10 @@ import java.time.LocalDateTime;
 @Setter
 public class Role {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "role_id")
+    private Integer roleId;
+
     @Column(name = "role", length = 100)
     private String role;
 

--- a/api/src/main/java/com/example/api/permissions/PermissionsConfig.java
+++ b/api/src/main/java/com/example/api/permissions/PermissionsConfig.java
@@ -8,5 +8,5 @@ import java.util.Map;
 @Getter
 @Setter
 public class PermissionsConfig {
-    private Map<String, RolePermission> roles;
+    private Map<Integer, RolePermission> roles;
 }

--- a/api/src/main/java/com/example/api/repository/RoleRepository.java
+++ b/api/src/main/java/com/example/api/repository/RoleRepository.java
@@ -8,13 +8,13 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
-public interface RoleRepository extends JpaRepository<Role, String> {
+public interface RoleRepository extends JpaRepository<Role, Integer> {
     List<Role> findByIsDeletedFalse();
 
     @Modifying
     @Transactional
-    @Query(value = "UPDATE role_permission_config SET role = :newRole, updated_by = :updatedBy, updated_on = :updatedOn WHERE role = :oldRole", nativeQuery = true)
-    void renameRole(@Param("oldRole") String oldRole,
+    @Query(value = "UPDATE role_permission_config SET role = :newRole, updated_by = :updatedBy, updated_on = :updatedOn WHERE role_id = :roleId", nativeQuery = true)
+    void renameRole(@Param("roleId") Integer roleId,
                     @Param("newRole") String newRole,
                     @Param("updatedBy") String updatedBy,
                     @Param("updatedOn") java.time.LocalDateTime updatedOn);

--- a/api/src/main/java/com/example/api/service/LevelService.java
+++ b/api/src/main/java/com/example/api/service/LevelService.java
@@ -42,6 +42,7 @@ public class LevelService {
                         dto.setEmailId(user.getEmailId());
                         dto.setMobileNo(user.getMobileNo());
                         dto.setOffice(user.getOffice());
+                        dto.setRoles(user.getRoles());
                         userDtos.add(dto);
                     }
                     return userDtos;

--- a/api/src/main/java/com/example/api/service/PermissionService.java
+++ b/api/src/main/java/com/example/api/service/PermissionService.java
@@ -23,19 +23,19 @@ public class PermissionService {
 
     @PostConstruct
     public void loadPermissions() throws IOException {
-        Map<String, RolePermission> map = new HashMap<>();
+        Map<Integer, RolePermission> map = new HashMap<>();
         for (Role rpc : repository.findByIsDeletedFalse()) {
             RolePermission rp = objectMapper.readValue(rpc.getPermissions(), RolePermission.class);
-            map.put(rpc.getRole(), rp);
+            map.put(rpc.getRoleId(), rp);
         }
         config = new PermissionsConfig();
         config.setRoles(map);
     }
 
-    public void updateRolePermissions(String role, RolePermission permission) throws IOException {
+    public void updateRolePermissions(Integer roleId, RolePermission permission) throws IOException {
         String json = objectMapper.writeValueAsString(permission);
         Role rpc = new Role();
-        rpc.setRole(role);
+        rpc.setRoleId(roleId);
         rpc.setPermissions(json);
         java.time.LocalDateTime now = java.time.LocalDateTime.now();
 //        if (isNew) {
@@ -53,16 +53,16 @@ public class PermissionService {
         if (config.getRoles() == null) {
             config.setRoles(new HashMap<>());
         }
-        config.getRoles().put(role, permission);
+        config.getRoles().put(roleId, permission);
     }
 
     public void overwritePermissions(PermissionsConfig permissions) throws IOException {
         repository.deleteAll();
         if (permissions != null && permissions.getRoles() != null) {
-            for (Map.Entry<String, RolePermission> entry : permissions.getRoles().entrySet()) {
+            for (Map.Entry<Integer, RolePermission> entry : permissions.getRoles().entrySet()) {
                 String json = objectMapper.writeValueAsString(entry.getValue());
                 Role rpc = new Role();
-                rpc.setRole(entry.getKey());
+                rpc.setRoleId(entry.getKey());
                 rpc.setPermissions(json);
                 java.time.LocalDateTime now = java.time.LocalDateTime.now();
                 rpc.setCreatedOn(now);
@@ -76,21 +76,21 @@ public class PermissionService {
         loadPermissions();
     }
 
-    public Map<String, RolePermission> getAllRolePermissions() {
+    public Map<Integer, RolePermission> getAllRolePermissions() {
         if (config == null || config.getRoles() == null) {
             return Collections.emptyMap();
         }
         return config.getRoles();
     }
 
-    public RolePermission getRolePermission(String role) {
+    public RolePermission getRolePermission(Integer roleId) {
         if (config == null || config.getRoles() == null) {
             return null;
         }
-        return config.getRoles().get(role);
+        return config.getRoles().get(roleId);
     }
 
-    private List<RolePermission> getRolePermissions(List<String> roles) {
+    private List<RolePermission> getRolePermissions(List<Integer> roles) {
         List<RolePermission> list = new ArrayList<>();
         if (config == null || config.getRoles() == null) {
             return list;
@@ -104,7 +104,7 @@ public class PermissionService {
         return list;
     }
 
-    public boolean hasSidebarAccess(List<String> roles, String key) {
+    public boolean hasSidebarAccess(List<Integer> roles, String key) {
         return getRolePermissions(roles).stream()
                 .map(RolePermission::getSidebar)
                 .filter(Objects::nonNull)
@@ -118,7 +118,7 @@ public class PermissionService {
                 });
     }
 
-    public boolean hasFormAccess(List<String> roles, String form, String action) {
+    public boolean hasFormAccess(List<Integer> roles, String form, String action) {
         return getRolePermissions(roles).stream()
                 .map(RolePermission::getPages)
                 .filter(Objects::nonNull)
@@ -126,7 +126,7 @@ public class PermissionService {
                 .anyMatch(obj -> checkAction(obj, action));
     }
 
-    public boolean hasFieldAccess(List<String> roles, String form, String field) {
+    public boolean hasFieldAccess(List<Integer> roles, String form, String field) {
         return getRolePermissions(roles).stream()
                 .map(RolePermission::getPages)
                 .filter(Objects::nonNull)
@@ -152,7 +152,7 @@ public class PermissionService {
         return false;
     }
 
-    public RolePermission mergeRolePermissions(List<String> roles) {
+    public RolePermission mergeRolePermissions(List<Integer> roles) {
         RolePermission result = new RolePermission();
         result.setSidebar(new HashMap<>());
         result.setPages(new HashMap<>());

--- a/api/src/main/java/com/example/api/service/RoleService.java
+++ b/api/src/main/java/com/example/api/service/RoleService.java
@@ -45,10 +45,11 @@ public class RoleService {
 
         if(rolePermission == null) {
             if (permissionsList.length == 1) {
-                rolePermission = permissionService.getRolePermission(
-                        Arrays.stream(permissionsList).findFirst().orElse(null));
+                Integer id = Integer.valueOf(Arrays.stream(permissionsList).findFirst().orElse("0"));
+                rolePermission = permissionService.getRolePermission(id);
             } else {
-                rolePermission = permissionService.mergeRolePermissions(List.of(permissionsList));
+                List<Integer> ids = Arrays.stream(permissionsList).map(Integer::valueOf).toList();
+                rolePermission = permissionService.mergeRolePermissions(ids);
             }
         }
 
@@ -70,11 +71,11 @@ public class RoleService {
         return DtoMapper.toRoleDto(addedRole);
     }
 
-    public void deleteRoles(List<String> roles, boolean hardDelete) {
+    public void deleteRoles(List<Integer> roles, boolean hardDelete) {
         if (hardDelete && developerMode) {
             roleRepository.deleteAllById(roles);
         } else {
-            for (String r : roles) {
+            for (Integer r : roles) {
                 roleRepository.findById(r).ifPresent(role -> {
                     role.setDeleted(true);
                     roleRepository.save(role);
@@ -84,7 +85,7 @@ public class RoleService {
     }
 
     public void updateRole(RoleDto dto) {
-        roleRepository.findById(dto.getRole()).ifPresent(role -> {
+        roleRepository.findById(dto.getRoleId()).ifPresent(role -> {
             role.setUpdatedBy(dto.getUpdatedBy());
             role.setUpdatedOn(LocalDateTime.now());
             role.setAllowedStatusActionIds(dto.getAllowedStatusActionIds());
@@ -95,8 +96,8 @@ public class RoleService {
         });
     }
 
-    public void renameRole(String oldRole, String newRole, String updatedBy) {
-        roleRepository.renameRole(oldRole, newRole, updatedBy, LocalDateTime.now());
+    public void renameRole(Integer roleId, String newRole, String updatedBy) {
+        roleRepository.renameRole(roleId, newRole, updatedBy, LocalDateTime.now());
         try {
             permissionService.loadPermissions();
         } catch (Exception ignored) {

--- a/api/src/main/java/com/example/api/service/TicketStatusWorkflowService.java
+++ b/api/src/main/java/com/example/api/service/TicketStatusWorkflowService.java
@@ -50,7 +50,7 @@ public class TicketStatusWorkflowService {
                 .collect(Collectors.groupingBy(tsw -> String.valueOf(tsw.getCurrentStatus())));
     }
 
-    public Map<String, List<TicketStatusWorkflow>> getMappingsByRoles(List<String> roles) {
+    public Map<String, List<TicketStatusWorkflow>> getMappingsByRoles(List<Integer> roles) {
         Set<Integer> ids = new HashSet<>();
         if (roles == null || roles.isEmpty()) {
             return Map.of();

--- a/api/src/main/java/com/example/api/service/UserService.java
+++ b/api/src/main/java/com/example/api/service/UserService.java
@@ -30,6 +30,7 @@ public class UserService {
             dto.setEmailId(emp.getEmailId());
             dto.setMobileNo(emp.getMobileNo());
             dto.setOffice(emp.getOffice());
+            dto.setRoles(emp.getRoles());
             return dto;
         }).toList();
     }

--- a/ui/src/components/AllTickets/AssigneeDropdown.tsx
+++ b/ui/src/components/AllTickets/AssigneeDropdown.tsx
@@ -18,7 +18,7 @@ interface AssigneeDropdownProps {
 }
 
 interface Level { levelId: string; levelName: string; }
-interface User { userId: string; username: string; name: string; }
+interface User { userId: string; username: string; name: string; roles?: string; }
 
 const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ ticketId, assigneeName, onAssigned, searchCurrentTicketsPaginatedApi }) => {
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
@@ -80,8 +80,12 @@ const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ ticketId, assigneeN
 
     const levels: Level[] = levelsData || [];
     const users: User[] = selectedLevel ? (usersData || []) : (allUsersData || []);
+    const allowedRoleIds = ['2', '3', '4', '6', '8'];
+    const allowedUsers = users.filter(u =>
+        u.roles?.split('|').some(r => allowedRoleIds.includes(r))
+    );
 
-    const filtered = users.filter(u =>
+    const filtered = allowedUsers.filter(u =>
         u.name.toLowerCase().includes(search.toLowerCase()) ||
         u.username.toLowerCase().includes(search.toLowerCase())
     );


### PR DESCRIPTION
## Summary
- migrate role and permission management to use numeric `role_id`
- expose user roles for filtering and show only assignable roles in assignee dropdown
- adjust services and controllers to handle role ids instead of names

## Testing
- `./gradlew test` *(failed: Cannot find a Java installation)*
- `npm test` *(failed: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a41d1cb69083329173561aa01d09eb