### PR TITLE
feat: merge show flag across roles with OR logic

### DIFF
--- a/api/src/main/java/com/example/api/service/PermissionService.java
+++ b/api/src/main/java/com/example/api/service/PermissionService.java
@@ -192,6 +192,10 @@ public class PermissionService {
             Object existing = target.get(key);
             if (existing instanceof Map<?, ?> && value instanceof Map<?, ?>) {
                 deepMerge((Map<String, Object>) existing, (Map<String, Object>) value);
+            } else if ("show".equals(key)
+                    && existing instanceof Boolean exBool
+                    && value instanceof Boolean srcBool) {
+                target.put(key, exBool || srcBool);
             } else {
                 target.put(key, value);
             }

--- a/api/src/test/java/com/example/api/service/PermissionServiceTest.java
+++ b/api/src/test/java/com/example/api/service/PermissionServiceTest.java
@@ -1,0 +1,63 @@
+package com.example.api.service;
+
+import com.example.api.permissions.PermissionsConfig;
+import com.example.api.permissions.RolePermission;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for {@link PermissionService}.
+ */
+class PermissionServiceTest {
+
+    @Test
+    void mergeRolePermissionsOrsShowFlag() throws Exception {
+        PermissionService service = new PermissionService(null);
+
+        // Role 1 grants Knowledge Base but not FAQ
+        RolePermission role1 = new RolePermission();
+        Map<String, Object> kb1 = new HashMap<>();
+        kb1.put("show", true);
+        Map<String, Object> faq1 = new HashMap<>();
+        faq1.put("show", false);
+        Map<String, Object> sidebar1 = new HashMap<>();
+        sidebar1.put("knowledgeBase", kb1);
+        sidebar1.put("faq", faq1);
+        role1.setSidebar(sidebar1);
+
+        // Role 2 grants FAQ but not Knowledge Base
+        RolePermission role2 = new RolePermission();
+        Map<String, Object> kb2 = new HashMap<>();
+        kb2.put("show", false);
+        Map<String, Object> faq2 = new HashMap<>();
+        faq2.put("show", true);
+        Map<String, Object> sidebar2 = new HashMap<>();
+        sidebar2.put("knowledgeBase", kb2);
+        sidebar2.put("faq", faq2);
+        role2.setSidebar(sidebar2);
+
+        Map<Integer, RolePermission> roles = new HashMap<>();
+        roles.put(1, role1);
+        roles.put(2, role2);
+
+        PermissionsConfig cfg = new PermissionsConfig();
+        cfg.setRoles(roles);
+
+        Field configField = PermissionService.class.getDeclaredField("config");
+        configField.setAccessible(true);
+        configField.set(service, cfg);
+
+        RolePermission merged = service.mergeRolePermissions(Arrays.asList(1, 2));
+
+        Map<String, Object> sidebar = merged.getSidebar();
+        assertEquals(Boolean.TRUE, ((Map<?, ?>) sidebar.get("knowledgeBase")).get("show"));
+        assertEquals(Boolean.TRUE, ((Map<?, ?>) sidebar.get("faq")).get("show"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure `show` flag combines with logical OR when merging permissions from multiple roles
- add regression test for merging show flags across roles

## Testing
- `./gradlew test` *(fails: Could not download typesense-java-0.2.0.jar, received 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a4318a20a88332a7b9b51c7dc18c91