### PR TITLE
Add priority/severity metadata and UI popovers

### DIFF
--- a/api/src/main/java/com/example/api/controller/PriorityController.java
+++ b/api/src/main/java/com/example/api/controller/PriorityController.java
@@ -1,5 +1,6 @@
 package com.example.api.controller;
 
+import com.example.api.models.Priority;
 import com.example.api.service.PriorityService;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,7 +20,7 @@ public class PriorityController {
     private final PriorityService priorityService;
 
     @GetMapping
-    public ResponseEntity<List<String>> getPriorities() {
-        return ResponseEntity.ok(priorityService.getAllValues());
+    public ResponseEntity<List<Priority>> getPriorities() {
+        return ResponseEntity.ok(priorityService.getAll());
     }
 }

--- a/api/src/main/java/com/example/api/controller/SeverityController.java
+++ b/api/src/main/java/com/example/api/controller/SeverityController.java
@@ -1,5 +1,6 @@
 package com.example.api.controller;
 
+import com.example.api.models.Severity;
 import com.example.api.service.SeverityService;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,7 +20,7 @@ public class SeverityController {
     private final SeverityService severityService;
 
     @GetMapping
-    public ResponseEntity<List<String>> getSeverities() {
-        return ResponseEntity.ok(severityService.getAllValues());
+    public ResponseEntity<List<Severity>> getSeverities() {
+        return ResponseEntity.ok(severityService.getAll());
     }
 }

--- a/api/src/main/java/com/example/api/dto/CategoryDto.java
+++ b/api/src/main/java/com/example/api/dto/CategoryDto.java
@@ -14,5 +14,7 @@ public class CategoryDto {
     private String createdBy;
     private LocalDateTime timestamp;
     private LocalDateTime lastUpdated;
+    private String updatedBy;
+    private String isActive;
     private Set<SubCategoryDto> subCategories;
 }

--- a/api/src/main/java/com/example/api/dto/SubCategoryDto.java
+++ b/api/src/main/java/com/example/api/dto/SubCategoryDto.java
@@ -10,8 +10,12 @@ import java.time.LocalDateTime;
 public class SubCategoryDto {
     private String subCategoryId;
     private String subCategory;
+    private String description;
     private String createdBy;
     private LocalDateTime timestamp;
     private String categoryId;
     private LocalDateTime lastUpdated;
+    private String severityId;
+    private String updatedBy;
+    private String isActive;
 }

--- a/api/src/main/java/com/example/api/dto/TicketDto.java
+++ b/api/src/main/java/com/example/api/dto/TicketDto.java
@@ -1,8 +1,6 @@
 package com.example.api.dto;
 
 import com.example.api.enums.Mode;
-import com.example.api.enums.Priority;
-import com.example.api.enums.Severity;
 import com.example.api.enums.TicketStatus;
 import com.example.api.enums.FeedbackStatus;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -27,9 +25,9 @@ public class TicketDto {
     private String description;
     private String category;
     private String subCategory;
-    private Priority priority;
-    private Severity severity;
-    private Severity recommendedSeverity;
+    private String priority;
+    private String severity;
+    private String recommendedSeverity;
     private String impact;
     private String severityRecommendedBy;
     private TicketStatus status;

--- a/api/src/main/java/com/example/api/enums/Priority.java
+++ b/api/src/main/java/com/example/api/enums/Priority.java
@@ -1,5 +1,0 @@
-package com.example.api.enums;
-
-public enum Priority {
-    Critical, High, Medium, Low
-}

--- a/api/src/main/java/com/example/api/enums/Severity.java
+++ b/api/src/main/java/com/example/api/enums/Severity.java
@@ -1,5 +1,0 @@
-package com.example.api.enums;
-
-public enum Severity {
-    CRITICAL, HIGH, MEDIUM, LOW
-}

--- a/api/src/main/java/com/example/api/mapper/DtoMapper.java
+++ b/api/src/main/java/com/example/api/mapper/DtoMapper.java
@@ -15,6 +15,8 @@ public class DtoMapper {
         dto.setCreatedBy(category.getCreatedBy());
         dto.setTimestamp(category.getTimestamp());
         dto.setLastUpdated(category.getLastUpdated());
+        dto.setUpdatedBy(category.getUpdatedBy());
+        dto.setIsActive(category.getIsActive());
         if (category.getSubCategories() != null) {
             Set<SubCategoryDto> subDtos = category.getSubCategories().stream()
                     .map(DtoMapper::toSubCategoryDto)
@@ -29,10 +31,14 @@ public class DtoMapper {
         SubCategoryDto dto = new SubCategoryDto();
         dto.setSubCategoryId(subCategory.getSubCategoryId() != null ? String.valueOf(subCategory.getSubCategoryId()) : null);
         dto.setSubCategory(subCategory.getSubCategory());
+        dto.setDescription(subCategory.getDescription());
         dto.setCreatedBy(subCategory.getCreatedBy());
         dto.setTimestamp(subCategory.getTimestamp());
         dto.setLastUpdated(subCategory.getLastUpdated());
         dto.setCategoryId(subCategory.getCategory() != null ? String.valueOf(subCategory.getCategory().getCategoryId()) : null);
+        dto.setSeverityId(subCategory.getSeverity() != null ? subCategory.getSeverity().getId() : null);
+        dto.setUpdatedBy(subCategory.getUpdatedBy());
+        dto.setIsActive(subCategory.getIsActive());
         return dto;
     }
 

--- a/api/src/main/java/com/example/api/models/Category.java
+++ b/api/src/main/java/com/example/api/models/Category.java
@@ -32,6 +32,12 @@ public class Category {
     @Column(name = "last_updated")
     private LocalDateTime lastUpdated;
 
+    @Column(name = "updated_by")
+    private String updatedBy;
+
+    @Column(name = "isActive")
+    private String isActive;
+
     @OneToMany(mappedBy = "category")
     private Set<SubCategory> subCategories;
 }

--- a/api/src/main/java/com/example/api/models/Priority.java
+++ b/api/src/main/java/com/example/api/models/Priority.java
@@ -1,19 +1,36 @@
 package com.example.api.models;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * Represents priority configuration stored in {@code priority_master}.
+ * The table stores descriptive details for each priority level which are
+ * surfaced to the UI for contextual help.
+ */
 @Entity
 @Table(name = "priority_master")
 @Getter
 @Setter
 public class Priority {
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "priority_id")
-    private String priorityId;
 
-    @Column(name = "value")
-    private String value;
+    @Id
+    @Column(name = "tp_id")
+    private String id;
+
+    @Column(name = "tp_level")
+    private String level;
+
+    @Column(name = "tp_description")
+    private String description;
+
+    @Column(name = "tp_weightage")
+    private Integer weightage;
+
+    @Column(name = "tp_active_flg")
+    private String activeFlag;
 }

--- a/api/src/main/java/com/example/api/models/Severity.java
+++ b/api/src/main/java/com/example/api/models/Severity.java
@@ -1,19 +1,34 @@
 package com.example.api.models;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * Entity representing severity configuration from {@code severity_master}.
+ */
 @Entity
 @Table(name = "severity_master")
 @Getter
 @Setter
 public class Severity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "severity_id")
-    private String severityId;
 
-    @Column(name = "value")
-    private String value;
+    @Id
+    @Column(name = "ts_id")
+    private String id;
+
+    @Column(name = "ts_level")
+    private String level;
+
+    @Column(name = "ts_description")
+    private String description;
+
+    @Column(name = "ts_weightage")
+    private Integer weightage;
+
+    @Column(name = "ts_active_flg")
+    private String activeFlag;
 }

--- a/api/src/main/java/com/example/api/models/SubCategory.java
+++ b/api/src/main/java/com/example/api/models/SubCategory.java
@@ -22,6 +22,9 @@ public class SubCategory {
     @Column(name = "sub_category")
     private String subCategory;
 
+    @Column(name = "description")
+    private String description;
+
     @Column(name = "created_by")
     private String createdBy;
 
@@ -32,8 +35,18 @@ public class SubCategory {
     @JoinColumn(name = "category_id")
     private Category category;
 
+    @ManyToOne
+    @JoinColumn(name = "severity_id")
+    private Severity severity;
+
     @Column(name = "last_updated")
     private LocalDateTime lastUpdated;
+
+    @Column(name = "updated_by")
+    private String updatedBy;
+
+    @Column(name = "isActive")
+    private String isActive;
 
     public SubCategory() {}
 

--- a/api/src/main/java/com/example/api/models/Ticket.java
+++ b/api/src/main/java/com/example/api/models/Ticket.java
@@ -1,8 +1,6 @@
 package com.example.api.models;
 
 import com.example.api.enums.Mode;
-import com.example.api.enums.Priority;
-import com.example.api.enums.Severity;
 import com.example.api.enums.TicketStatus;
 import com.example.api.enums.FeedbackStatus;
 import com.example.api.models.Status;
@@ -44,13 +42,10 @@ public class Ticket {
     private String category;
     @Column(name="sub_category")
     private String subCategory;
-    @Enumerated(EnumType.STRING)
-    private Priority priority;
-    @Enumerated(EnumType.STRING)
-    private Severity severity;
-    @Enumerated(EnumType.STRING)
+    private String priority;
+    private String severity;
     @Column(name = "recommended_severity")
-    private Severity recommendedSeverity;
+    private String recommendedSeverity;
     private String impact;
     @Column(name = "severity_recommended_by")
     private String severityRecommendedBy;

--- a/api/src/main/java/com/example/api/service/CategoryService.java
+++ b/api/src/main/java/com/example/api/service/CategoryService.java
@@ -31,6 +31,9 @@ public class CategoryService {
         java.time.LocalDateTime now = java.time.LocalDateTime.now();
         category.setTimestamp(now);
         category.setLastUpdated(now);
+        if (category.getIsActive() == null) {
+            category.setIsActive("Y");
+        }
         return categoryRepository.save(category);
     }
 
@@ -38,6 +41,8 @@ public class CategoryService {
         return categoryRepository.findById(id)
                 .map(existing -> {
                     existing.setCategory(updated.getCategory());
+                    if (updated.getUpdatedBy() != null) existing.setUpdatedBy(updated.getUpdatedBy());
+                    if (updated.getIsActive() != null) existing.setIsActive(updated.getIsActive());
                     return categoryRepository.save(existing);
                 });
     }

--- a/api/src/main/java/com/example/api/service/PriorityService.java
+++ b/api/src/main/java/com/example/api/service/PriorityService.java
@@ -1,5 +1,6 @@
 package com.example.api.service;
 
+import com.example.api.models.Priority;
 import com.example.api.repository.PriorityRepository;
 import org.springframework.stereotype.Service;
 
@@ -13,7 +14,7 @@ public class PriorityService {
         this.repository = repository;
     }
 
-    public List<String> getAllValues() {
-        return repository.findAll().stream().map(p -> p.getValue()).toList();
+    public List<Priority> getAll() {
+        return repository.findAll();
     }
 }

--- a/api/src/main/java/com/example/api/service/SeverityService.java
+++ b/api/src/main/java/com/example/api/service/SeverityService.java
@@ -1,5 +1,6 @@
 package com.example.api.service;
 
+import com.example.api.models.Severity;
 import com.example.api.repository.SeverityRepository;
 import org.springframework.stereotype.Service;
 
@@ -13,7 +14,7 @@ public class SeverityService {
         this.repository = repository;
     }
 
-    public List<String> getAllValues() {
-        return repository.findAll().stream().map(s -> s.getValue()).toList();
+    public List<Severity> getAll() {
+        return repository.findAll();
     }
 }

--- a/api/src/main/java/com/example/api/service/SubCategoryService.java
+++ b/api/src/main/java/com/example/api/service/SubCategoryService.java
@@ -4,6 +4,7 @@ import com.example.api.dto.SubCategoryDto;
 import com.example.api.models.Category;
 import com.example.api.models.SubCategory;
 import com.example.api.repository.CategoryRepository;
+import com.example.api.repository.SeverityRepository;
 import com.example.api.repository.SubCategoryRepository;
 import org.springframework.stereotype.Service;
 
@@ -15,10 +16,14 @@ import com.example.api.mapper.DtoMapper;
 public class SubCategoryService {
     private final SubCategoryRepository subCategoryRepository;
     private final CategoryRepository categoryRepository;
+    private final SeverityRepository severityRepository;
 
-    public SubCategoryService(SubCategoryRepository subCategoryRepository, CategoryRepository categoryRepository) {
+    public SubCategoryService(SubCategoryRepository subCategoryRepository,
+                              CategoryRepository categoryRepository,
+                              SeverityRepository severityRepository) {
         this.subCategoryRepository = subCategoryRepository;
         this.categoryRepository = categoryRepository;
+        this.severityRepository = severityRepository;
     }
 
     public List<SubCategoryDto> getAllSubCategories() {
@@ -36,9 +41,16 @@ public class SubCategoryService {
         Category category = categoryRepository.findById(categoryId)
             .orElseThrow(() -> new RuntimeException("Category not found"));
         subCategory.setCategory(category);
+        if (subCategory.getSeverity() != null && subCategory.getSeverity().getId() != null) {
+            severityRepository.findById(subCategory.getSeverity().getId())
+                    .ifPresent(subCategory::setSeverity);
+        }
         java.time.LocalDateTime now = java.time.LocalDateTime.now();
         subCategory.setTimestamp(now);
         subCategory.setLastUpdated(now);
+        if (subCategory.getIsActive() == null) {
+            subCategory.setIsActive("Y");
+        }
         return subCategoryRepository.save(subCategory);
     }
 

--- a/ui/src/components/AllTickets/ViewTicket.tsx
+++ b/ui/src/components/AllTickets/ViewTicket.tsx
@@ -8,6 +8,8 @@ import { getTicket, updateTicket } from '../../services/TicketService';
 import { getCurrentUserDetails } from '../../config/config';
 import { getPriorities } from '../../services/PriorityService';
 import { getSeverities } from '../../services/SeverityService';
+import InfoIcon from '../UI/InfoIcon';
+import { PriorityInfo, SeverityInfo } from '../../types';
 import CustomIconButton from '../UI/IconButton/CustomIconButton';
 import CommentsSection from '../Comments/CommentsSection';
 import { useNavigate } from 'react-router-dom';
@@ -32,12 +34,20 @@ const ViewTicket: React.FC<ViewTicketProps> = ({ ticketId, open, onClose }) => {
   const [recommendedSeverity, setRecommendedSeverity] = useState('');
   const [priorityOptions, setPriorityOptions] = useState<string[]>([]);
   const [severityOptions, setSeverityOptions] = useState<string[]>([]);
+  const [priorityDetails, setPriorityDetails] = useState<PriorityInfo[]>([]);
+  const [severityDetails, setSeverityDetails] = useState<SeverityInfo[]>([]);
 
   useEffect(() => {
     if (open && ticketId) {
       getTicketHandler(() => getTicket(ticketId));
-      getPriorities().then(res => setPriorityOptions(res.data || []));
-      getSeverities().then(res => setSeverityOptions(res.data || []));
+      getPriorities().then(res => {
+        setPriorityOptions((res.data || []).map((p: PriorityInfo) => p.level));
+        setPriorityDetails(res.data || []);
+      });
+      getSeverities().then(res => {
+        setSeverityOptions((res.data || []).map((s: SeverityInfo) => s.level));
+        setSeverityDetails(res.data || []);
+      });
     }
   }, [open, ticketId, getTicketHandler]);
 
@@ -174,13 +184,27 @@ const ViewTicket: React.FC<ViewTicketProps> = ({ ticketId, open, onClose }) => {
             {renderText(description, setDescription, true)}
           </Box>
           <Box sx={{ mt: 2 }}>
-            <Box sx={{ display: 'flex', gap: 2, alignItems: 'baseline' }}>
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'baseline' }}>
               <Typography variant="body2" color="text.secondary">Priority</Typography>
               {renderSelect(priority, setPriority, priorityOptions)}
+              <InfoIcon content={(
+                <div>
+                  {priorityDetails.map(p => (
+                    <div key={p.id}>{p.level} - {p.description}</div>
+                  ))}
+                </div>
+              )} />
             </Box>
-            <Box sx={{ display: 'flex', gap: 2, alignItems: 'baseline' }}>
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'baseline' }}>
               <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>Severity</Typography>
               {renderSelect(severity, setSeverity, severityOptions)}
+              <InfoIcon content={(
+                <div>
+                  {severityDetails.map(s => (
+                    <div key={s.id}>{s.level} - {s.description}</div>
+                  ))}
+                </div>
+              )} />
             </Box>
             <Box sx={{ display: 'flex', gap: 2, alignItems: 'baseline' }}>
               <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>Recommended Severity</Typography>

--- a/ui/src/components/RaiseTicket/TicketDetails.tsx
+++ b/ui/src/components/RaiseTicket/TicketDetails.tsx
@@ -15,6 +15,8 @@ import { getCurrentUserDetails } from "../../config/config";
 import { checkFieldAccess } from "../../utils/permissions";
 import { getPriorities } from "../../services/PriorityService";
 import { getSeverities } from "../../services/SeverityService";
+import InfoIcon from "../UI/InfoIcon";
+import { PriorityInfo, SeverityInfo } from "../../types";
 
 interface TicketDetailsProps extends FormProps {
     disableAll?: boolean;
@@ -60,8 +62,24 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
     const categoryOptions: DropdownOption[] = getDropdownOptions(allCategories, 'category', 'category');
     const subCategoryOptions: DropdownOption[] = getDropdownOptions(allSubCategories, 'subCategory', 'subCategoryId');
     const statusOptions: DropdownOption[] = getDropdownOptions(nextStatusListByStatusIdData, 'action', 'nextStatus');
-    const priorityOptions: DropdownOption[] = Array.isArray(priorityList) ? priorityList.map((p: string) => ({ label: p, value: p })) : [];
-    const severityOptions: DropdownOption[] = Array.isArray(severityList) ? severityList.map((s: string) => ({ label: s, value: s })) : [];
+    const priorityOptions: DropdownOption[] = Array.isArray(priorityList) ? priorityList.map((p: PriorityInfo) => ({ label: p.level, value: p.level })) : [];
+    const severityOptions: DropdownOption[] = Array.isArray(severityList) ? severityList.map((s: SeverityInfo) => ({ label: s.level, value: s.level })) : [];
+
+    const priorityContent = Array.isArray(priorityList) ? (
+        <div>
+            {priorityList.map((p: PriorityInfo) => (
+                <div key={p.id}>{p.level} - {p.description}</div>
+            ))}
+        </div>
+    ) : undefined;
+
+    const severityContent = Array.isArray(severityList) ? (
+        <div>
+            {severityList.map((s: SeverityInfo) => (
+                <div key={s.id}>{s.level} - {s.description}</div>
+            ))}
+        </div>
+    ) : undefined;
 
     const assignedToLevel = useWatch({ control, name: 'assignedToLevel' });
     const assignToLevel = useWatch({ control, name: 'assignToLevel' });
@@ -194,15 +212,16 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
                     </div>
                 )}
                 {showPriority && (
-                    <div className="col-md-4 mb-3 px-4">
+                    <div className="col-md-4 mb-3 px-4 d-flex align-items-center">
                         <GenericDropdownController
                             name="priority"
                             control={control}
                             label="Priority"
                             options={priorityOptions}
-                            className="form-select"
+                            className="form-select flex-grow-1"
                             disabled={disableAll}
                         />
+                        <InfoIcon content={priorityContent} />
                     </div>
                 )}
                 {showSeverityFields && (
@@ -232,15 +251,16 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
                             </div>
                         )}
                         {showSeverity && (
-                            <div className="col-md-4 mb-3 px-4">
+                            <div className="col-md-4 mb-3 px-4 d-flex align-items-center">
                                 <GenericDropdownController
                                     name="severity"
                                     control={control}
                                     label="Confirm Severity"
                                     options={severityOptions}
-                                    className="form-select"
+                                    className="form-select flex-grow-1"
                                     disabled={disableAll}
                                 />
+                                <InfoIcon content={severityContent} />
                             </div>
                         )}
                     </>

--- a/ui/src/components/UI/InfoIcon.tsx
+++ b/ui/src/components/UI/InfoIcon.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import Popover from '@mui/material/Popover';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+
+export interface InfoIconProps {
+  content?: React.ReactNode;
+  text?: string;
+  title?: string;
+}
+
+const InfoIcon: React.FC<InfoIconProps> = ({ content, text, title }) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  const handleOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+
+  return (
+    <>
+      <InfoOutlinedIcon
+        fontSize="small"
+        sx={{ ml: 0.5, cursor: 'pointer' }}
+        onMouseEnter={handleOpen}
+        onMouseLeave={handleClose}
+      />
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        disableRestoreFocus
+        PaperProps={{ sx: { pointerEvents: 'none', p: 1 } }}
+      >
+        <Box onMouseEnter={handleOpen} onMouseLeave={handleClose}>
+          {title && (
+            <Typography variant="subtitle2" gutterBottom>
+              {title}
+            </Typography>
+          )}
+          {text && (
+            <Typography variant="body2" gutterBottom>
+              {text}
+            </Typography>
+          )}
+          {content ? (
+            content
+          ) : (
+            <Typography color="error">Something went wrong!</Typography>
+          )}
+        </Box>
+      </Popover>
+    </>
+  );
+};
+
+export default InfoIcon;

--- a/ui/src/services/PriorityService.ts
+++ b/ui/src/services/PriorityService.ts
@@ -1,13 +1,14 @@
 import axios from 'axios';
 import { BASE_URL } from './api';
+import { PriorityInfo } from '../types';
 
-let priorityCache: any[] | null = null;
+let priorityCache: PriorityInfo[] | null = null;
 
 export function getPriorities() {
     if (priorityCache) {
         return Promise.resolve({ data: priorityCache } as any);
     }
-    return axios.get(`${BASE_URL}/priorities`).then(res => {
+    return axios.get<PriorityInfo[]>(`${BASE_URL}/priorities`).then(res => {
         priorityCache = res.data;
         return res;
     });

--- a/ui/src/services/SeverityService.ts
+++ b/ui/src/services/SeverityService.ts
@@ -1,13 +1,14 @@
 import axios from 'axios';
 import { BASE_URL } from './api';
+import { SeverityInfo } from '../types';
 
-let severityCache: any[] | null = null;
+let severityCache: SeverityInfo[] | null = null;
 
 export function getSeverities() {
     if (severityCache) {
         return Promise.resolve({ data: severityCache } as any);
     }
-    return axios.get(`${BASE_URL}/severities`).then(res => {
+    return axios.get<SeverityInfo[]>(`${BASE_URL}/severities`).then(res => {
         severityCache = res.data;
         return res;
     });

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -26,6 +26,18 @@ export interface Category {
     subCategories: SubCategory[];
 }
 
+export interface PriorityInfo {
+    id: string;
+    level: string;
+    description: string;
+}
+
+export interface SeverityInfo {
+    id: string;
+    level: string;
+    description: string;
+}
+
 export interface Ticket {
     id: string;
     subject: string;


### PR DESCRIPTION
## Summary
- map new priority and severity master tables in backend and expose them via REST
- extend categories/sub-categories to include activity flags and severity link
- add InfoIcon component with hover popovers and show priority & severity details in ticket forms

## Testing
- `./gradlew test` *(fails: Could not download typesense-java-0.2.0.jar - 403 Forbidden)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a55bbfccb883328c749df3add1e495