### PR TITLE
style: adjust request mode buttons and requestor layout

### DIFF
--- a/ui/src/components/CustomFieldset.tsx
+++ b/ui/src/components/CustomFieldset.tsx
@@ -56,6 +56,7 @@ const CustomFieldset: React.FC<CustomFieldsetProps> = ({ title, variant = "under
             className={className}
             style={style}
             legendProps={{ onClick: toggleCollapse }}
+            collapsed={collapsed}
         >
             {!collapsed && (
                 <div>

--- a/ui/src/components/RaiseTicket/RequestDetails.tsx
+++ b/ui/src/components/RaiseTicket/RequestDetails.tsx
@@ -8,6 +8,7 @@ import { checkFieldAccess } from "../../utils/permissions";
 import React, { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import CustomIconButton from "../UI/IconButton/CustomIconButton";
+import { useTheme } from "@mui/material/styles";
 
 interface RequestDetailsProps extends FormProps {
     disableAll?: boolean;
@@ -28,6 +29,7 @@ const RequestDetails: React.FC<RequestDetailsProps> = ({ register, control, erro
     const ticketId = useWatch({ control, name: 'ticketId' });
     const mode = useWatch({ control, name: 'mode' });
     const helpdesk = true
+    const theme = useTheme();
 
     useEffect(() => {
         setValue && setValue("mode", "Self");
@@ -43,9 +45,14 @@ const RequestDetails: React.FC<RequestDetailsProps> = ({ register, control, erro
                             <div key={opt.value} className="text-center">
                                 <CustomIconButton
                                     icon={opt.icon}
-                                    color={mode === opt.value ? 'primary' : 'default'}
                                     onClick={() => setValue && setValue('mode', opt.value)}
                                     disabled={disableAll || !helpdesk}
+                                    sx={{
+                                        color: theme.palette.primary.main,
+                                        border: `1px solid ${theme.palette.primary.main}`,
+                                        borderRadius: '50%',
+                                        backgroundColor: mode === opt.value ? theme.palette.secondary.main : 'transparent',
+                                    }}
                                 />
                                 <div>{t(opt.label)}</div>
                             </div>

--- a/ui/src/components/RaiseTicket/RequestorDetails.tsx
+++ b/ui/src/components/RaiseTicket/RequestorDetails.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, FormControlLabel, InputAdornment, ToggleButton, ToggleButtonGroup, Autocomplete, TextField } from "@mui/material";
+import { Checkbox, FormControlLabel, InputAdornment, ToggleButton, ToggleButtonGroup, Autocomplete, TextField, Card } from "@mui/material";
 import { formFieldValue, inputColStyling } from "../../constants/bootstrapClasses";
 import { FormProps } from "../../types";
 import CustomFormInput from "../UI/Input/CustomFormInput";
@@ -406,49 +406,54 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
                         />
                     </div>
                 )} */}
-                {showSearchUserAutocomplete && <div className="col-md-6 p-0">
-                    <Autocomplete
-                        options={filteredUsers}
-                        getOptionLabel={(option: any) => option.name || ''}
-                        renderOption={(props, option: any) => (
-                            <li {...props} key={option.userId}>
-                                <span className="fw-semibold">{option.name}</span>
-                                <span className="text-muted ms-2">{option.username} | {option.mobileNo} | {option.emailId}</span>
-                            </li>
-                        )}
-                        renderInput={(params) => (
-                            <TextField {...params} label="Search User" size="medium" />
-                        )}
-                        value={selectedUser}
-                        inputValue={searchText}
-                        onInputChange={(e, val) => setSearchText(val)}
-                        onChange={handleSelectUserChange}
-                        filterOptions={handleFilterOptions}
-                        disabled={disableAll}
-                    />
-                </div>}
-                {showStakeholder && (
-                    <div className="col-md-6 px-4">
-                        <GenericDropdownController
-                            label="Stakeholder"
-                            name="stakeholder"
-                            control={control}
-                            options={stakeholderOptions}
-                            rules={{ required: isNonFci ? 'Please select Stakeholder' : false }}
-                            className="form-select"
-                            disabled={isStakeholderDisabled}
-                        />
+                {showRequestorDetailsCard && (
+                    <div className="col-md-6">
+                        <Card className="p-2 mb-4" elevation={1}>
+                            {showUserId && userId && renderReadOnlyField("User ID", userId)}
+                            {showRequestorName && requestorName && renderReadOnlyField("Name", requestorName)}
+                            {showEmailId && emailId && renderReadOnlyField("Email ID", emailId)}
+                            {showMobileNo && mobileNo && renderReadOnlyField("Mobile No.", mobileNo)}
+                            {showRole && control._formValues?.role && renderReadOnlyField("Role", control._formValues?.role || "")}
+                            {showOffice && control._formValues?.office && renderReadOnlyField("Office", control._formValues?.office || "")}
+                        </Card>
                     </div>
                 )}
-
-                {showRequestorDetailsCard && <CustomFieldset variant="basic" className="d-flex flex-column col-5 mb-4">
-                    {showUserId && userId && renderReadOnlyField("User ID", userId)}
-                    {showRequestorName && requestorName && renderReadOnlyField("Name", requestorName)}
-                    {showEmailId && emailId && renderReadOnlyField("Email ID", emailId)}
-                    {showMobileNo && mobileNo && renderReadOnlyField("Mobile No.", mobileNo)}
-                    {showRole && control._formValues?.role && renderReadOnlyField("Role", control._formValues?.role || "")}
-                    {showOffice && control._formValues?.office && renderReadOnlyField("Office", control._formValues?.office || "")}
-                </CustomFieldset>}
+                {(showSearchUserAutocomplete || showStakeholder) && (
+                    <div className="col-md-6 d-flex flex-column">
+                        {showSearchUserAutocomplete && (
+                            <Autocomplete
+                                options={filteredUsers}
+                                getOptionLabel={(option: any) => option.name || ''}
+                                renderOption={(props, option: any) => (
+                                    <li {...props} key={option.userId}>
+                                        <span className="fw-semibold">{option.name}</span>
+                                         <span className="text-muted ms-2">{option.username} | {option.mobileNo} | {option.emailId}</span>
+                                    </li>
+                                )}
+                                renderInput={(params) => (
+                                    <TextField {...params} label="Search User" size="medium" />
+                                )}
+                                value={selectedUser}
+                                inputValue={searchText}
+                                onInputChange={(e, val) => setSearchText(val)}
+                                onChange={handleSelectUserChange}
+                                filterOptions={handleFilterOptions}
+                                disabled={disableAll}
+                            />
+                        )}
+                        {showStakeholder && (
+                            <GenericDropdownController
+                                label="Stakeholder"
+                                name="stakeholder"
+                                control={control}
+                                options={stakeholderOptions}
+                                rules={{ required: isNonFci ? 'Please select Stakeholder' : false }}
+                                className="form-select mt-3"
+                                disabled={isStakeholderDisabled}
+                            />
+                        )}
+                    </div>
+                )}
             </div>
         </CustomFieldset>
     )

--- a/ui/src/components/UI/Fieldset/index.tsx
+++ b/ui/src/components/UI/Fieldset/index.tsx
@@ -7,12 +7,13 @@ interface FieldsetProps {
     className?: string;
     style?: React.CSSProperties;
     legendProps?: React.HTMLAttributes<HTMLLegendElement>;
+    collapsed?: boolean;
 }
 
-const Fieldset: React.FC<FieldsetProps> = ({ title, children, className = "", style, legendProps }) => {
+const Fieldset: React.FC<FieldsetProps> = ({ title, children, className = "", style, legendProps, collapsed = false }) => {
     return (
         <fieldset
-            className={`border p-4 pt-5 position-relative rounded mb-4 ${className}`}
+            className={`border ${collapsed ? 'p-4' : 'p-4 pt-5'} position-relative rounded mb-4 ${className}`}
             style={style}
         >
             <legend
@@ -25,7 +26,7 @@ const Fieldset: React.FC<FieldsetProps> = ({ title, children, className = "", st
                     padding: "0 8px",
                     margin: 0,
                     position: "absolute",
-                    top: "-1.1rem",
+                    top: collapsed ? '0' : '-1.1rem',
                     left: "1rem",
                     backgroundColor: "white",
                     display: "flex",


### PR DESCRIPTION
## Summary
- Style request mode icons with green borders and orange active background
- Show bordered fieldset title inside when collapsed
- Switch requestor details to card layout with side-by-side form controls

## Testing
- `npm test -- --watchAll=false` (fails: Cannot find module 'react-router-dom' from 'src/App.tsx')

------
https://chatgpt.com/codex/tasks/task_e_68a5903a17148332b84b848a39761bcb