### PR TITLE
Add stakeholder entities and enhance Raise Ticket validations

### DIFF
--- a/api/src/main/java/com/example/api/controller/StakeholderController.java
+++ b/api/src/main/java/com/example/api/controller/StakeholderController.java
@@ -1,0 +1,25 @@
+package com.example.api.controller;
+
+import com.example.api.dto.StakeholderDto;
+import com.example.api.service.StakeholderService;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/stakeholders")
+@CrossOrigin(origins = "http://localhost:3000")
+@AllArgsConstructor
+public class StakeholderController {
+    private final StakeholderService stakeholderService;
+
+    @GetMapping
+    public ResponseEntity<List<StakeholderDto>> getStakeholders() {
+        return ResponseEntity.ok(stakeholderService.getAll());
+    }
+}

--- a/api/src/main/java/com/example/api/dto/StakeholderDto.java
+++ b/api/src/main/java/com/example/api/dto/StakeholderDto.java
@@ -1,0 +1,13 @@
+package com.example.api.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StakeholderDto {
+    private Integer id;
+    private String description;
+    private Integer stakeholderGroupId;
+    private String isActive;
+}

--- a/api/src/main/java/com/example/api/dto/StakeholderGroupDto.java
+++ b/api/src/main/java/com/example/api/dto/StakeholderGroupDto.java
@@ -1,0 +1,12 @@
+package com.example.api.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StakeholderGroupDto {
+    private Integer id;
+    private String description;
+    private String isActive;
+}

--- a/api/src/main/java/com/example/api/mapper/DtoMapper.java
+++ b/api/src/main/java/com/example/api/mapper/DtoMapper.java
@@ -118,4 +118,25 @@ public class DtoMapper {
         dto.setRemark(statusHistory.getRemark());
         return dto;
     }
+
+    public static StakeholderDto toStakeholderDto(Stakeholder stakeholder) {
+        if (stakeholder == null) return null;
+        StakeholderDto dto = new StakeholderDto();
+        dto.setId(stakeholder.getId());
+        dto.setDescription(stakeholder.getDescription());
+        dto.setStakeholderGroupId(stakeholder.getStakeholderGroup() != null
+                ? stakeholder.getStakeholderGroup().getId()
+                : null);
+        dto.setIsActive(stakeholder.getIsActive());
+        return dto;
+    }
+
+    public static StakeholderGroupDto toStakeholderGroupDto(StakeholderGroup group) {
+        if (group == null) return null;
+        StakeholderGroupDto dto = new StakeholderGroupDto();
+        dto.setId(group.getId());
+        dto.setDescription(group.getDescription());
+        dto.setIsActive(group.getIsActive());
+        return dto;
+    }
 }

--- a/api/src/main/java/com/example/api/models/Stakeholder.java
+++ b/api/src/main/java/com/example/api/models/Stakeholder.java
@@ -1,0 +1,29 @@
+package com.example.api.models;
+
+import jakarta.persistence.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "stakeholder")
+@Getter
+@Setter
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class Stakeholder {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "stakeholder_id")
+    @EqualsAndHashCode.Include
+    private Integer id;
+
+    @Column(name = "description")
+    private String description;
+
+    @ManyToOne
+    @JoinColumn(name = "sg_id")
+    private StakeholderGroup stakeholderGroup;
+
+    @Column(name = "is_active")
+    private String isActive;
+}

--- a/api/src/main/java/com/example/api/models/StakeholderGroup.java
+++ b/api/src/main/java/com/example/api/models/StakeholderGroup.java
@@ -1,0 +1,30 @@
+package com.example.api.models;
+
+import jakarta.persistence.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Set;
+
+@Entity
+@Table(name = "stakeholder_group")
+@Getter
+@Setter
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class StakeholderGroup {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "sg_id")
+    @EqualsAndHashCode.Include
+    private Integer id;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "is_active")
+    private String isActive;
+
+    @OneToMany(mappedBy = "stakeholderGroup")
+    private Set<Stakeholder> stakeholders;
+}

--- a/api/src/main/java/com/example/api/repository/StakeholderGroupRepository.java
+++ b/api/src/main/java/com/example/api/repository/StakeholderGroupRepository.java
@@ -1,0 +1,7 @@
+package com.example.api.repository;
+
+import com.example.api.models.StakeholderGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StakeholderGroupRepository extends JpaRepository<StakeholderGroup, Integer> {
+}

--- a/api/src/main/java/com/example/api/repository/StakeholderRepository.java
+++ b/api/src/main/java/com/example/api/repository/StakeholderRepository.java
@@ -1,0 +1,7 @@
+package com.example.api.repository;
+
+import com.example.api.models.Stakeholder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StakeholderRepository extends JpaRepository<Stakeholder, Integer> {
+}

--- a/api/src/main/java/com/example/api/service/StakeholderService.java
+++ b/api/src/main/java/com/example/api/service/StakeholderService.java
@@ -1,0 +1,24 @@
+package com.example.api.service;
+
+import com.example.api.dto.StakeholderDto;
+import com.example.api.mapper.DtoMapper;
+import com.example.api.repository.StakeholderRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class StakeholderService {
+    private final StakeholderRepository repository;
+
+    public StakeholderService(StakeholderRepository repository) {
+        this.repository = repository;
+    }
+
+    public List<StakeholderDto> getAll() {
+        return repository.findAll().stream()
+                .map(DtoMapper::toStakeholderDto)
+                .collect(Collectors.toList());
+    }
+}

--- a/ui/src/components/RaiseTicket/RequestorDetails.tsx
+++ b/ui/src/components/RaiseTicket/RequestorDetails.tsx
@@ -17,6 +17,7 @@ import { DropdownOption } from "../UI/Dropdown/GenericDropdown";
 import ViewToggle from "../UI/ViewToggle";
 import { useTranslation } from "react-i18next";
 import { checkFieldAccess } from "../../utils/permissions";
+import { getStakeholders } from "../../services/StakeholderService";
 
 interface RequestorDetailsProps extends FormProps {
     disableAll?: boolean;
@@ -26,11 +27,6 @@ const FCI_User = "fci";
 const NON_FCI_User = "nonFci";
 
 type ViewMode = typeof FCI_User | typeof NON_FCI_User;
-
-const stakeholderOptions: DropdownOption[] = [
-    { label: "Farmer", value: "Farmer" },
-    { label: "Miller", value: "Miller" }
-];
 
 const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, setValue, control, disableAll = false, createMode }) => {
     const [verified, setVerified] = useState<boolean>(false);
@@ -47,6 +43,7 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
 
     const { data: userDetailsData, pending, success, apiHandler: getUserDetailsApiHandler } = useApi<any>();
     const { data: usersData, apiHandler: getAllUsersApiHandler } = useApi<any>();
+    const { data: stakeholderData, apiHandler: getStakeholdersApiHandler } = useApi<any>();
 
     const userId = useWatch({ control, name: 'userId' });
     const mode = useWatch({ control, name: 'mode', defaultValue: 'Self' });
@@ -60,6 +57,9 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
 
     const allUsers = usersData || [];
     const filteredUsers = allUsers.filter((u: any) => !stakeholder || u.stakeholder === stakeholder);
+    const stakeholderOptions: DropdownOption[] = Array.isArray(stakeholderData)
+        ? stakeholderData.map((s: any) => ({ label: s.description, value: s.id }))
+        : [];
 
     const getUserDetailsHandler = (userId: any) => {
         getUserDetailsApiHandler(() => getUserDetails(userId))
@@ -95,7 +95,8 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
 
     useEffect(() => {
         getAllUsersApiHandler(() => getAllUsers());
-    }, [getAllUsersApiHandler]);
+        getStakeholdersApiHandler(() => getStakeholders());
+    }, [getAllUsersApiHandler, getStakeholdersApiHandler]);
 
     // On initial render, if mode is Self, verify and populate logged-in user details
     // useEffect(() => {

--- a/ui/src/components/RaiseTicket/TicketDetails.tsx
+++ b/ui/src/components/RaiseTicket/TicketDetails.tsx
@@ -59,10 +59,10 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
     // getDropdownOptions(arr, label, value)
     const assignLevelOptions: DropdownOption[] = getDropdownOptions(allLevels, 'levelName', 'levelId');
     const assignToOptions: DropdownOption[] = getDropdownOptions(allUsersByLevel, 'name', 'username');
-    const categoryOptions: DropdownOption[] = getDropdownOptions(allCategories, 'category', 'category');
+    const categoryOptions: DropdownOption[] = getDropdownOptions(allCategories, 'category', 'categoryId');
     const subCategoryOptions: DropdownOption[] = getDropdownOptions(allSubCategories, 'subCategory', 'subCategoryId');
     const statusOptions: DropdownOption[] = getDropdownOptions(nextStatusListByStatusIdData, 'action', 'nextStatus');
-    const priorityOptions: DropdownOption[] = Array.isArray(priorityList) ? priorityList.map((p: PriorityInfo) => ({ label: p.level, value: p.level })) : [];
+    const priorityOptions: DropdownOption[] = Array.isArray(priorityList) ? priorityList.map((p: PriorityInfo) => ({ label: p.level, value: p.id })) : [];
     const severityOptions: DropdownOption[] = Array.isArray(severityList) ? severityList.map((s: SeverityInfo) => ({ label: s.level, value: s.level })) : [];
 
     const priorityContent = Array.isArray(priorityList) ? (
@@ -140,11 +140,8 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
     }, [])
 
     useEffect(() => {
-        if (category && Array.isArray(allCategories)) {
-            const selectedCategory = allCategories.find((cat: any) => cat.category === category);
-            if (selectedCategory?.categoryId) {
-                getSubCategoriesApiHandler(() => getSubCategories(selectedCategory.categoryId));
-            }
+        if (category) {
+            getSubCategoriesApiHandler(() => getSubCategories(category));
         }
     }, [category])
 
@@ -196,6 +193,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
                             options={categoryOptions}
                             className="form-select"
                             disabled={disableAll}
+                            rules={{ required: 'Please select Category' }}
                         />
                     </div>
                 )}
@@ -208,6 +206,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
                             options={subCategoryOptions}
                             className="form-select"
                             disabled={disableAll || !category}
+                            rules={{ required: 'Please select Sub Category' }}
                         />
                     </div>
                 )}
@@ -220,6 +219,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
                             options={priorityOptions}
                             className="form-select flex-grow-1"
                             disabled={disableAll}
+                            rules={{ required: 'Please select Priority' }}
                         />
                         <InfoIcon content={priorityContent} />
                     </div>
@@ -297,6 +297,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
                             errors={errors}
                             type="text"
                             disabled={disableAll || subjectDisabled}
+                            required
                         />
                     </div>
                 )}
@@ -313,6 +314,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
                             multiline
                             rows={4}
                             disabled={disableAll}
+                            required
                         />
                     </div>
                 )}

--- a/ui/src/components/UI/InfoIcon.tsx
+++ b/ui/src/components/UI/InfoIcon.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import Popover from '@mui/material/Popover';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
+import { grey } from '@mui/material/colors';
 import { IconComponent } from './IconButton/CustomIconButton';
 export interface InfoIconProps {
   content?: React.ReactNode;
@@ -23,23 +24,28 @@ const InfoIcon: React.FC<InfoIconProps> = ({ content, text, title }) => {
   const open = Boolean(anchorEl);
 
   return (
-    <div 
-      onMouseEnter={handleOpen}
-      onMouseLeave={handleClose}
-    >
+    <div onMouseEnter={handleOpen} onMouseLeave={handleClose} style={{ display: 'inline-block' }}>
       <IconComponent
         icon='infoOutlined'
-        style={{ cursor: 'pointer' }}
+        style={{ cursor: 'pointer', color: grey[500] }}
       />
       <Popover
         open={open}
         anchorEl={anchorEl}
         onClose={handleClose}
+        onMouseLeave={handleClose}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
         disableRestoreFocus
-        PaperProps={{ sx: { pointerEvents: 'none', p: 1 } }}
+        PaperProps={{
+          sx: {
+            p: 0,
+            borderRadius: 2,
+            opacity: 0.9,
+            transition: 'opacity 0.3s ease-in-out'
+          }
+        }}
       >
-        <Box onMouseEnter={handleOpen} onMouseLeave={handleClose}>
+        <Box sx={{ p: 1, border: 1, borderRadius: 2 }}>
           {title && (
             <Typography variant="subtitle2" gutterBottom>
               {title}

--- a/ui/src/services/StakeholderService.ts
+++ b/ui/src/services/StakeholderService.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+import { BASE_URL } from './api';
+
+let stakeholderCache: any[] | null = null;
+
+export function getStakeholders() {
+    if (stakeholderCache) {
+        return Promise.resolve({ data: stakeholderCache } as any);
+    }
+    return axios.get(`${BASE_URL}/stakeholders`).then(res => {
+        stakeholderCache = res.data;
+        return res;
+    });
+}


### PR DESCRIPTION
## Summary
- add stakeholder & stakeholder group entities with REST endpoint
- validate ticket fields and submit stakeholder/category/etc by id
- restyle info popover with hover hide, fade and rounded border

## Testing
- `./api/gradlew -p api test` *(fails: Could not download typesense-java-0.2.0.jar (403 Forbidden))*
- `cd ui && npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b83cc0248332bf367010ab4eab1c