### PR TITLE
Switch to helpdesk support levels and add level filter

### DIFF
--- a/api/src/main/java/com/example/api/controller/AuthController.java
+++ b/api/src/main/java/com/example/api/controller/AuthController.java
@@ -43,6 +43,7 @@ public class AuthController {
                     session.setAttribute("username", request.getUsername());
                     session.setAttribute("password", request.getPassword());
                     session.setAttribute("roles", emp.getRoles());
+                    session.setAttribute("levels", emp.getUserLevel() != null ? emp.getUserLevel().getLevelId() : null);
 
                     List<String> roles = emp.getRoles() == null ? List.of()
                             : Arrays.asList(emp.getRoles().split("\\|"));
@@ -50,6 +51,10 @@ public class AuthController {
                             .filter(r -> !r.isBlank())
                             .map(Integer::parseInt)
                             .toList();
+
+                    List<String> levels = emp.getUserLevel() == null || emp.getUserLevel().getLevelId() == null
+                            ? List.of()
+                            : Arrays.asList(emp.getUserLevel().getLevelId().split("\\|"));
 
                     RolePermission permissions = permissionService.mergeRolePermissions(roleIds);
                     System.out.println("Perm: " + permissions);
@@ -59,7 +64,8 @@ public class AuthController {
                             "name", emp.getName(),
                             "username", emp.getUsername(),
                             "roles", roles,
-                            "permissions", permissions
+                            "permissions", permissions,
+                            "levels", levels
                     ));
                 })
                 .orElseGet(() -> ResponseEntity.status(HttpStatus.UNAUTHORIZED)

--- a/api/src/main/java/com/example/api/controller/TicketController.java
+++ b/api/src/main/java/com/example/api/controller/TicketController.java
@@ -67,9 +67,10 @@ public class TicketController {
             @RequestParam(required = false, name = "status") String statusId,
             @RequestParam(required = false) Boolean master,
             @RequestParam(required = false) String assignedTo,
+            @RequestParam(required = false) String levelId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
-        Page<TicketDto> p = ticketService.searchTickets(query, statusId, master, assignedTo, PageRequest.of(page, size));
+        Page<TicketDto> p = ticketService.searchTickets(query, statusId, master, assignedTo, levelId, PageRequest.of(page, size));
         PaginationResponse<TicketDto> resp = new PaginationResponse<>(p.getContent(), p.getNumber(), p.getSize(), p.getTotalElements(), p.getTotalPages());
         return ResponseEntity.ok(resp);
     }

--- a/api/src/main/java/com/example/api/dto/UserDto.java
+++ b/api/src/main/java/com/example/api/dto/UserDto.java
@@ -3,6 +3,8 @@ package com.example.api.dto;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.List;
+
 @Getter
 @Setter
 public class UserDto {
@@ -13,5 +15,5 @@ public class UserDto {
     private String mobileNo;
     private String office;
     private String roles;
-    private String levels;
+    private List<String> levels;
 }

--- a/api/src/main/java/com/example/api/mapper/DtoMapper.java
+++ b/api/src/main/java/com/example/api/mapper/DtoMapper.java
@@ -3,6 +3,8 @@ package com.example.api.mapper;
 import com.example.api.dto.*;
 import com.example.api.models.*;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -103,10 +105,8 @@ public class DtoMapper {
         userDto.setMobileNo(user.getMobileNo());
         userDto.setOffice(user.getOffice());
         userDto.setRoles(user.getRoles());
-        if (user.getLevels() != null) {
-            String levels = user.getLevels().stream()
-                    .map(Level::getLevelId)
-                    .collect(java.util.stream.Collectors.joining("|"));
+        if (user.getUserLevel() != null && user.getUserLevel().getLevelId() != null) {
+            List<String> levels = Arrays.asList(user.getUserLevel().getLevelId().split("\\|"));
             userDto.setLevels(levels);
         }
         return userDto;

--- a/api/src/main/java/com/example/api/models/Level.java
+++ b/api/src/main/java/com/example/api/models/Level.java
@@ -5,28 +5,18 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.Set;
-
 @Entity
-@Table(name = "levels")
+@Table(name = "helpdesk_support_levels")
 @Getter // Replaces @Data for getters
 @Setter // Replaces @Data for setters
 // IMPORTANT: Configure EqualsAndHashCode to only use the ID field
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class Level {
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "level_id")
+    @Column(name = "hl_level")
     @EqualsAndHashCode.Include
     private String levelId;
-    @Column(name = "level_name")
-    private String levelName;
 
-    @ManyToMany
-    @JoinTable(
-            name = "user_levels",
-            joinColumns = @JoinColumn(name = "level_id"),
-            inverseJoinColumns = @JoinColumn(name = "user_id")
-    )
-    private Set<User> users;
+    @Column(name = "hl_name")
+    private String levelName;
 }

--- a/api/src/main/java/com/example/api/models/User.java
+++ b/api/src/main/java/com/example/api/models/User.java
@@ -5,8 +5,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.Set;
-
 @Entity
 @Table(name = "users")
 @Getter // Replaces @Data for getters
@@ -33,8 +31,8 @@ public class User {
     @Column(name = "password")
     private String password;
 
-    @ManyToMany(mappedBy = "users")
-    private Set<Level> levels;
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    private UserLevel userLevel;
 
     private String roles;
 }

--- a/api/src/main/java/com/example/api/models/UserLevel.java
+++ b/api/src/main/java/com/example/api/models/UserLevel.java
@@ -1,0 +1,26 @@
+package com.example.api.models;
+
+import jakarta.persistence.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "user_levels")
+@Getter
+@Setter
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class UserLevel {
+    @Id
+    @Column(name = "user_id")
+    @EqualsAndHashCode.Include
+    private String userId;
+
+    @Column(name = "level_id")
+    private String levelId;
+
+    @OneToOne
+    @MapsId
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/api/src/main/java/com/example/api/repository/TicketRepository.java
+++ b/api/src/main/java/com/example/api/repository/TicketRepository.java
@@ -26,10 +26,11 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
             "WHERE (:statusId IS NULL OR s.statusId = :statusId) " +
             "AND (:master IS NULL OR t.isMaster = :master) " +
             "AND (:assignedTo IS NULL OR LOWER(t.assignedTo) = LOWER(:assignedTo)) " +
+            "AND (:levelId IS NULL OR t.levelId = :levelId) " +
             "AND (LOWER(t.requestorName) LIKE LOWER(CONCAT('%', :query, '%')) " +
             "OR LOWER(t.category) LIKE LOWER(CONCAT('%', :query, '%')) " +
             "OR LOWER(t.subCategory) LIKE LOWER(CONCAT('%', :query, '%')) " +
             "OR LOWER(t.subject) LIKE LOWER(CONCAT('%', :query, '%')) " +
             "OR LOWER(t.id) LIKE LOWER(CONCAT('%', :query, '%')) )")
-    Page<Ticket> searchTickets(@Param("query") String query, @Param("statusId") String statusName, @Param("master") Boolean master, @Param("assignedTo") String assignedTo, Pageable pageable);
+    Page<Ticket> searchTickets(@Param("query") String query, @Param("statusId") String statusName, @Param("master") Boolean master, @Param("assignedTo") String assignedTo, @Param("levelId") String levelId, Pageable pageable);
 }

--- a/api/src/main/java/com/example/api/repository/UserLevelRepository.java
+++ b/api/src/main/java/com/example/api/repository/UserLevelRepository.java
@@ -1,0 +1,10 @@
+package com.example.api.repository;
+
+import com.example.api.models.UserLevel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserLevelRepository extends JpaRepository<UserLevel, String> {
+    List<UserLevel> findByLevelIdContaining(String levelId);
+}

--- a/api/src/main/java/com/example/api/service/TicketService.java
+++ b/api/src/main/java/com/example/api/service/TicketService.java
@@ -163,8 +163,8 @@ public class TicketService {
         return typesenseClient.searchTickets(query);
     }
 
-    public Page<TicketDto> searchTickets(String query, String statusId, Boolean master, String assignedTo, Pageable pageable) {
-        Page<Ticket> page = ticketRepository.searchTickets(query, statusId, master, assignedTo, pageable);
+    public Page<TicketDto> searchTickets(String query, String statusId, Boolean master, String assignedTo, String levelId, Pageable pageable) {
+        Page<Ticket> page = ticketRepository.searchTickets(query, statusId, master, assignedTo, levelId, pageable);
         return page.map(this::mapWithStatusId);
     }
 

--- a/api/src/main/java/com/example/api/service/UserService.java
+++ b/api/src/main/java/com/example/api/service/UserService.java
@@ -2,14 +2,12 @@ package com.example.api.service;
 
 import com.example.api.dto.UserDto;
 import com.example.api.mapper.DtoMapper;
-import com.example.api.models.Level;
 import com.example.api.models.User;
 import com.example.api.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Service
 public class UserService {
@@ -33,10 +31,9 @@ public class UserService {
             dto.setMobileNo(emp.getMobileNo());
             dto.setOffice(emp.getOffice());
             dto.setRoles(emp.getRoles());
-            String levels = emp.getLevels() != null ? emp.getLevels().stream()
-                    .map(Level::getLevelId)
-                    .collect(Collectors.joining("|")) : null;
-            dto.setLevels(levels);
+            if (emp.getUserLevel() != null && emp.getUserLevel().getLevelId() != null) {
+                dto.setLevels(java.util.Arrays.asList(emp.getUserLevel().getLevelId().split("\\|")));
+            }
             return dto;
         }).toList();
     }

--- a/ui/src/components/AllTickets/AssigneeDropdown.tsx
+++ b/ui/src/components/AllTickets/AssigneeDropdown.tsx
@@ -18,7 +18,7 @@ interface AssigneeDropdownProps {
 }
 
 interface Level { levelId: string; levelName: string; }
-interface User { userId: string; username: string; name: string; roles?: string; levels?: string; levelId?: string; levelName?: string; }
+interface User { userId: string; username: string; name: string; roles?: string; levels?: string[]; levelId?: string; levelName?: string; }
 
 const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ ticketId, assigneeName, onAssigned, searchCurrentTicketsPaginatedApi }) => {
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
@@ -83,7 +83,7 @@ const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ ticketId, assigneeN
     const levelMap = Object.fromEntries(levels.map(l => [l.levelId, l.levelName]));
     const baseUsers: User[] = selectedLevel ? (usersData || []) : (allUsersData || []);
     const expandedUsers: User[] = baseUsers.flatMap(u => {
-        const ids = u.levels ? u.levels.split('|') : [''];
+        const ids = u.levels && u.levels.length ? u.levels : [''];
         return ids.map(id => ({ ...u, levelId: id, levelName: levelMap[id] }));
     });
     const allowedRoleIds = ['2', '3', '4', '6', '8'];

--- a/ui/src/pages/AllTickets.tsx
+++ b/ui/src/pages/AllTickets.tsx
@@ -53,6 +53,9 @@ const AllTickets: React.FC = () => {
     const [totalPages, setTotalPages] = useState(1);
     const [statusFilter, setStatusFilter] = useState("All");
     const [masterOnly, setMasterOnly] = useState(false);
+    const levels = getCurrentUserDetails()?.levels || [];
+    const [levelFilter, setLevelFilter] = useState<string | undefined>(undefined);
+    const showLevelFilterToggle = levels.length > 1;
     const { t } = useTranslation();
     const showTable = checkMyTicketsAccess('table');
 
@@ -70,7 +73,7 @@ const AllTickets: React.FC = () => {
     const debouncedSearch = useDebounce(search, 300);
 
     const searchTicketsPaginatedApi = (query: string, statusName?: string, master?: boolean, page: number = 0, size: number = 5) => {
-        searchTicketsPaginatedApiHandler(() => searchTicketsPaginated(query, statusName, master, page, size));
+        searchTicketsPaginatedApiHandler(() => searchTicketsPaginated(query, statusName, master, page, size, undefined, levelFilter));
     }
 
     const onIdClick = (id: string) => {
@@ -86,7 +89,7 @@ const AllTickets: React.FC = () => {
         async (id: string) => {
             setRefreshingTicketId(id);
             await searchTicketsPaginatedApiHandler(() =>
-                searchTicketsPaginated(debouncedSearch, statusFilter === 'All' ? undefined : statusFilter, masterOnly ? true : undefined, page - 1, pageSize)
+                searchTicketsPaginated(debouncedSearch, statusFilter === 'All' ? undefined : statusFilter, masterOnly ? true : undefined, page - 1, pageSize, undefined, levelFilter)
             );
             setRefreshingTicketId(null);
         },
@@ -95,7 +98,7 @@ const AllTickets: React.FC = () => {
 
     useEffect(() => {
         searchTicketsPaginatedApi(debouncedSearch, statusFilter === 'All' ? undefined : statusFilter, masterOnly ? true : undefined, page - 1, pageSize);
-    }, [debouncedSearch, statusFilter, masterOnly, page, pageSize]);
+    }, [debouncedSearch, statusFilter, masterOnly, levelFilter, page, pageSize]);
 
     useEffect(() => {
         getStatuses().then(setStatusList);
@@ -136,6 +139,16 @@ const AllTickets: React.FC = () => {
                         options={statusFilterOptions}
                         style={{ width: 180, marginRight: 8 }}
                     />
+                    {showLevelFilterToggle && levels.map(l => (
+                        <Chip
+                            key={l}
+                            label={l}
+                            color={levelFilter === l ? 'primary' : 'default'}
+                            variant={levelFilter === l ? 'filled' : 'outlined'}
+                            onClick={() => setLevelFilter(prev => prev === l ? undefined : l)}
+                            sx={{ mr: 1 }}
+                        />
+                    ))}
                     <Chip
                         label={t('Master')}
                         color={masterOnly ? 'primary' : 'default'}

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -11,6 +11,7 @@ type LoginResponse = {
     userId?: string;
     username?: string;
     roles?: string[];
+    levels?: string[];
     name?: string;
     [key: string]: any;
 };
@@ -33,6 +34,7 @@ const Login: React.FC = () => {
                     userId: res.userId || userId,
                     username: res.username,
                     role: res.roles,
+                    levels: res.levels,
                     name: res.name
                 };
                 setUserDetails(details);

--- a/ui/src/pages/MyTickets.tsx
+++ b/ui/src/pages/MyTickets.tsx
@@ -53,6 +53,9 @@ const MyTickets: React.FC = () => {
     const [totalPages, setTotalPages] = useState(1);
     const [statusFilter, setStatusFilter] = useState("All");
     const [masterOnly, setMasterOnly] = useState(false);
+    const levels = getCurrentUserDetails()?.levels || [];
+    const [levelFilter, setLevelFilter] = useState<string | undefined>(undefined);
+    const showLevelFilterToggle = levels.length > 1;
 
     const showSearchBar = checkMyTicketsAccess('searchBar');
     const showStatusFilter = checkMyTicketsAccess('statusFilter');
@@ -74,7 +77,7 @@ const MyTickets: React.FC = () => {
 
     const searchTicketsPaginatedApi = (query: string, statusName?: string, master?: boolean, page: number = 0, size: number = 5) => {
         const username = getCurrentUserDetails()?.username || "";
-        return searchTicketsPaginatedApiHandler(() => searchTicketsPaginated(query, statusName, master, page, size, username));
+        return searchTicketsPaginatedApiHandler(() => searchTicketsPaginated(query, statusName, master, page, size, username, levelFilter));
     };
 
     const onIdClick = (id: string) => {
@@ -92,12 +95,12 @@ const MyTickets: React.FC = () => {
             await searchTicketsPaginatedApi(debouncedSearch, statusFilter === 'All' ? undefined : statusFilter, masterOnly ? true : undefined, page - 1, pageSize);
             setRefreshingTicketId(null);
         },
-        [debouncedSearch, statusFilter, masterOnly, page, pageSize]
+        [debouncedSearch, statusFilter, masterOnly, levelFilter, page, pageSize]
     );
 
     useEffect(() => {
         searchTicketsPaginatedApi(debouncedSearch, statusFilter === 'All' ? undefined : statusFilter, masterOnly ? true : undefined, page - 1, pageSize);
-    }, [debouncedSearch, statusFilter, masterOnly, page, pageSize]);
+    }, [debouncedSearch, statusFilter, masterOnly, levelFilter, page, pageSize]);
 
     useEffect(() => {
         getStatuses().then(setStatusList);
@@ -142,6 +145,16 @@ const MyTickets: React.FC = () => {
                             style={{ width: 180, marginRight: 8 }}
                         />
                     )}
+                    {showLevelFilterToggle && levels.map(l => (
+                        <Chip
+                            key={l}
+                            label={l}
+                            color={levelFilter === l ? 'primary' : 'default'}
+                            variant={levelFilter === l ? 'filled' : 'outlined'}
+                            onClick={() => setLevelFilter(prev => prev === l ? undefined : l)}
+                            sx={{ mr: 1 }}
+                        />
+                    ))}
                     {showMasterFilterToggle && (
                         <Chip
                             label={t('Master')}

--- a/ui/src/services/TicketService.ts
+++ b/ui/src/services/TicketService.ts
@@ -46,10 +46,11 @@ export function deleteComment(commentId: string) {
     return axios.delete(`${BASE_URL}/tickets/comments/${commentId}`);
 }
 
-export function searchTicketsPaginated(query: string, statusName?: string, master?: boolean, page: number = 0, size: number = 5, assignedTo?: string) {
+export function searchTicketsPaginated(query: string, statusName?: string, master?: boolean, page: number = 0, size: number = 5, assignedTo?: string, levelId?: string) {
     const params = new URLSearchParams({ query, page: String(page), size: String(size) });
     if (statusName) params.append('status', statusName);
     if (master !== undefined) params.append('master', String(master));
     if (assignedTo) params.append('assignedTo', assignedTo);
+    if (levelId) params.append('levelId', levelId);
     return axios.get(`${BASE_URL}/tickets/search?${params.toString()}`);
 }

--- a/ui/src/utils/Utils.ts
+++ b/ui/src/utils/Utils.ts
@@ -4,6 +4,7 @@ export interface UserDetails {
   userId: string;
   username?: string;
   role?: string[];
+  levels?: string[];
   name?: string;
   email?: string;
   phone?: string;


### PR DESCRIPTION
## Summary
- replace legacy level table with `helpdesk_support_levels`
- return user levels as arrays and expose them in auth/login
- add ticket search filtering by level and UI level toggle

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation matching languageVersion=17)*
- `npm test --silent` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e0d299c48332b10d9f9b1b9ee2a0