### PR TITLE
Add login themes and session guard

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import './App.css';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import RaiseTicket from './pages/RaiseTicket';
@@ -13,12 +14,22 @@ import SidebarLayout from './components/Layout/SidebarLayout';
 import Login from './pages/Login';
 import MyTickets from './pages/MyTickets';
 import Faq from './pages/Faq';
+import { getUserDetails, getUserPermissions } from './utils/Utils';
+
+const RequireAuth: React.FC<{ children: JSX.Element }> = ({ children }) => {
+  const user = getUserDetails();
+  const perms = getUserPermissions();
+  if (!user?.userId || !perms) {
+    return <Navigate to="/login" replace />;
+  }
+  return children;
+};
 
 function App() {
   return (
     <Routes>
       <Route path="/login" element={<Login />} />
-      <Route path="/" element={<SidebarLayout />}>
+      <Route path="/" element={<RequireAuth><SidebarLayout /></RequireAuth>}>
         <Route index element={<Navigate to="/create-ticket" replace />} />
         <Route path="create-ticket" element={<RaiseTicket />} />
         <Route path="tickets" element={<AllTickets />} />

--- a/ui/src/components/Layout/SidebarLayout.tsx
+++ b/ui/src/components/Layout/SidebarLayout.tsx
@@ -4,8 +4,10 @@ import Sidebar from "./Sidebar";
 import Header from "./Header";
 import Drawer from "@mui/material/Drawer";
 import { useTheme, useMediaQuery } from "@mui/material";
+import { useAuthGuard } from "../../hooks/useAuthGuard";
 
 const SidebarLayout: React.FC = () => {
+  useAuthGuard();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const [collapsedState, setCollapsedState] = useState(false);

--- a/ui/src/hooks/useAuthGuard.ts
+++ b/ui/src/hooks/useAuthGuard.ts
@@ -1,0 +1,26 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { getUserDetails, getUserPermissions } from "../utils/Utils";
+
+export const useAuthGuard = () => {
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        const check = () => {
+            const user = getUserDetails();
+            const perms = getUserPermissions();
+            if (!user?.userId || !perms) {
+                navigate("/login");
+            }
+        };
+        check();
+        const id = setInterval(check, 1000);
+        window.addEventListener("storage", check);
+        return () => {
+            clearInterval(id);
+            window.removeEventListener("storage", check);
+        };
+    }, [navigate]);
+};
+
+export default useAuthGuard;

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -1,10 +1,76 @@
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { loginUser } from "../services/AuthService";
 import { getCurrentUserDetails } from "../config/config";
 import { RolePermission, setPermissions } from "../utils/permissions";
 import { setUserDetails, UserDetails } from "../utils/Utils";
 import { useApi } from "../hooks/useApi";
+import { DevModeContext } from "../context/DevModeContext";
+import PersonIcon from "@mui/icons-material/Person";
+import LockIcon from "@mui/icons-material/Lock";
+
+interface ThemeProps {
+    userId: string;
+    password: string;
+    setUserId: (v: string) => void;
+    setPassword: (v: string) => void;
+    handleSubmit: (e: React.FormEvent) => void;
+}
+
+const ThemeOne: React.FC<ThemeProps> = ({ userId, password, setUserId, setPassword, handleSubmit }) => (
+    <div style={{ display: "flex", height: "100vh", justifyContent: "center", alignItems: "center", background: "#f5f5f5" }}>
+        <div style={{ background: "#fff", padding: "2rem", borderRadius: "8px", boxShadow: "0 0 10px rgba(0,0,0,0.1)", textAlign: "center", width: "300px" }}>
+            <h2 style={{ color: "#1b5e20" }}>Login</h2>
+            <form onSubmit={handleSubmit}>
+                <div className="mb-3 text-start">
+                    <label className="form-label">User ID</label>
+                    <input className="form-control" value={userId} onChange={e => setUserId(e.target.value)} />
+                </div>
+                <div className="mb-3 text-start">
+                    <label className="form-label">Password</label>
+                    <input type="password" className="form-control" value={password} onChange={e => setPassword(e.target.value)} />
+                </div>
+                <button style={{ background: "#FF671F", border: "none" }} className="btn w-100 text-white" type="submit">Login</button>
+            </form>
+        </div>
+    </div>
+);
+
+const ThemeTwo: React.FC<ThemeProps> = ({ userId, password, setUserId, setPassword, handleSubmit }) => (
+    <div style={{ display: "flex", height: "100vh", justifyContent: "center", alignItems: "center", background: "linear-gradient(135deg, #1b5e20, #FF671F)" }}>
+        <form onSubmit={handleSubmit} style={{ background: "#fff", padding: "2rem", borderRadius: "8px", width: "320px", boxShadow: "0 0 10px rgba(0,0,0,0.2)" }}>
+            <h2 style={{ textAlign: "center", color: "#FF671F" }}>Sign In</h2>
+            <div className="mb-3">
+                <label className="form-label">User ID</label>
+                <input className="form-control" value={userId} onChange={e => setUserId(e.target.value)} />
+            </div>
+            <div className="mb-3">
+                <label className="form-label">Password</label>
+                <input type="password" className="form-control" value={password} onChange={e => setPassword(e.target.value)} />
+            </div>
+            <button style={{ background: "#1b5e20", border: "none" }} className="btn w-100 text-white" type="submit">Login</button>
+        </form>
+    </div>
+);
+
+const ThemeThree: React.FC<ThemeProps> = ({ userId, password, setUserId, setPassword, handleSubmit }) => (
+    <div style={{ display: "flex", height: "100vh", justifyContent: "center", alignItems: "center", background: "#fff8e1" }}>
+        <div style={{ width: "280px" }}>
+            <h2 style={{ textAlign: "center", color: "#1b5e20", marginBottom: "1rem" }}>Welcome Back</h2>
+            <form onSubmit={handleSubmit}>
+                <div style={{ display: "flex", alignItems: "center", border: "1px solid #1b5e20", borderRadius: "4px", padding: "0.5rem", marginBottom: "1rem" }}>
+                    <PersonIcon style={{ color: "#FF671F", marginRight: "0.5rem" }} />
+                    <input style={{ border: "none", outline: "none", flex: 1 }} value={userId} onChange={e => setUserId(e.target.value)} placeholder="User ID" />
+                </div>
+                <div style={{ display: "flex", alignItems: "center", border: "1px solid #1b5e20", borderRadius: "4px", padding: "0.5rem", marginBottom: "1rem" }}>
+                    <LockIcon style={{ color: "#FF671F", marginRight: "0.5rem" }} />
+                    <input type="password" style={{ border: "none", outline: "none", flex: 1 }} value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+                </div>
+                <button style={{ background: "#FF671F", border: "none" }} className="btn w-100 text-white" type="submit">Login</button>
+            </form>
+        </div>
+    </div>
+);
 
 type LoginResponse = {
     permissions?: RolePermission;
@@ -19,13 +85,15 @@ type LoginResponse = {
 const Login: React.FC = () => {
     const [userId, setUserId] = useState("");
     const [password, setPassword] = useState("");
+    const [themeIdx, setThemeIdx] = useState(0);
     const navigate = useNavigate();
+    const { devMode } = useContext(DevModeContext);
 
-    const { data: loginData, apiHandler: loginApiHandler } = useApi()
+    const { data: loginData, apiHandler: loginApiHandler } = useApi();
 
     useEffect(() => {
         if (loginData) {
-            const res: LoginResponse = loginData
+            const res: LoginResponse = loginData;
             if (res) {
                 if (res.permissions) {
                     setPermissions(res.permissions);
@@ -46,42 +114,39 @@ const Login: React.FC = () => {
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
         const roles = getCurrentUserDetails()?.role as string[];
+        loginApiHandler(() => loginUser({ username: userId, password, roles }));
+    };
 
-        loginApiHandler(() => loginUser({ username: userId, password, roles }))
+    const changeTheme = (delta: number) => {
+        setThemeIdx((prev) => {
+            const total = 3;
+            return (prev + delta + total) % total;
+        });
+    };
 
-        // loginUser({ username: userId, password, roles })
-        //     .then(response => {
-        //         let res = response.data.body
-        //         if (res.data) {
-        //             if (res.data.permissions) {
-        //                 setPermissions(res.data.permissions);
-        //             }
-        //             const details = {
-        //                 userId: res.data.userId || userId,
-        //                 role: roles,
-        //                 name: res.data.name
-        //             };
-        //             setUserDetails(details);
-        //         }
-        //         navigate("/");
-        //     });
+    const renderTheme = () => {
+        switch (themeIdx) {
+            case 0:
+                return <ThemeOne userId={userId} password={password} setUserId={setUserId} setPassword={setPassword} handleSubmit={handleSubmit} />;
+            case 1:
+                return <ThemeTwo userId={userId} password={password} setUserId={setUserId} setPassword={setPassword} handleSubmit={handleSubmit} />;
+            case 2:
+                return <ThemeThree userId={userId} password={password} setUserId={setUserId} setPassword={setPassword} handleSubmit={handleSubmit} />;
+            default:
+                return <ThemeOne userId={userId} password={password} setUserId={setUserId} setPassword={setPassword} handleSubmit={handleSubmit} />;
+        }
     };
 
     return (
-        <div className="container mt-5" style={{ maxWidth: "400px" }}>
-            <h3 className="mb-3">Login</h3>
-            <form onSubmit={handleSubmit}>
-                <div className="mb-3">
-                    <label className="form-label">User ID</label>
-                    <input className="form-control" value={userId} onChange={e => setUserId(e.target.value)} />
+        <>
+            {renderTheme()}
+            {devMode && (
+                <div style={{ position: "fixed", bottom: "20px", width: "100%", display: "flex", justifyContent: "space-between", padding: "0 20px" }}>
+                    <button className="btn btn-light" onClick={() => changeTheme(-1)}>&larr;</button>
+                    <button className="btn btn-light" onClick={() => changeTheme(1)}>&rarr;</button>
                 </div>
-                <div className="mb-3">
-                    <label className="form-label">Password</label>
-                    <input type="password" className="form-control" value={password} onChange={e => setPassword(e.target.value)} />
-                </div>
-                <button className="btn btn-primary" type="submit">Login</button>
-            </form>
-        </div>
+            )}
+        </>
     );
 };
 


### PR DESCRIPTION
## Summary
- enforce login as entry point and redirect when session data missing
- add multiple stylized login themes with dev-mode navigation arrows
- create reusable auth guard hook for session validation

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e967f6748332a9bb821d075744c2