### PR TITLE
Fix level-based user lookup and display IDs in assignee dropdown

### DIFF
--- a/api/src/main/java/com/example/api/repository/UserLevelRepository.java
+++ b/api/src/main/java/com/example/api/repository/UserLevelRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface UserLevelRepository extends JpaRepository<UserLevel, String> {
-    List<UserLevel> findByLevelIdContaining(String levelId);
+    List<UserLevel> findByLevelIdsContaining(String levelId);
 
     UserLevel findByUserId(String userId);
 }

--- a/api/src/main/java/com/example/api/service/LevelService.java
+++ b/api/src/main/java/com/example/api/service/LevelService.java
@@ -31,7 +31,7 @@ public class LevelService {
     }
 
     public Optional<Set<UserDto>> getUsersByLevel(String levelId) {
-        List<UserLevel> userLevels = userLevelRepository.findByLevelIdContaining(levelId);
+        List<UserLevel> userLevels = userLevelRepository.findByLevelIdsContaining(levelId);
         if (userLevels.isEmpty()) return Optional.empty();
         Set<UserDto> userDtos = new HashSet<>();
         for (UserLevel ul : userLevels) {

--- a/ui/src/components/AllTickets/AssigneeDropdown.tsx
+++ b/ui/src/components/AllTickets/AssigneeDropdown.tsx
@@ -80,11 +80,10 @@ const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ ticketId, assigneeN
     };
 
     const levels: Level[] = levelsData || [];
-    const levelMap = Object.fromEntries(levels.map(l => [l.levelId, l.levelName]));
     const baseUsers: User[] = selectedLevel ? (usersData || []) : (allUsersData || []);
     const expandedUsers: User[] = baseUsers.flatMap(u => {
         const ids = u.levels && u.levels.length ? u.levels : [''];
-        return ids.map(id => ({ ...u, levelId: id, levelName: levelMap[id] }));
+        return ids.map(id => ({ ...u, levelId: id }));
     });
     const allowedRoleIds = ['2', '3', '4', '6', '8'];
     const allowedUsers = expandedUsers.filter(u =>
@@ -124,7 +123,7 @@ const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ ticketId, assigneeN
                         {levels.map(l => (
                             <Chip
                                 key={l.levelId}
-                                label={l.levelName}
+                                label={l.levelId}
                                 onClick={() => setSelectedLevel(prev => prev === l.levelId ? '' : l.levelId)}
                                 color={selectedLevel === l.levelId ? 'primary' : 'default'}
                                 size="small"
@@ -137,7 +136,7 @@ const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ ticketId, assigneeN
                             {filtered.map(u => (
                                 <ListItemButton key={`${u.userId}-${u.levelId}`} onClick={() => handleSelect(u)}>
                                     <Box sx={{ display: 'flex', width: '100%' }}>
-                                        <Box sx={{ width: 60 }}>{u.levelName}</Box>
+                                        <Box sx={{ width: 60 }}>{u.levelId}</Box>
                                         <Box sx={{ flexGrow: 1 }}>{u.name}</Box>
                                         <Box sx={{ width: 80, fontStyle: 'italic', color: 'text.secondary' }}>{u.username}</Box>
                                     </Box>


### PR DESCRIPTION
## Summary
- query user levels using `levelIds` to return correct users per level
- show level identifiers instead of names in the assignee dropdown

## Testing
- `./gradlew test` *(fails: Could not resolve com.github.typesense:typesense-java:0.2.0: Received status code 403 from server)*
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68aaec15b1b883328961efc2b24d3a4b