### PR TITLE
feat: add user menu with logout option

### DIFF
--- a/ui/src/components/Layout/Header.tsx
+++ b/ui/src/components/Layout/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { ThemeModeContext } from "../../context/ThemeContext";
 import CustomIconButton from "../UI/IconButton/CustomIconButton";
 import Avatar from "@mui/material/Avatar";
@@ -6,6 +6,7 @@ import { getCurrentUserDetails } from "../../config/config";
 import { useTheme } from "@mui/material/styles";
 import { LanguageContext } from "../../context/LanguageContext";
 import { DevModeContext } from "../../context/DevModeContext";
+import UserMenu from "./UserMenu";
 
 interface HeaderProps {
   collapsed: boolean;
@@ -18,6 +19,7 @@ const Header: React.FC<HeaderProps> = ({ collapsed, toggleSidebar }) => {
   const { toggleDevMode, devMode } = useContext(DevModeContext);
   const theme = useTheme();
   const user = getCurrentUserDetails();
+  const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
   const initials = user?.name
     ? user?.name
       .split(" ")
@@ -36,6 +38,14 @@ const Header: React.FC<HeaderProps> = ({ collapsed, toggleSidebar }) => {
     theme.palette.mode === "dark"
       ? theme.palette.success.main
       : theme.palette.getContrastText(headerBgColor);
+
+  const handleAvatarClick = (event: React.MouseEvent<HTMLElement>) => {
+    setMenuAnchorEl(event.currentTarget);
+  };
+
+  const handleMenuClose = () => {
+    setMenuAnchorEl(null);
+  };
 
   return (
     <header
@@ -96,11 +106,14 @@ const Header: React.FC<HeaderProps> = ({ collapsed, toggleSidebar }) => {
             width: 32,
             height: 32,
             fontSize: 14,
+            cursor: "pointer",
           }}
+          onClick={handleAvatarClick}
         >
           {initials}
         </Avatar>
       </div>
+      <UserMenu anchorEl={menuAnchorEl} open={Boolean(menuAnchorEl)} onClose={handleMenuClose} />
     </header>
   );
 };

--- a/ui/src/components/Layout/UserMenu.tsx
+++ b/ui/src/components/Layout/UserMenu.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Menu, MenuItem, ListItemIcon } from "@mui/material";
+import LogoutIcon from "@mui/icons-material/Logout";
+import { logout } from "../../utils/Utils";
+
+interface UserMenuProps {
+  anchorEl: null | HTMLElement;
+  open: boolean;
+  onClose: () => void;
+}
+
+const UserMenu: React.FC<UserMenuProps> = ({ anchorEl, open, onClose }) => {
+  const handleLogout = () => {
+    onClose();
+    if (window.confirm("Are you sure you want to logout?")) {
+      logout();
+    }
+  };
+
+  return (
+    <Menu anchorEl={anchorEl} open={open} onClose={onClose} anchorOrigin={{ vertical: "bottom", horizontal: "right" }} transformOrigin={{ vertical: "top", horizontal: "right" }}>
+      <MenuItem onClick={handleLogout}>
+        <ListItemIcon>
+          <LogoutIcon fontSize="small" />
+        </ListItemIcon>
+        Logout
+      </MenuItem>
+    </Menu>
+  );
+};
+
+export default UserMenu;

--- a/ui/src/utils/Utils.ts
+++ b/ui/src/utils/Utils.ts
@@ -92,3 +92,9 @@ export function formatDateWithSuffix(date: string | Date): string {
   const year = d.getFullYear();
   return `${day}${suffix} ${month}, ${year}`;
 }
+
+export function logout() {
+  sessionStorage.clear();
+  statusCache = null;
+  window.location.href = '/login';
+}


### PR DESCRIPTION
## Summary
- add UserMenu floating menu component with logout option
- integrate user menu into Header triggered by avatar click
- add logout utility to clear session and redirect to login

## Testing
- `npm test --silent -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68accd913d50833295c3fff5d8341471