### PR TITLE
Add mode permission handling and assignee validation

### DIFF
--- a/ui/src/components/RaiseTicket/RequestDetails.tsx
+++ b/ui/src/components/RaiseTicket/RequestDetails.tsx
@@ -4,7 +4,7 @@ import CustomFormInput from "../UI/Input/CustomFormInput";
 import { useWatch } from "react-hook-form";
 import CustomFieldset from "../CustomFieldset";
 import { isHelpdesk } from "../../config/config";
-import { checkFieldAccess } from "../../utils/permissions";
+import { checkFieldAccess, getFieldChildren } from "../../utils/permissions";
 import React, { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import CustomIconButton from "../UI/IconButton/CustomIconButton";
@@ -31,9 +31,14 @@ const RequestDetails: React.FC<RequestDetailsProps> = ({ register, control, erro
     const helpdesk = true
     const theme = useTheme();
 
+    const modeChildren = getFieldChildren('requestDetails', 'mode') || {};
+    const allowedModes = modeOptions.filter(opt => modeChildren?.[opt.value]?.show);
+
     useEffect(() => {
-        setValue && setValue("mode", "Self");
-    }, [setValue]);
+        if (setValue && allowedModes.length) {
+            setValue("mode", allowedModes[0].value);
+        }
+    }, [setValue, allowedModes.length]);
 
     const { t } = useTranslation();
     return (
@@ -42,7 +47,7 @@ const RequestDetails: React.FC<RequestDetailsProps> = ({ register, control, erro
                 // <CustomFieldset variant="basic" title={t('Request Mode')} style={{ width: 'fit-content' }} className="d-flex">
                 <div className="d-flex gap-4 align-items-center px-4 py-2 border rounded-2 mb-4" style={{ width: 'fit-content' }}>
                     <span className="text-muted fs-6 ">{t('Request Mode')}</span>
-                    {modeOptions.map(opt => (
+                    {allowedModes.map(opt => (
                         <div
                             key={opt.value}
                             onClick={() => setValue && setValue('mode', opt.value)}

--- a/ui/src/components/RaiseTicket/TicketDetails.tsx
+++ b/ui/src/components/RaiseTicket/TicketDetails.tsx
@@ -383,6 +383,8 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
                                     label="Assign to"
                                     options={assignToOptions}
                                     className="form-select"
+                                    disabled={!assignToLevel}
+                                    rules={assignToLevel ? { required: 'Please select Assignee' } : undefined}
                                 />
                             </div>
                         )}
@@ -614,6 +616,8 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
                                     label="Assign to"
                                     options={assignToOptions}
                                     className="form-select"
+                                    disabled={!assignToLevel}
+                                    rules={assignToLevel ? { required: 'Please select Assignee' } : undefined}
                                 />
                             </div>
                         )}

--- a/ui/src/utils/permissions.ts
+++ b/ui/src/utils/permissions.ts
@@ -37,6 +37,11 @@ export function checkFieldAccess(section: string, field: string): boolean {
   return !!fields[field]?.show;
 }
 
+export function getFieldChildren(section: string, field: string) {
+  const perms = getUserPermissions() as RolePermission | null;
+  return perms?.pages?.children?.ticketForm?.children?.[section]?.children?.[field]?.children;
+}
+
 export function checkMyTicketsAccess(key: string): boolean {
   const perms = getUserPermissions() as RolePermission | null;
   return perms?.pages?.children?.myTickets?.children?.[key]?.show ?? false;


### PR DESCRIPTION
## Summary
- filter request mode options based on permissions and set default
- require assignee selection after level chosen in ticket details
- expose utility to fetch field children permissions

## Testing
- `npm test` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68adaec5af008332be6c795c41f88cd8