### PR TITLE
Ensure assignee dropdown visible when column is accessible

### DIFF
--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -57,17 +57,14 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
     const priorityMap: Record<string, number> = { Low: 1, Medium: 2, High: 3, Critical: 4 };
 
     const getAvailableActions = (statusId?: string) => {
-        console.log(statusWorkflows, statusId);
         return (statusWorkflows[statusId || ''] || []).filter(a => {
-            console.log({ a })
-            return !disallowed.includes(a.action)
-        })
+            return !disallowed.includes(a.action);
+        });
     };
 
     const allowAssigneeChange = (statusId?: string) => {
-        console.log(statusWorkflows);
-        return (statusWorkflows[statusId || ''] || []).some(a => disallowed.includes(a.action));
-    }
+        return Boolean(statusWorkflows[statusId || '']);
+    };
 
     const getActionIcon = (action: string) => {
         switch (action) {


### PR DESCRIPTION
## Summary
- Show AssigneeDropdown once status workflows are loaded, without restricting by workflow actions

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*


------
https://chatgpt.com/codex/tasks/task_e_68ade1f84fdc8332beef768f4bb8e648