### PR TITLE
Add sorting options for My Tickets

### DIFF
--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -17,6 +17,8 @@ import { updateTicket } from '../../services/TicketService';
 import { useApi } from '../../hooks/useApi';
 import { getCurrentUserDetails } from '../../config/config';
 import { Popover } from 'antd';
+import DropdownController from '../UI/Dropdown/DropdownController';
+import { DropdownOption } from '../UI/Dropdown/GenericDropdown';
 
 export interface TicketRow {
     id: string;
@@ -40,9 +42,11 @@ interface TicketsTableProps {
     onIdClick: (id: string) => void;
     refreshingTicketId?: string | null;
     statusWorkflows: Record<string, TicketStatusWorkflow[]>;
+    sortBy: string;
+    onSortChange: (value: string) => void;
 }
 
-const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowClick, searchCurrentTicketsPaginatedApi, refreshingTicketId, statusWorkflows }) => {
+const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowClick, searchCurrentTicketsPaginatedApi, refreshingTicketId, statusWorkflows, sortBy, onSortChange }) => {
     console.log(tickets)
     const { t } = useTranslation();
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -55,6 +59,11 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
     const disallowed = ['Assign', 'Further Assign', 'Assign / Assign Further', 'Assign Further'];
 
     const priorityMap: Record<string, number> = { Low: 1, Medium: 2, High: 3, Critical: 4 };
+
+    const sortOptions: DropdownOption[] = [
+        { label: 'Created Date', value: 'reportedDate' },
+        { label: 'Latest Updated', value: 'lastModified' },
+    ];
 
     const getAvailableActions = (statusId?: string) => {
         console.log(statusWorkflows, statusId);
@@ -240,6 +249,15 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
 
     return (
         <>
+            <div className="d-flex justify-content-end mb-2">
+                <DropdownController
+                    label="Sort By"
+                    value={sortBy}
+                    onChange={onSortChange}
+                    options={sortOptions}
+                    style={{ width: 200 }}
+                />
+            </div>
             <GenericTable
                 dataSource={tickets}
                 columns={columns as any}

--- a/ui/src/pages/MyTickets.tsx
+++ b/ui/src/pages/MyTickets.tsx
@@ -56,6 +56,8 @@ const MyTickets: React.FC = () => {
     const levels = getCurrentUserDetails()?.levels || [];
     const [levelFilter, setLevelFilter] = useState<string | undefined>(undefined);
     const showLevelFilterToggle = levels.length > 1;
+    const [sortBy, setSortBy] = useState<'reportedDate' | 'lastModified'>('reportedDate');
+    const sortDirection: 'asc' | 'desc' = 'desc';
 
     const showSearchBar = checkMyTicketsAccess('searchBar');
     const showStatusFilter = checkMyTicketsAccess('statusFilter');
@@ -77,7 +79,9 @@ const MyTickets: React.FC = () => {
 
     const searchTicketsPaginatedApi = (query: string, statusName?: string, master?: boolean, page: number = 0, size: number = 5) => {
         const username = getCurrentUserDetails()?.username || "";
-        return searchTicketsPaginatedApiHandler(() => searchTicketsPaginated(query, statusName, master, page, size, username, levelFilter));
+        return searchTicketsPaginatedApiHandler(() =>
+            searchTicketsPaginated(query, statusName, master, page, size, username, levelFilter, sortBy, sortDirection)
+        );
     };
 
     const onIdClick = (id: string) => {
@@ -95,12 +99,18 @@ const MyTickets: React.FC = () => {
             await searchTicketsPaginatedApi(debouncedSearch, statusFilter === 'All' ? undefined : statusFilter, masterOnly ? true : undefined, page - 1, pageSize);
             setRefreshingTicketId(null);
         },
-        [debouncedSearch, statusFilter, masterOnly, levelFilter, page, pageSize]
+        [debouncedSearch, statusFilter, masterOnly, levelFilter, page, pageSize, sortBy, sortDirection]
     );
 
     useEffect(() => {
-        searchTicketsPaginatedApi(debouncedSearch, statusFilter === 'All' ? undefined : statusFilter, masterOnly ? true : undefined, page - 1, pageSize);
-    }, [debouncedSearch, statusFilter, masterOnly, levelFilter, page, pageSize]);
+        searchTicketsPaginatedApi(
+            debouncedSearch,
+            statusFilter === 'All' ? undefined : statusFilter,
+            masterOnly ? true : undefined,
+            page - 1,
+            pageSize
+        );
+    }, [debouncedSearch, statusFilter, masterOnly, levelFilter, page, pageSize, sortBy, sortDirection]);
 
     useEffect(() => {
         getStatuses().then(setStatusList);
@@ -179,7 +189,19 @@ const MyTickets: React.FC = () => {
                 {error && <p className="text-danger">{t('Error loading tickets')}</p>}
                 {viewMode === 'table' && showTable && (
                     <div>
-                        <TicketsTable tickets={filtered} onIdClick={onIdClick} onRowClick={(id: any) => navigate(`/tickets/${id}`)} searchCurrentTicketsPaginatedApi={searchCurrentTicketsPaginatedApi} refreshingTicketId={refreshingTicketId} statusWorkflows={workflowMap} />
+                        <TicketsTable
+                            tickets={filtered}
+                            onIdClick={onIdClick}
+                            onRowClick={(id: any) => navigate(`/tickets/${id}`)}
+                            searchCurrentTicketsPaginatedApi={searchCurrentTicketsPaginatedApi}
+                            refreshingTicketId={refreshingTicketId}
+                            statusWorkflows={workflowMap}
+                            sortBy={sortBy}
+                            onSortChange={(value) => {
+                                setSortBy(value as 'reportedDate' | 'lastModified');
+                                setPage(1);
+                            }}
+                        />
                         <div className="d-flex justify-content-between align-items-center mt-3">
                             <PaginationControls page={page} totalPages={totalPages} onChange={(_, val) => setPage(val)} />
                             <div className="d-flex align-items-center">

--- a/ui/src/services/TicketService.ts
+++ b/ui/src/services/TicketService.ts
@@ -46,11 +46,23 @@ export function deleteComment(commentId: string) {
     return axios.delete(`${BASE_URL}/tickets/comments/${commentId}`);
 }
 
-export function searchTicketsPaginated(query: string, statusName?: string, master?: boolean, page: number = 0, size: number = 5, assignedTo?: string, levelId?: string) {
+export function searchTicketsPaginated(
+    query: string,
+    statusName?: string,
+    master?: boolean,
+    page: number = 0,
+    size: number = 5,
+    assignedTo?: string,
+    levelId?: string,
+    sortBy?: string,
+    direction?: string
+) {
     const params = new URLSearchParams({ query, page: String(page), size: String(size) });
     if (statusName) params.append('status', statusName);
     if (master !== undefined) params.append('master', String(master));
     if (assignedTo) params.append('assignedTo', assignedTo);
     if (levelId) params.append('levelId', levelId);
+    if (sortBy) params.append('sortBy', sortBy);
+    if (direction) params.append('direction', direction);
     return axios.get(`${BASE_URL}/tickets/search?${params.toString()}`);
 }


### PR DESCRIPTION
## Summary
- add Sort By dropdown to tickets table
- track sort selection in MyTickets and request API accordingly
- allow ticket search API to receive sorting parameters

## Testing
- ❌ `CI=true npm test -- --watchAll=false` (fails: Cannot find module 'react-router-dom' from 'src/App.tsx')

------
https://chatgpt.com/codex/tasks/task_e_68ade1f7f2e883329efbbddc4262443b