### PR TITLE
feat: add FAQ management and modals

### DIFF
--- a/api/src/main/java/com/example/api/controller/FaqController.java
+++ b/api/src/main/java/com/example/api/controller/FaqController.java
@@ -1,0 +1,28 @@
+package com.example.api.controller;
+
+import com.example.api.dto.FaqDto;
+import com.example.api.service.FaqService;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/faqs")
+@CrossOrigin(origins = "http://localhost:3000")
+@AllArgsConstructor
+public class FaqController {
+    private final FaqService faqService;
+
+    @GetMapping
+    public ResponseEntity<List<FaqDto>> getFaqs() {
+        return ResponseEntity.ok(faqService.getAllFaqs());
+    }
+
+    @PostMapping
+    public ResponseEntity<FaqDto> createFaq(@RequestBody FaqDto faqDto) {
+        return ResponseEntity.ok(faqService.createFaq(faqDto));
+    }
+}
+

--- a/api/src/main/java/com/example/api/dto/FaqDto.java
+++ b/api/src/main/java/com/example/api/dto/FaqDto.java
@@ -1,0 +1,16 @@
+package com.example.api.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FaqDto {
+    private String id;
+    private String questionEn;
+    private String questionHi;
+    private String answerEn;
+    private String answerHi;
+    private String keywords;
+}
+

--- a/api/src/main/java/com/example/api/mapper/DtoMapper.java
+++ b/api/src/main/java/com/example/api/mapper/DtoMapper.java
@@ -170,4 +170,16 @@ public class DtoMapper {
         dto.setIsActive(group.getIsActive());
         return dto;
     }
+
+    public static FaqDto toFaqDto(Faq faq) {
+        if (faq == null) return null;
+        FaqDto dto = new FaqDto();
+        dto.setId(faq.getId());
+        dto.setQuestionEn(faq.getQuestionEn());
+        dto.setQuestionHi(faq.getQuestionHi());
+        dto.setAnswerEn(faq.getAnswerEn());
+        dto.setAnswerHi(faq.getAnswerHi());
+        dto.setKeywords(faq.getKeywords());
+        return dto;
+    }
 }

--- a/api/src/main/java/com/example/api/models/Faq.java
+++ b/api/src/main/java/com/example/api/models/Faq.java
@@ -1,0 +1,29 @@
+package com.example.api.models;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Entity
+@Table(name = "faqs")
+@Data
+public class Faq {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    @Column(name = "question_en")
+    private String questionEn;
+
+    @Column(name = "question_hi")
+    private String questionHi;
+
+    @Column(name = "answer_en", columnDefinition = "TEXT")
+    private String answerEn;
+
+    @Column(name = "answer_hi", columnDefinition = "TEXT")
+    private String answerHi;
+
+    @Column(name = "keywords")
+    private String keywords;
+}
+

--- a/api/src/main/java/com/example/api/repository/FaqRepository.java
+++ b/api/src/main/java/com/example/api/repository/FaqRepository.java
@@ -1,0 +1,8 @@
+package com.example.api.repository;
+
+import com.example.api.models.Faq;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FaqRepository extends JpaRepository<Faq, String> {
+}
+

--- a/api/src/main/java/com/example/api/service/FaqService.java
+++ b/api/src/main/java/com/example/api/service/FaqService.java
@@ -1,0 +1,37 @@
+package com.example.api.service;
+
+import com.example.api.dto.FaqDto;
+import com.example.api.mapper.DtoMapper;
+import com.example.api.models.Faq;
+import com.example.api.repository.FaqRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class FaqService {
+    private final FaqRepository faqRepository;
+
+    public FaqService(FaqRepository faqRepository) {
+        this.faqRepository = faqRepository;
+    }
+
+    public List<FaqDto> getAllFaqs() {
+        return faqRepository.findAll().stream()
+                .map(DtoMapper::toFaqDto)
+                .collect(Collectors.toList());
+    }
+
+    public FaqDto createFaq(FaqDto dto) {
+        Faq faq = new Faq();
+        faq.setQuestionEn(dto.getQuestionEn());
+        faq.setQuestionHi(dto.getQuestionHi());
+        faq.setAnswerEn(dto.getAnswerEn());
+        faq.setAnswerHi(dto.getAnswerHi());
+        faq.setKeywords(dto.getKeywords());
+        Faq saved = faqRepository.save(faq);
+        return DtoMapper.toFaqDto(saved);
+    }
+}
+

--- a/db/ticketing_system_dump.sql
+++ b/db/ticketing_system_dump.sql
@@ -841,6 +841,21 @@ INSERT INTO `users` VALUES (201,'Arjun Mehta','arjun.mehta@example.com','9123456
 UNLOCK TABLES;
 
 --
+-- Table structure for table `faqs`
+--
+
+DROP TABLE IF EXISTS `faqs`;
+CREATE TABLE `faqs` (
+  `id` varchar(36) NOT NULL,
+  `question_en` text,
+  `question_hi` text,
+  `answer_en` text,
+  `answer_hi` text,
+  `keywords` text,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+--
 -- Temporary view structure for view `users_view`
 --
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -31,6 +31,7 @@
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.56.4",
         "react-i18next": "^15.5.3",
+        "react-quill": "^2.0.0",
         "react-router-dom": "^7.6.1",
         "react-scripts": "5.0.1",
         "sass": "^1.89.0",
@@ -4911,6 +4912,15 @@
       "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
       "license": "MIT"
     },
+    "node_modules/@types/quill": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.10.tgz",
+      "integrity": "sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==",
+      "license": "MIT",
+      "dependencies": {
+        "parchment": "^1.1.2"
+      }
+    },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
@@ -6890,6 +6900,15 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -7755,6 +7774,26 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "license": "MIT"
+    },
+    "node_modules/deep-equal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+      "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arguments": "^1.1.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -9230,11 +9269,23 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -10657,6 +10708,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-array-buffer": {
@@ -13078,6 +13145,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -13359,6 +13442,12 @@
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "node_modules/parchment": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
+      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -15112,6 +15201,40 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quill": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
+      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1",
+        "eventemitter3": "^2.0.3",
+        "extend": "^3.0.2",
+        "parchment": "^1.1.4",
+        "quill-delta": "^3.6.2"
+      }
+    },
+    "node_modules/quill-delta": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
+      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "^1.0.1",
+        "extend": "^3.0.2",
+        "fast-diff": "1.1.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/quill/node_modules/eventemitter3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+      "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg==",
+      "license": "MIT"
+    },
     "node_modules/raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -15974,6 +16097,21 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
+    },
+    "node_modules/react-quill": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
+      "integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/quill": "^1.3.10",
+        "lodash": "^4.17.4",
+        "quill": "^1.3.7"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.11.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -27,6 +27,7 @@
     "react-hook-form": "^7.56.4",
     "react-i18next": "^15.5.3",
     "react-router-dom": "^7.6.1",
+    "react-quill": "^2.0.0",
     "react-scripts": "5.0.1",
     "sass": "^1.89.0",
     "typesense": "^1.2.1",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -14,6 +14,7 @@ import SidebarLayout from './components/Layout/SidebarLayout';
 import Login from './pages/Login';
 import MyTickets from './pages/MyTickets';
 import Faq from './pages/Faq';
+import FaqForm from './pages/FaqForm';
 import { getUserDetails, getUserPermissions } from './utils/Utils';
 
 const RequireAuth: React.FC<{ children: JSX.Element }> = ({ children }) => {
@@ -35,6 +36,7 @@ function App() {
         <Route path="tickets" element={<AllTickets />} />
         <Route path="my-tickets" element={<MyTickets />} />
         <Route path="faq" element={<Faq />} />
+        <Route path="faq/new" element={<FaqForm />} />
         <Route path="tickets/:ticketId" element={<TicketDetails />} />
         <Route path="tickets/:ticketId/feedback" element={<CustomerSatisfactionForm />} />
         <Route path="knowledge-base" element={<KnowledgeBase />} />

--- a/ui/src/components/UI/FailureModal.tsx
+++ b/ui/src/components/UI/FailureModal.tsx
@@ -1,0 +1,26 @@
+import { Modal, Box } from '@mui/material';
+import HighlightOffIcon from '@mui/icons-material/HighlightOff';
+import './StatusModal.scss';
+
+interface FailureModalProps {
+  open: boolean;
+  title: string;
+  subtext?: string;
+  actions?: React.ReactNode;
+  onClose: () => void;
+}
+
+const FailureModal: React.FC<FailureModalProps> = ({ open, title, subtext, actions, onClose }) => (
+  <Modal open={open} onClose={onClose}>
+    <Box className="modal-box status-modal-error">
+      <div className="top-line" />
+      <h4 className="text-danger fw-bold mb-3 text-center">{title}</h4>
+      <HighlightOffIcon className="icon" />
+      {subtext && <p className="mb-3">{subtext}</p>}
+      {actions && <div className="d-flex flex-column flex-md-row justify-content-center gap-2">{actions}</div>}
+    </Box>
+  </Modal>
+);
+
+export default FailureModal;
+

--- a/ui/src/components/UI/StatusModal.scss
+++ b/ui/src/components/UI/StatusModal.scss
@@ -1,0 +1,33 @@
+.status-modal-success,
+.status-modal-error {
+  width: 65% !important;
+
+  .top-line {
+    height: 4px;
+    border-radius: 4px 4px 0 0;
+    margin-bottom: 16px;
+  }
+
+  .icon {
+    font-size: 48px;
+  }
+}
+
+.status-modal-success {
+  .top-line {
+    background-color: #1b5e20;
+  }
+  .icon {
+    color: #1b5e20;
+  }
+}
+
+.status-modal-error {
+  .top-line {
+    background-color: #e53935;
+  }
+  .icon {
+    color: #e53935;
+  }
+}
+

--- a/ui/src/components/UI/SuccessModal.tsx
+++ b/ui/src/components/UI/SuccessModal.tsx
@@ -1,0 +1,28 @@
+import { Modal, Box } from '@mui/material';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import './StatusModal.scss';
+
+interface SuccessModalProps {
+  open: boolean;
+  title: string;
+  subtext?: string;
+  actions?: React.ReactNode;
+  onClose: () => void;
+}
+
+const SuccessModal: React.FC<SuccessModalProps> = ({ open, title, subtext, actions, onClose }) => {
+  return (
+    <Modal open={open} onClose={onClose}>
+      <Box className="modal-box status-modal-success">
+        <div className="top-line" />
+        <h4 className="text-success fw-bold mb-3 text-center">{title}</h4>
+        <CheckCircleOutlineIcon className="icon" />
+        {subtext && <p className="mb-3">{subtext}</p>}
+        {actions && <div className="d-flex flex-column flex-md-row justify-content-center gap-2">{actions}</div>}
+      </Box>
+    </Modal>
+  );
+};
+
+export default SuccessModal;
+

--- a/ui/src/pages/Faq.tsx
+++ b/ui/src/pages/Faq.tsx
@@ -1,11 +1,40 @@
 import { useTheme } from "@mui/material/styles";
 import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
 
 const Faq: React.FC = () => {
     const { t } = useTranslation();
-    const theme = useTheme()
+    const theme = useTheme();
+    const navigate = useNavigate();
 
-    return (<>FAQ</>)
+    const faqs = [
+        {
+            question: "How do I reset my password?",
+            answer: "Click on the 'Forgot password' link on the login page and follow the instructions.",
+            keywords: "password|reset|account"
+        },
+        {
+            question: "How can I create a ticket?",
+            answer: "Navigate to the create ticket page and fill out the required details.",
+            keywords: "ticket|create|help"
+        }
+    ];
+
+    return (
+        <div className="p-3">
+            <div className="d-flex justify-content-end mb-3">
+                <button className="btn btn-primary" onClick={() => navigate('/faq/new')}>
+                    {t('Add Q & A')}
+                </button>
+            </div>
+            {faqs.map((item, index) => (
+                <div key={index} className="mb-4">
+                    <h5 className="ts-20" data-keywords={item.keywords}>{item.question}</h5>
+                    <p className="ts-16" data-keywords={item.keywords}>{item.answer}</p>
+                </div>
+            ))}
+        </div>
+    );
 }
 
 export default Faq;

--- a/ui/src/pages/FaqForm.tsx
+++ b/ui/src/pages/FaqForm.tsx
@@ -1,0 +1,96 @@
+import { useForm } from 'react-hook-form';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import ReactQuill from 'react-quill';
+import 'react-quill/dist/quill.snow.css';
+import { createFaq } from '../services/FaqService';
+import SuccessModal from '../components/UI/SuccessModal';
+import FailureModal from '../components/UI/FailureModal';
+
+interface FaqFormValues {
+  questionEn?: string;
+  questionHi?: string;
+  answerEn?: string;
+  answerHi?: string;
+  keywords?: string;
+}
+
+const FaqForm: React.FC = () => {
+  const { register, handleSubmit, reset, setValue, watch } = useForm<FaqFormValues>();
+  const navigate = useNavigate();
+  const [successOpen, setSuccessOpen] = useState(false);
+  const [failureOpen, setFailureOpen] = useState(false);
+
+  const onSubmit = async (data: FaqFormValues) => {
+      const hasQuestion = data.questionEn || data.questionHi;
+      const hasAnswer = data.answerEn || data.answerHi;
+      if (!hasQuestion || !hasAnswer) {
+          alert('Please provide at least one question and one answer.');
+          return;
+      }
+      if (!data.questionEn || !data.questionHi) {
+          const confirm = window.confirm('Are you sure you want to submit without adding both versions of the question?');
+          if (!confirm) return;
+      }
+      if (!data.answerEn || !data.answerHi) {
+          const confirm = window.confirm('Are you sure you want to submit without adding both versions of the answer?');
+          if (!confirm) return;
+      }
+
+      try {
+          await createFaq(data);
+          setSuccessOpen(true);
+      } catch (e) {
+          setFailureOpen(true);
+      }
+  };
+
+  const answerEn = watch('answerEn') || '';
+  const answerHi = watch('answerHi') || '';
+
+  return (
+    <div className="p-3">
+      <form onSubmit={handleSubmit(onSubmit)} className="d-flex flex-column gap-3">
+        <div className="d-flex gap-3">
+          <input className="form-control" placeholder="Question (English)" {...register('questionEn')} />
+          <input className="form-control" placeholder="Question (Hindi)" {...register('questionHi')} />
+        </div>
+        <div className="d-flex gap-3">
+          <div className="flex-grow-1">
+            <ReactQuill value={answerEn} onChange={(v) => setValue('answerEn', v)} />
+          </div>
+          <div className="flex-grow-1">
+            <ReactQuill value={answerHi} onChange={(v) => setValue('answerHi', v)} />
+          </div>
+        </div>
+        <input className="form-control" placeholder="Keywords (pipe separated)" {...register('keywords')} />
+        <button type="submit" className="btn btn-primary align-self-end">Submit</button>
+      </form>
+
+      <SuccessModal
+        open={successOpen}
+        title="Question and answer created successfully"
+        onClose={() => { setSuccessOpen(false); reset(); }}
+        actions={(
+          <>
+            <button className="btn btn-outline-primary" onClick={() => { setSuccessOpen(false); reset(); }}>
+              Create a new question and answer
+            </button>
+            <button className="btn btn-outline-secondary" onClick={() => navigate('/faq')}>
+              Go to FAQ
+            </button>
+          </>
+        )}
+      />
+
+      <FailureModal
+        open={failureOpen}
+        title="Failed to create question and answer"
+        onClose={() => setFailureOpen(false)}
+      />
+    </div>
+  );
+};
+
+export default FaqForm;
+

--- a/ui/src/services/FaqService.ts
+++ b/ui/src/services/FaqService.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+import { BASE_URL } from './api';
+
+export function getFaqs() {
+  return axios.get(`${BASE_URL}/faqs`);
+}
+
+export function createFaq(faq: any) {
+  return axios.post(`${BASE_URL}/faqs`, faq);
+}
+

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -85,6 +85,15 @@ export interface ApiResponse<T> {
     timestamp: string;
 }
 
+export interface Faq {
+    id: string;
+    questionEn?: string;
+    questionHi?: string;
+    answerEn?: string;
+    answerHi?: string;
+    keywords?: string;
+}
+
 export interface PermissionNode {
     show?: boolean;
     metadata?: {


### PR DESCRIPTION
## Summary
- add FAQ backend entity, DTO, service, controller
- add SQL table for FAQs with keywords
- implement FAQ page with add button and form with bilingual inputs and rich text editor
- create reusable success and failure modals

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*
- `./gradlew test` *(fails: Cannot find a Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_e_68b1415ccf5c8332973351a9cfe24efd