### PR TITLE
Enhance FAQ data model and UI

### DIFF
--- a/api/src/main/java/com/example/api/dto/FaqDto.java
+++ b/api/src/main/java/com/example/api/dto/FaqDto.java
@@ -3,6 +3,8 @@ package com.example.api.dto;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 public class FaqDto {
@@ -12,5 +14,9 @@ public class FaqDto {
     private String answerEn;
     private String answerHi;
     private String keywords;
+    private String createdBy;
+    private LocalDateTime createdOn;
+    private String updatedBy;
+    private LocalDateTime updatedOn;
 }
 

--- a/api/src/main/java/com/example/api/mapper/DtoMapper.java
+++ b/api/src/main/java/com/example/api/mapper/DtoMapper.java
@@ -180,6 +180,10 @@ public class DtoMapper {
         dto.setAnswerEn(faq.getAnswerEn());
         dto.setAnswerHi(faq.getAnswerHi());
         dto.setKeywords(faq.getKeywords());
+        dto.setCreatedBy(faq.getCreatedBy());
+        dto.setCreatedOn(faq.getCreatedOn());
+        dto.setUpdatedBy(faq.getUpdatedBy());
+        dto.setUpdatedOn(faq.getUpdatedOn());
         return dto;
     }
 }

--- a/api/src/main/java/com/example/api/models/Faq.java
+++ b/api/src/main/java/com/example/api/models/Faq.java
@@ -3,6 +3,8 @@ package com.example.api.models;
 import jakarta.persistence.*;
 import lombok.Data;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "faqs")
 @Data
@@ -25,5 +27,17 @@ public class Faq {
 
     @Column(name = "keywords")
     private String keywords;
+
+    @Column(name = "created_by")
+    private String createdBy;
+
+    @Column(name = "created_on")
+    private LocalDateTime createdOn;
+
+    @Column(name = "updated_by")
+    private String updatedBy;
+
+    @Column(name = "updated_on")
+    private LocalDateTime updatedOn;
 }
 

--- a/api/src/main/java/com/example/api/service/FaqService.java
+++ b/api/src/main/java/com/example/api/service/FaqService.java
@@ -30,6 +30,10 @@ public class FaqService {
         faq.setAnswerEn(dto.getAnswerEn());
         faq.setAnswerHi(dto.getAnswerHi());
         faq.setKeywords(dto.getKeywords());
+        faq.setCreatedBy(dto.getCreatedBy());
+        faq.setCreatedOn(dto.getCreatedOn());
+        faq.setUpdatedBy(dto.getUpdatedBy());
+        faq.setUpdatedOn(dto.getUpdatedOn());
         Faq saved = faqRepository.save(faq);
         return DtoMapper.toFaqDto(saved);
     }

--- a/db/ticketing_system_dump.sql
+++ b/db/ticketing_system_dump.sql
@@ -162,6 +162,9 @@ CREATE TABLE `faqs` (
 
 LOCK TABLES `faqs` WRITE;
 /*!40000 ALTER TABLE `faqs` DISABLE KEYS */;
+INSERT INTO `faqs` (`id`,`question_en`,`question_hi`,`answer_en`,`answer_hi`,`keywords`,`created_by`,`created_on`,`updated_by`,`updated_on`) VALUES
+('1','How do I reset my password?','मेरा पासवर्ड कैसे रीसेट करें?','Click on the ''Forgot password'' link on the login page and follow the instructions.','लॉगिन पृष्ठ पर "पासवर्ड भूल गए" लिंक पर क्लिक करें और निर्देशों का पालन करें.','password|reset|account','system','2024-01-01 10:00:00',NULL,NULL),
+('2','How can I create a ticket?','मैं टिकट कैसे बना सकता हूँ?','Navigate to the create ticket page and fill out the required details.','टिकट बनाने वाले पृष्ठ पर जाएँ और आवश्यक विवरण भरें.','ticket|create|help','system','2024-01-01 10:05:00',NULL,NULL);
 /*!40000 ALTER TABLE `faqs` ENABLE KEYS */;
 UNLOCK TABLES;
 

--- a/ui/src/pages/Faq.tsx
+++ b/ui/src/pages/Faq.tsx
@@ -1,38 +1,39 @@
-import { useTheme } from "@mui/material/styles";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
+import Title from "../components/Title";
+import { getFaqs } from "../services/FaqService";
+import { Faq as FaqType } from "../types";
 
 const Faq: React.FC = () => {
-    const { t } = useTranslation();
-    const theme = useTheme();
+    const { t, i18n } = useTranslation();
     const navigate = useNavigate();
+    const [faqs, setFaqs] = useState<FaqType[]>([]);
 
-    const faqs = [
-        {
-            question: "How do I reset my password?",
-            answer: "Click on the 'Forgot password' link on the login page and follow the instructions.",
-            keywords: "password|reset|account"
-        },
-        {
-            question: "How can I create a ticket?",
-            answer: "Navigate to the create ticket page and fill out the required details.",
-            keywords: "ticket|create|help"
-        }
-    ];
+    useEffect(() => {
+        getFaqs().then(res => setFaqs(res.data));
+    }, []);
 
     return (
         <div className="p-3">
-            <div className="d-flex justify-content-end mb-3">
-                <button className="btn btn-primary" onClick={() => navigate('/faq/new')}>
-                    {t('Add Q & A')}
-                </button>
-            </div>
-            {faqs.map((item, index) => (
-                <div key={index} className="mb-4">
-                    <h5 className="ts-20" data-keywords={item.keywords}>{item.question}</h5>
-                    <p className="ts-16" data-keywords={item.keywords}>{item.answer}</p>
-                </div>
-            ))}
+            <Title
+                textKey="FAQ"
+                rightContent={
+                    <button className="btn btn-primary" onClick={() => navigate('/faq/new')}>
+                        {t('Add Q & A')}
+                    </button>
+                }
+            />
+            {faqs.map((item, index) => {
+                const question = i18n.language === 'hi' ? (item.questionHi || item.questionEn) : (item.questionEn || item.questionHi);
+                const answer = i18n.language === 'hi' ? (item.answerHi || item.answerEn) : (item.answerEn || item.answerHi);
+                return (
+                    <div key={index} className="mb-4">
+                        <h5 className="ts-20" data-keywords={item.keywords}>{question}</h5>
+                        <p className="ts-16" data-keywords={item.keywords}>{answer}</p>
+                    </div>
+                );
+            })}
         </div>
     );
 }

--- a/ui/src/pages/FaqForm.tsx
+++ b/ui/src/pages/FaqForm.tsx
@@ -5,6 +5,8 @@ import { createFaq } from '../services/FaqService';
 import SuccessModal from '../components/UI/SuccessModal';
 import FailureModal from '../components/UI/FailureModal';
 import CustomFormInput from '../components/UI/Input/CustomFormInput';
+import Title from '../components/Title';
+import { getCurrentUserDetails } from '../config/config';
 
 interface FaqFormValues {
   questionEn?: string;
@@ -12,6 +14,8 @@ interface FaqFormValues {
   answerEn?: string;
   answerHi?: string;
   keywords?: string;
+  createdBy?: string;
+  createdOn?: string;
 }
 
 const FaqForm: React.FC = () => {
@@ -25,6 +29,8 @@ const FaqForm: React.FC = () => {
   const onSubmit = async (data: FaqFormValues) => {
       data.answerEn = answerEnRef.current?.value;
       data.answerHi = answerHiRef.current?.value;
+      data.createdBy = getCurrentUserDetails()?.userId;
+      data.createdOn = new Date().toISOString();
       const hasQuestion = data.questionEn || data.questionHi;
       const hasAnswer = data.answerEn || data.answerHi;
       if (!hasQuestion || !hasAnswer) {
@@ -50,6 +56,7 @@ const FaqForm: React.FC = () => {
 
   return (
     <div className="p-3">
+      <Title textKey="Add Q & A" />
       <form onSubmit={handleSubmit(onSubmit)} className="d-flex flex-column gap-3">
         <div className="d-flex gap-3">
           <CustomFormInput

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -92,6 +92,10 @@ export interface Faq {
     answerEn?: string;
     answerHi?: string;
     keywords?: string;
+    createdBy?: string;
+    createdOn?: string;
+    updatedBy?: string;
+    updatedOn?: string;
 }
 
 export interface PermissionNode {


### PR DESCRIPTION
## Summary
- extend FAQ entity/DTO/service with creator and timestamp fields
- show FAQ list from API and add Title component
- send creator metadata when submitting new FAQ
- seed FAQ table with example data

## Testing
- `./gradlew test` *(fails: Cannot find Java installation)*
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68b15701427c833299a1bb4d68670188