### PR TITLE
Fix ticket assignee mapping on creation

### DIFF
--- a/ui/src/pages/RaiseTicket.tsx
+++ b/ui/src/pages/RaiseTicket.tsx
@@ -36,11 +36,13 @@ const RaiseTicket: React.FC<any> = () => {
             emailId,
             mobileNo,
             stakeholder,
+            assignTo,
+            assignToLevel,
             ...rest
         } = formValues;
 
         // Build JSON payload without attachments
-        const payload = {
+        const payload: any = {
             ...rest,
             requestorName: name,
             requestorEmailId: emailId,
@@ -49,6 +51,10 @@ const RaiseTicket: React.FC<any> = () => {
             // include time (ISO-8601) similar to lastModified
             reportedDate: new Date()
         };
+
+        // Map assignment fields to backend expected keys
+        if (assignTo) payload.assignedTo = assignTo;
+        if (assignToLevel) payload.levelId = assignToLevel;
 
         const formData = new FormData();
         Object.entries(payload).forEach(([key, value]) => {


### PR DESCRIPTION
## Summary
- map assignment fields in RaiseTicket to backend keys so tickets get an assignee

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*
- `./gradlew test` *(fails: Failed to calculate value of task ':compileJava' property 'javaCompiler'; Java 17 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b1671483988332939a819452a77a94