### PR TITLE
Fix attachment upload duplication and allow removal

### DIFF
--- a/api/src/main/java/com/example/api/controller/TicketController.java
+++ b/api/src/main/java/com/example/api/controller/TicketController.java
@@ -84,6 +84,11 @@ public class TicketController {
         return ResponseEntity.ok(ticketService.addAttachments(id, paths));
     }
 
+    @DeleteMapping("/{id}/attachments")
+    public ResponseEntity<TicketDto> deleteAttachment(@PathVariable String id, @RequestParam String path) {
+        return ResponseEntity.ok(ticketService.removeAttachment(id, path));
+    }
+
     @PutMapping("/{id}")
     public ResponseEntity<TicketDto> updateTicket(@PathVariable String id, @RequestBody Ticket ticket) {
         return ResponseEntity.ok(ticketService.updateTicket(id, ticket));

--- a/api/src/main/java/com/example/api/repository/UploadedFileRepository.java
+++ b/api/src/main/java/com/example/api/repository/UploadedFileRepository.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface UploadedFileRepository extends JpaRepository<UploadedFile, String> {
     List<UploadedFile> findByTicket_IdAndIsActive(String ticketId, String isActive);
+    java.util.Optional<UploadedFile> findByTicket_IdAndRelativePath(String ticketId, String relativePath);
 }

--- a/api/src/main/java/com/example/api/service/TicketService.java
+++ b/api/src/main/java/com/example/api/service/TicketService.java
@@ -317,6 +317,24 @@ public class TicketService {
         return mapWithStatusId(saved);
     }
 
+    public TicketDto removeAttachment(String id, String path) {
+        Ticket ticket = ticketRepository.findById(id)
+                .orElseThrow(() -> new TicketNotFoundException(id));
+        if (ticket.getAttachmentPath() != null && !ticket.getAttachmentPath().isEmpty()) {
+            java.util.List<String> list = new java.util.ArrayList<>(
+                    java.util.Arrays.asList(ticket.getAttachmentPath().split(",")));
+            list.removeIf(p -> p.equals(path));
+            ticket.setAttachmentPath(String.join(",", list));
+        }
+        uploadedFileRepository.findByTicket_IdAndRelativePath(id, path)
+                .ifPresent(uf -> {
+                    uf.setIsActive("N");
+                    uploadedFileRepository.save(uf);
+                });
+        Ticket saved = ticketRepository.save(ticket);
+        return mapWithStatusId(saved);
+    }
+
     public TicketDto linkToMaster(String id, String masterId) {
         Ticket ticket = ticketRepository.findById(id)
                 .orElseThrow(() -> new TicketNotFoundException(id));

--- a/ui/src/components/TicketView.tsx
+++ b/ui/src/components/TicketView.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { Box, Typography, TextField, MenuItem, Select, SelectChangeEvent } from '@mui/material';
 import UserAvatar from './UI/UserAvatar/UserAvatar';
 import { useApi } from '../hooks/useApi';
-import { getTicket, updateTicket, addAttachments } from '../services/TicketService';
+import { getTicket, updateTicket, addAttachments, deleteAttachment } from '../services/TicketService';
 import { BASE_URL } from '../services/api';
 import { getCurrentUserDetails } from '../config/config';
 import { getPriorities } from '../services/PriorityService';
@@ -114,6 +114,16 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
     });
   };
 
+  const handleAttachmentRemove = (index: number) => {
+    const att = attachments[index];
+    const path = att.replace(`${BASE_URL}/uploads/`, '');
+    if (window.confirm('Are you sure you want to delete this file?')) {
+      deleteAttachment(ticketId, path).then(() => {
+        setAttachments(prev => prev.filter((_, i) => i !== index));
+      });
+    }
+  };
+
   const renderText = (value: string, onChange: (v: string) => void, multiline?: boolean) => (
     editing ? (
       <TextField
@@ -198,7 +208,7 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
       </Box>
       {attachments.length > 0 && (
         <Box sx={{ mt: 2 }}>
-          <ThumbnailList attachments={attachments} thumbnailSize={100} />
+          <ThumbnailList attachments={attachments} thumbnailSize={100} onRemove={handleAttachmentRemove} />
         </Box>
       )}
       <Box sx={{ mt: 1 }}>

--- a/ui/src/components/UI/FileUpload.tsx
+++ b/ui/src/components/UI/FileUpload.tsx
@@ -181,11 +181,9 @@ const FileUpload: React.FC<FileUploadProps> = ({ maxSizeMB, thumbnailSize, onFil
     }, [attachments]);
 
     const handleRemove = (index: number) => {
-        setFiles((prev) => {
-            const updated = prev.filter((_, i) => i !== index);
-            onFilesChange?.(updated);
-            return updated;
-        });
+        const updated = files.filter((_, i) => i !== index);
+        setFiles(updated);
+        onFilesChange?.(updated);
     };
 
     const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -200,11 +198,9 @@ const FileUpload: React.FC<FileUploadProps> = ({ maxSizeMB, thumbnailSize, onFil
             }
         });
         if (valid.length > 0) {
-            setFiles((prev) => {
-                const updated = [...prev, ...valid];
-                onFilesChange?.(updated);
-                return updated;
-            });
+            const updated = [...files, ...valid];
+            setFiles(updated);
+            onFilesChange?.(valid);
             setError('');
         }
         e.target.value = '';

--- a/ui/src/services/TicketService.ts
+++ b/ui/src/services/TicketService.ts
@@ -18,6 +18,12 @@ export function addAttachments(id: string, files: File[] | FileList) {
     });
 }
 
+export function deleteAttachment(id: string, path: string) {
+    return axios.delete(`${BASE_URL}/tickets/${id}/attachments`, {
+        params: { path }
+    });
+}
+
 export function getTickets(page: number = 0, size: number = 5) {
     return axios.get(`${BASE_URL}/tickets?page=${page}&size=${size}`);
 }


### PR DESCRIPTION
## Summary
- ensure attachment upload triggers API once and uploads new files only
- allow removing ticket attachments with confirmation
- support backend endpoint to delete attachments and mark uploads inactive

## Testing
- `./gradlew test` *(fails: Could not initialize SSL context / dependency resolution)*
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68b170fe55e88332a05e84f1a548f60f