### PR TITLE
feat: add advanced ticket assignment options

### DIFF
--- a/api/src/main/java/com/example/api/controller/TicketController.java
+++ b/api/src/main/java/com/example/api/controller/TicketController.java
@@ -90,8 +90,9 @@ public class TicketController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<TicketDto> updateTicket(@PathVariable String id, @RequestBody Ticket ticket) {
-        return ResponseEntity.ok(ticketService.updateTicket(id, ticket));
+    public ResponseEntity<java.util.Map<String, Object>> updateTicket(@PathVariable String id, @RequestBody Ticket ticket) {
+        TicketDto dto = ticketService.updateTicket(id, ticket);
+        return ResponseEntity.ok(java.util.Map.of("ticket", dto));
     }
 
     @PostMapping("/{id}/comments")

--- a/api/src/main/java/com/example/api/controller/UserController.java
+++ b/api/src/main/java/com/example/api/controller/UserController.java
@@ -22,6 +22,12 @@ public class UserController {
         return ResponseEntity.ok(userService.getAllUsers());
     }
 
+    @GetMapping("/regional-nodal-officers")
+    public ResponseEntity<List<UserDto>> getRegionalNodalOfficers() {
+        // role id 4 corresponds to Regional Nodal Officer
+        return ResponseEntity.ok(userService.getUsersByRole("4"));
+    }
+
     @GetMapping("/{userId}")
     public ResponseEntity<?> getUserDetails(@PathVariable String userId) {
 //        Optional<User> user = userService.getUserDetails(userId);

--- a/api/src/main/java/com/example/api/repository/UserRepository.java
+++ b/api/src/main/java/com/example/api/repository/UserRepository.java
@@ -2,9 +2,15 @@ package com.example.api.repository;
 
 import com.example.api.models.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, String> {
     Optional<User> findByUsername(String username);
+
+    @Query(value = "SELECT * FROM users WHERE FIND_IN_SET(:roleId, REPLACE(roles, '|', ','))", nativeQuery = true)
+    List<User> findByRoleId(@Param("roleId") String roleId);
 }

--- a/api/src/main/java/com/example/api/service/UserService.java
+++ b/api/src/main/java/com/example/api/service/UserService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class UserService {
@@ -41,6 +42,12 @@ public class UserService {
 
     public User saveUser(User user) {
         return userRepository.save(user);
+    }
+
+    public List<UserDto> getUsersByRole(String roleId) {
+        return userRepository.findByRoleId(roleId).stream()
+                .map(DtoMapper::toUserDto)
+                .collect(Collectors.toList());
     }
 
     public Optional<User> updateUser(String id, User updated) {

--- a/ui/src/components/AllTickets/AssigneeDropdown.tsx
+++ b/ui/src/components/AllTickets/AssigneeDropdown.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import { Menu, Box, TextField, Chip, List, ListItemButton, IconButton, Tooltip } from '@mui/material';
+import { Menu, Box, TextField, Chip, List, ListItemButton, IconButton, Tooltip, Button, Dialog, DialogTitle, DialogContent, Tabs, Tab } from '@mui/material';
 import { getAllLevels, getAllUsersByLevel } from '../../services/LevelService';
-import { getAllUsers } from '../../services/UserService';
+import { getAllUsers, getRegionalNodalOfficers } from '../../services/UserService';
 import UserAvatar from '../UI/UserAvatar/UserAvatar';
 import { useApi } from '../../hooks/useApi';
 import PersonAddAltIcon from '@mui/icons-material/PersonAddAlt';
@@ -15,24 +15,35 @@ interface AssigneeDropdownProps {
     assigneeName?: string;
     onAssigned?: (name: string) => void;
     searchCurrentTicketsPaginatedApi?: (id: string) => void;
+    requestorId?: string;
 }
 
 interface Level { levelId: string; levelName: string; }
 interface User { userId: string; username: string; name: string; roles?: string; levels?: string[]; levelId?: string; levelName?: string; }
 
-const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ ticketId, assigneeName, onAssigned, searchCurrentTicketsPaginatedApi }) => {
+const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ ticketId, assigneeName, onAssigned, searchCurrentTicketsPaginatedApi, requestorId }) => {
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
     const open = Boolean(anchorEl);
     const [search, setSearch] = useState('');
     const [selectedLevel, setSelectedLevel] = useState<string>('');
     const [showActionRemark, setShowActionRemark] = useState(false);
     const [selectedUser, setSelectedUser] = useState<User | null>(null);
+    const [advancedOpen, setAdvancedOpen] = useState(false);
+    const [tab, setTab] = useState<'user' | 'requester' | 'rno'>('user');
+    const [rnoSearch, setRnoSearch] = useState('');
 
     // Use useApi for all API calls
     const { data: levelsData, apiHandler: getLevelsApiHandler } = useApi<any>();
     const { data: usersData, apiHandler: getUsersByLevelApiHandler } = useApi<any>();
     const { data: allUsersData, apiHandler: getAllUsersApiHandler } = useApi<any>();
+    const { data: rnoData, apiHandler: getRnoApiHandler } = useApi<any>();
     const { apiHandler: updateTicketApiHandler } = useApi<any>();
+
+    const allowedActions = getCurrentUserDetails()?.allowedStatusActionIds || [];
+    const canRequester = allowedActions.includes('4');
+    const canRno = allowedActions.includes('16');
+    const REQUESTER_STATUS_ID = '3';
+    const FCI_STATUS_ID = '5';
 
     // Fetch levels on mount
     useEffect(() => {
@@ -47,6 +58,12 @@ const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ ticketId, assigneeN
         }
     }, [selectedLevel]);
 
+    useEffect(() => {
+        if (advancedOpen && tab === 'rno') {
+            getRnoApiHandler(() => getRegionalNodalOfficers());
+        }
+    }, [advancedOpen, tab]);
+
 
     const handleSelect = (u: User) => {
         setSelectedUser(u);
@@ -59,10 +76,28 @@ const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ ticketId, assigneeN
     };
 
     const handleSubmitRemark = (remark: string, selectedUser: User) => {
-        const payload = {
+        let payload: any = {
             assignedTo: selectedUser.username,
-            assignedToLevel: selectedUser.levelId,
-            levelId: selectedUser.levelId,
+            remark,
+            assignedBy: getCurrentUserDetails()?.username,
+            updatedBy: getCurrentUserDetails()?.username
+        };
+        if (tab === 'user') {
+            payload.assignedToLevel = selectedUser.levelId;
+            payload.levelId = selectedUser.levelId;
+        }
+        if (tab === 'rno') {
+            payload.status = { statusId: FCI_STATUS_ID };
+        }
+        updateTicketApiHandler(() => updateTicket(ticketId, payload)).then(() => {
+            handleSuccess(selectedUser.name);
+        });
+    };
+
+    const handleAssignRequester = (remark: string) => {
+        const payload = {
+            assignedTo: requestorId,
+            status: { statusId: REQUESTER_STATUS_ID },
             remark,
             assignedBy: getCurrentUserDetails()?.username,
             updatedBy: getCurrentUserDetails()?.username
@@ -70,13 +105,14 @@ const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ ticketId, assigneeN
         updateTicketApiHandler(() => updateTicket(ticketId, payload)).then(() => {
             handleSuccess();
         });
-    }
+    };
 
-    const handleSuccess = () => {
+    const handleSuccess = (name?: string) => {
         searchCurrentTicketsPaginatedApi && searchCurrentTicketsPaginatedApi(ticketId);
-        onAssigned && selectedUser && onAssigned(selectedUser.name);
+        if (onAssigned && name) onAssigned(name);
         handleCancelRemark();
         setAnchorEl(null);
+        setAdvancedOpen(false);
     };
 
     const levels: Level[] = levelsData || [];
@@ -93,6 +129,52 @@ const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ ticketId, assigneeN
     const filtered = allowedUsers.filter(u =>
         u.name.toLowerCase().includes(search.toLowerCase()) ||
         u.username.toLowerCase().includes(search.toLowerCase())
+    );
+
+    const rnoUsers: User[] = rnoData || [];
+    const rnoFiltered = rnoUsers.filter(u =>
+        u.name.toLowerCase().includes(rnoSearch.toLowerCase()) ||
+        u.username.toLowerCase().includes(rnoSearch.toLowerCase())
+    );
+
+    const renderAssignForm = () => (
+        <>
+            <TextField value={search} onChange={e => setSearch(e.target.value)} placeholder="Search" size="small" fullWidth />
+            <Box sx={{ mt: 1, mb: 1, display: 'flex', flexWrap: 'wrap' }}>
+                {levels.map(l => (
+                    <Chip
+                        key={l.levelId}
+                        label={l.levelId}
+                        onClick={() => setSelectedLevel(prev => prev === l.levelId ? '' : l.levelId)}
+                        color={selectedLevel === l.levelId ? 'primary' : 'default'}
+                        size="small"
+                        sx={{ mr: 0.5, mb: 0.5 }}
+                    />
+                ))}
+            </Box>
+            <Box sx={{ maxHeight: 300, overflowY: 'auto' }}>
+                <List dense>
+                    {filtered.map(u => (
+                        <ListItemButton key={`${u.userId}-${u.levelId}`} onClick={() => handleSelect(u)}>
+                            <Box sx={{ display: 'flex', width: '100%' }}>
+                                <Box sx={{ width: 60 }}>{u.levelId}</Box>
+                                <Box sx={{ flexGrow: 1 }}>{u.name}</Box>
+                                <Box sx={{ width: 80, fontStyle: 'italic', color: 'text.secondary' }}>{u.username}</Box>
+                            </Box>
+                        </ListItemButton>
+                    ))}
+                </List>
+            </Box>
+            {showActionRemark && selectedUser && (
+                <Box sx={{ mt: 1 }}>
+                    <ActionRemarkComponent
+                        actionName="Assign"
+                        onCancel={handleCancelRemark}
+                        onSubmit={(remark) => handleSubmitRemark(remark, selectedUser)}
+                    />
+                </Box>
+            )}
+        </>
     );
 
     return (
@@ -118,43 +200,58 @@ const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ ticketId, assigneeN
             )}
             <Menu anchorEl={anchorEl} open={open} onClose={() => setAnchorEl(null)}>
                 <Box sx={{ p: 1, width: 350 }}>
-                    <TextField value={search} onChange={e => setSearch(e.target.value)} placeholder="Search" size="small" fullWidth />
-                    <Box sx={{ mt: 1, mb: 1, display: 'flex', flexWrap: 'wrap' }}>
-                        {levels.map(l => (
-                            <Chip
-                                key={l.levelId}
-                                label={l.levelId}
-                                onClick={() => setSelectedLevel(prev => prev === l.levelId ? '' : l.levelId)}
-                                color={selectedLevel === l.levelId ? 'primary' : 'default'}
-                                size="small"
-                                sx={{ mr: 0.5, mb: 0.5 }}
-                            />
-                        ))}
+                    {renderAssignForm()}
+                    <Box sx={{ mt: 1, textAlign: 'right' }}>
+                        <Button size="small" onClick={() => { setAdvancedOpen(true); setTab('user'); setAnchorEl(null); }}>Advanced Options</Button>
                     </Box>
-                    <Box sx={{ maxHeight: 300, overflowY: 'auto' }}>
-                        <List dense>
-                            {filtered.map(u => (
-                                <ListItemButton key={`${u.userId}-${u.levelId}`} onClick={() => handleSelect(u)}>
-                                    <Box sx={{ display: 'flex', width: '100%' }}>
-                                        <Box sx={{ width: 60 }}>{u.levelId}</Box>
-                                        <Box sx={{ flexGrow: 1 }}>{u.name}</Box>
-                                        <Box sx={{ width: 80, fontStyle: 'italic', color: 'text.secondary' }}>{u.username}</Box>
-                                    </Box>
-                                </ListItemButton>
-                            ))}
-                        </List>
-                    </Box>
-                    {showActionRemark && selectedUser && (
+                </Box>
+            </Menu>
+            <Dialog open={advancedOpen} onClose={() => setAdvancedOpen(false)} fullWidth maxWidth="sm">
+                <DialogTitle>Advanced Options</DialogTitle>
+                <DialogContent>
+                    <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 1 }}>
+                        <Tab label="Assign User" value="user" />
+                        {canRequester && <Tab label="Requester" value="requester" />}
+                        {canRno && <Tab label="Regional Nodal Officer" value="rno" />}
+                    </Tabs>
+                    {tab === 'user' && renderAssignForm()}
+                    {tab === 'requester' && (
                         <Box sx={{ mt: 1 }}>
                             <ActionRemarkComponent
-                                actionName="Assign"
-                                onCancel={handleCancelRemark}
-                                onSubmit={(remark) => handleSubmitRemark(remark, selectedUser)}
+                                actionName="Assign to Requester"
+                                onCancel={() => setAdvancedOpen(false)}
+                                onSubmit={handleAssignRequester}
                             />
                         </Box>
                     )}
-                </Box>
-            </Menu>
+                    {tab === 'rno' && (
+                        <Box>
+                            <TextField value={rnoSearch} onChange={e => setRnoSearch(e.target.value)} placeholder="Search" size="small" fullWidth sx={{ mt: 1 }} />
+                            <Box sx={{ maxHeight: 300, overflowY: 'auto', mt: 1 }}>
+                                <List dense>
+                                    {rnoFiltered.map(u => (
+                                        <ListItemButton key={u.userId} onClick={() => handleSelect(u)}>
+                                            <Box sx={{ display: 'flex', width: '100%' }}>
+                                                <Box sx={{ flexGrow: 1 }}>{u.name}</Box>
+                                                <Box sx={{ width: 80, fontStyle: 'italic', color: 'text.secondary' }}>{u.username}</Box>
+                                            </Box>
+                                        </ListItemButton>
+                                    ))}
+                                </List>
+                            </Box>
+                            {showActionRemark && selectedUser && (
+                                <Box sx={{ mt: 1 }}>
+                                    <ActionRemarkComponent
+                                        actionName="Assign"
+                                        onCancel={handleCancelRemark}
+                                        onSubmit={(remark) => handleSubmitRemark(remark, selectedUser)}
+                                    />
+                                </Box>
+                            )}
+                        </Box>
+                    )}
+                </DialogContent>
+            </Dialog>
         </>
     );
 };

--- a/ui/src/components/AllTickets/TicketCard.tsx
+++ b/ui/src/components/AllTickets/TicketCard.tsx
@@ -22,6 +22,7 @@ export interface TicketCardData {
     subCategory: string;
     priority: string;
     isMaster: boolean;
+    userId?: string;
     requestorName?: string;
     assignedTo?: string;
     statusId?: string;
@@ -165,6 +166,7 @@ const TicketCard: React.FC<TicketCardProps> = ({ ticket, priorityConfig, onClick
                     ? <AssigneeDropdown
                         ticketId={ticket.id}
                         assigneeName={ticket.assignedTo}
+                        requestorId={ticket.userId}
                         searchCurrentTicketsPaginatedApi={searchCurrentTicketsPaginatedApi}
                     />
                     : ticket.assignedTo

--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -29,6 +29,7 @@ export interface TicketRow {
     priority: string;
     priorityId: string;
     isMaster: boolean;
+    userId?: string;
     requestorName?: string;
     requestorEmailId?: string;
     requestorMobileNo?: string;
@@ -203,6 +204,7 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
                             <AssigneeDropdown
                                 ticketId={record.id}
                                 assigneeName={record.assignedTo}
+                                requestorId={record.userId}
                                 searchCurrentTicketsPaginatedApi={searchCurrentTicketsPaginatedApi}
                             />
                         );

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -83,6 +83,7 @@ type LoginResponse = {
     roles?: string[];
     levels?: string[];
     name?: string;
+    allowedStatusActionIds?: string[];
     [key: string]: any;
 };
 
@@ -107,7 +108,8 @@ const Login: React.FC = () => {
                     username: res.username,
                     role: res.roles,
                     levels: res.levels,
-                    name: res.name
+                    name: res.name,
+                    allowedStatusActionIds: res.allowedStatusActionIds
                 };
                 setUserDetails(details);
             }

--- a/ui/src/services/TicketService.ts
+++ b/ui/src/services/TicketService.ts
@@ -33,7 +33,7 @@ export function getTicket(id: string) {
 }
 
 export function updateTicket(id: string, payload: any) {
-    return axios.put(`${BASE_URL}/tickets/${id}`, payload);
+    return axios.put(`${BASE_URL}/tickets/${id}`, payload).then(res => res.data.ticket);
 }
 
 export function linkTicketToMaster(id: string, masterId: string) {

--- a/ui/src/services/UserService.ts
+++ b/ui/src/services/UserService.ts
@@ -9,6 +9,10 @@ export function getAllUsers() {
     return axios.get(`${BASE_URL}/users`);
 }
 
+export function getRegionalNodalOfficers() {
+    return axios.get(`${BASE_URL}/users/regional-nodal-officers`);
+}
+
 export function addUser(user: any) {
     return axios.post(`${BASE_URL}/users`, user);
 }

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -47,6 +47,7 @@ export interface Ticket {
     priority: string;
     priorityId?: string;
     isMaster: boolean;
+    userId?: string;
     requestorName?: string;
     requestorEmailId?: string;
     requestorMobileNo?: string;

--- a/ui/src/utils/Utils.ts
+++ b/ui/src/utils/Utils.ts
@@ -9,6 +9,7 @@ export interface UserDetails {
   name?: string;
   email?: string;
   phone?: string;
+  allowedStatusActionIds?: string[];
 }
 
 const USER_KEY = 'userDetails';


### PR DESCRIPTION
## Summary
- add advanced assignment modal with options for requester and regional nodal officer
- expose endpoint to list regional nodal officers and include allowed status actions in login
- return full ticket object on update and support role-based user queries

## Testing
- `npm test` *(fails: Cannot find module 'react-router-dom')*
- `./gradlew test` *(fails: Could not find Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_e_68b7caf4361c8332b419ad6ee7f9c481