### PR TITLE
Replace regional nodal officers lookup with role-based search

### DIFF
--- a/api/src/main/java/com/example/api/controller/UserController.java
+++ b/api/src/main/java/com/example/api/controller/UserController.java
@@ -22,10 +22,9 @@ public class UserController {
         return ResponseEntity.ok(userService.getAllUsers());
     }
 
-    @GetMapping("/regional-nodal-officers")
-    public ResponseEntity<List<UserDto>> getRegionalNodalOfficers() {
-        // role id 4 corresponds to Regional Nodal Officer
-        return ResponseEntity.ok(userService.getUsersByRole("4"));
+    @PostMapping("/by-roles")
+    public ResponseEntity<List<UserDto>> getUsersByRoles(@RequestBody List<String> roleIds) {
+        return ResponseEntity.ok(userService.getUsersByRoles(roleIds));
     }
 
     @GetMapping("/{userId}")

--- a/api/src/main/java/com/example/api/repository/UserRepository.java
+++ b/api/src/main/java/com/example/api/repository/UserRepository.java
@@ -2,15 +2,8 @@ package com.example.api.repository;
 
 import com.example.api.models.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, String> {
     Optional<User> findByUsername(String username);
-
-    @Query(value = "SELECT * FROM users WHERE FIND_IN_SET(:roleId, REPLACE(roles, '|', ','))", nativeQuery = true)
-    List<User> findByRoleId(@Param("roleId") String roleId);
 }

--- a/api/src/main/java/com/example/api/service/UserService.java
+++ b/api/src/main/java/com/example/api/service/UserService.java
@@ -6,6 +6,7 @@ import com.example.api.models.User;
 import com.example.api.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -44,8 +45,13 @@ public class UserService {
         return userRepository.save(user);
     }
 
-    public List<UserDto> getUsersByRole(String roleId) {
-        return userRepository.findByRoleId(roleId).stream()
+    public List<UserDto> getUsersByRoles(List<String> roleIds) {
+        return userRepository.findAll().stream()
+                .filter(user -> {
+                    if (user.getRoles() == null) return false;
+                    String[] roles = user.getRoles().split("\\|");
+                    return Arrays.stream(roles).anyMatch(roleIds::contains);
+                })
                 .map(DtoMapper::toUserDto)
                 .collect(Collectors.toList());
     }

--- a/ui/src/components/AllTickets/AssigneeDropdown.tsx
+++ b/ui/src/components/AllTickets/AssigneeDropdown.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { Menu, Box, TextField, Chip, List, ListItemButton, IconButton, Tooltip, Button, Dialog, DialogTitle, DialogContent, Tabs, Tab } from '@mui/material';
 import { getAllLevels, getAllUsersByLevel } from '../../services/LevelService';
-import { getAllUsers, getRegionalNodalOfficers } from '../../services/UserService';
+import { getAllUsers, getUsersByRoles } from '../../services/UserService';
+import { getAllRoles } from '../../services/RoleService';
 import UserAvatar from '../UI/UserAvatar/UserAvatar';
 import { useApi } from '../../hooks/useApi';
 import PersonAddAltIcon from '@mui/icons-material/PersonAddAlt';
@@ -37,7 +38,8 @@ const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ ticketId, assigneeN
     const { data: levelsData, apiHandler: getLevelsApiHandler } = useApi<any>();
     const { data: usersData, apiHandler: getUsersByLevelApiHandler } = useApi<any>();
     const { data: allUsersData, apiHandler: getAllUsersApiHandler } = useApi<any>();
-    const { data: rnoData, apiHandler: getRnoApiHandler } = useApi<any>();
+    const { data: rolesData, apiHandler: getRolesApiHandler } = useApi<any>();
+    const { data: rnoData, apiHandler: getRnoUsersApiHandler } = useApi<any>();
     const { apiHandler: updateTicketApiHandler } = useApi<any>();
 
     const allowedActions = getCurrentUserDetails()?.allowedStatusActionIds || [];
@@ -46,10 +48,11 @@ const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ ticketId, assigneeN
     const REQUESTER_STATUS_ID = '3';
     const FCI_STATUS_ID = '5';
 
-    // Fetch levels on mount
+    // Fetch levels, users and roles on mount
     useEffect(() => {
         getLevelsApiHandler(() => getAllLevels());
         getAllUsersApiHandler(() => getAllUsers());
+        getRolesApiHandler(() => getAllRoles());
     }, []);
 
     // Fetch users when selectedLevel changes
@@ -60,10 +63,13 @@ const AssigneeDropdown: React.FC<AssigneeDropdownProps> = ({ ticketId, assigneeN
     }, [selectedLevel]);
 
     useEffect(() => {
-        if (advancedOpen && tab === 'rno') {
-            getRnoApiHandler(() => getRegionalNodalOfficers());
+        if (advancedOpen && tab === 'rno' && rolesData) {
+            const rnoRole = (rolesData as any[]).find(r => r.role === 'RegionalNodalOfficer');
+            if (rnoRole) {
+                getRnoUsersApiHandler(() => getUsersByRoles([String(rnoRole.roleId)]));
+            }
         }
-    }, [advancedOpen, tab]);
+    }, [advancedOpen, tab, rolesData]);
 
 
     const handleSelect = (u: User) => {

--- a/ui/src/services/UserService.ts
+++ b/ui/src/services/UserService.ts
@@ -9,8 +9,8 @@ export function getAllUsers() {
     return axios.get(`${BASE_URL}/users`);
 }
 
-export function getRegionalNodalOfficers() {
-    return axios.get(`${BASE_URL}/users/regional-nodal-officers`);
+export function getUsersByRoles(roleIds: string[]) {
+    return axios.post(`${BASE_URL}/users/by-roles`, roleIds);
 }
 
 export function addUser(user: any) {


### PR DESCRIPTION
## Summary
- remove `getRegionalNodalOfficers` usage and introduce generic `getUsersByRoles` API
- query backend for users by role ids and load roles to map "RegionalNodalOfficer" role
- update Advanced Assignment flow to call new API when RNO tab opens

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation matching {languageVersion=17...})*
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68b80a8766648332a847ca2bd3ba66a5