### PR TITLE
Include permissions when listing roles

### DIFF
--- a/api/src/main/java/com/example/api/mapper/DtoMapper.java
+++ b/api/src/main/java/com/example/api/mapper/DtoMapper.java
@@ -3,6 +3,9 @@ package com.example.api.mapper;
 import com.example.api.dto.*;
 import com.example.api.models.*;
 import com.example.api.service.LevelService;
+import com.example.api.permissions.RolePermission;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -11,6 +14,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class DtoMapper {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     public static CategoryDto toCategoryDto(Category category) {
         if (category == null) return null;
         CategoryDto dto = new CategoryDto();
@@ -114,6 +118,14 @@ public class DtoMapper {
         dto.setAllowedStatusActionIds(role.getAllowedStatusActionIds());
         dto.setDeleted(role.isDeleted());
         dto.setDescription(role.getDescription());
+        if (role.getPermissions() != null) {
+            try {
+                RolePermission perm = OBJECT_MAPPER.readValue(role.getPermissions(), RolePermission.class);
+                dto.setPermissions(perm);
+            } catch (JsonProcessingException e) {
+                // ignore parsing errors and leave permissions null
+            }
+        }
         return dto;
     }
 

--- a/ui/src/pages/RoleDetails.tsx
+++ b/ui/src/pages/RoleDetails.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useContext } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useApi } from '../hooks/useApi';
-import { getRolePermission, updateRolePermission, updateRole, loadPermissions, renameRole, getAllRoles } from '../services/RoleService';
+import { updateRolePermission, updateRole, loadPermissions, renameRole, getAllRoles } from '../services/RoleService';
 import { getStatusActions } from '../services/StatusService';
 import { getCurrentUserDetails } from '../config/config';
 import Title from '../components/Title';
@@ -14,7 +14,6 @@ import { DevModeContext } from '../context/DevModeContext';
 
 const RoleDetails: React.FC = () => {
     const { roleId } = useParams<{ roleId: string }>();
-    const { data, apiHandler } = useApi<any>();
     const { data: actions, apiHandler: actionsApiHandler } = useApi<any>();
     const { data: rolesData, pending: rolesApiPending, success: rolesApiSucsess, apiHandler: rolesApiHandler } = useApi<any>();
     const [perm, setPerm] = useState<any>(null);
@@ -32,7 +31,6 @@ const RoleDetails: React.FC = () => {
     
     useEffect(() => {
         if (roleId) {
-            apiHandler(() => getRolePermission(roleId));
             rolesApiHandler(() => getAllRoles());
             actionsApiHandler(() => getStatusActions());
         }
@@ -46,7 +44,7 @@ const RoleDetails: React.FC = () => {
 
     useEffect(() => {
         if (rolesData && roleId) {
-            const role = (rolesData as any[]).find(r => r.role === roleId);
+            const role = (rolesData as any[]).find(r => String(r.roleId) === roleId || r.role === roleId);
             if (role) {
                 if (role.allowedStatusActionIds) {
                     setSelectedActionIds(role.allowedStatusActionIds.split('|'));
@@ -54,13 +52,12 @@ const RoleDetails: React.FC = () => {
                 if (role.description) {
                     setDescription(role.description);
                 }
+                if (role.permissions) {
+                    setPerm(role.permissions);
+                }
             }
         }
     }, [rolesData, roleId]);
-
-    useEffect(() => {
-        if (data) setPerm(data);
-    }, [data]);
 
     const handleSubmit = (submitPerm = isPermissionsModified ? modifiedPermissions : perm) => {
         if (roleId) {


### PR DESCRIPTION
## Summary
- parse stored permission JSON into `RolePermission` when mapping roles, exposing permissions in role list
- use role's embedded permissions in RoleDetails page instead of fetching separately

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./gradlew test` *(fails: Could not resolve dependencies - trustAnchors parameter must be non-empty)*
- `CI=true npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' in App.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bede0bba4c8332a945df71af4ba662