### PR TITLE
feat: add ticket SLA tracking

### DIFF
--- a/api/src/main/java/com/example/api/dto/TicketSlaDto.java
+++ b/api/src/main/java/com/example/api/dto/TicketSlaDto.java
@@ -1,0 +1,20 @@
+package com.example.api.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * DTO for {@link com.example.api.models.TicketSla}.
+ */
+@Data
+public class TicketSlaDto {
+    private String id;
+    private String ticketId;
+    private String slaId;
+    private LocalDateTime dueAt;
+    private Long resolutionTimeMinutes;
+    private Long elapsedTimeMinutes;
+    private Long responseTimeMinutes;
+    private Long breachedByMinutes;
+}

--- a/api/src/main/java/com/example/api/mapper/DtoMapper.java
+++ b/api/src/main/java/com/example/api/mapper/DtoMapper.java
@@ -198,4 +198,18 @@ public class DtoMapper {
         dto.setUpdatedOn(faq.getUpdatedOn());
         return dto;
     }
+
+    public static TicketSlaDto toTicketSlaDto(TicketSla ticketSla) {
+        if (ticketSla == null) return null;
+        TicketSlaDto dto = new TicketSlaDto();
+        dto.setId(ticketSla.getId());
+        dto.setTicketId(ticketSla.getTicket() != null ? ticketSla.getTicket().getId() : null);
+        dto.setSlaId(ticketSla.getSlaConfig() != null ? ticketSla.getSlaConfig().getId() : null);
+        dto.setDueAt(ticketSla.getDueAt());
+        dto.setResolutionTimeMinutes(ticketSla.getResolutionTimeMinutes());
+        dto.setElapsedTimeMinutes(ticketSla.getElapsedTimeMinutes());
+        dto.setResponseTimeMinutes(ticketSla.getResponseTimeMinutes());
+        dto.setBreachedByMinutes(ticketSla.getBreachedByMinutes());
+        return dto;
+    }
 }

--- a/api/src/main/java/com/example/api/models/SlaConfig.java
+++ b/api/src/main/java/com/example/api/models/SlaConfig.java
@@ -1,0 +1,26 @@
+package com.example.api.models;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+/**
+ * Configuration for SLA timings based on severity.
+ */
+@Entity
+@Table(name = "sla_config")
+@Data
+public class SlaConfig {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "sla_id")
+    private String id;
+
+    @Column(name = "severity_level")
+    private String severityLevel;
+
+    @Column(name = "response_minutes")
+    private Long responseMinutes;
+
+    @Column(name = "resolution_minutes")
+    private Long resolutionMinutes;
+}

--- a/api/src/main/java/com/example/api/models/TicketSla.java
+++ b/api/src/main/java/com/example/api/models/TicketSla.java
@@ -1,0 +1,42 @@
+package com.example.api.models;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * Tracks SLA metrics for a ticket.
+ */
+@Entity
+@Table(name = "ticket_sla")
+@Data
+public class TicketSla {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "ticket_sla_id")
+    private String id;
+
+    @ManyToOne
+    @JoinColumn(name = "ticket_id", referencedColumnName = "ticket_id")
+    private Ticket ticket;
+
+    @ManyToOne
+    @JoinColumn(name = "sla_id", referencedColumnName = "sla_id")
+    private SlaConfig slaConfig;
+
+    @Column(name = "due_at")
+    private LocalDateTime dueAt;
+
+    @Column(name = "resolution_time_minutes")
+    private Long resolutionTimeMinutes;
+
+    @Column(name = "elapsed_time_minutes")
+    private Long elapsedTimeMinutes;
+
+    @Column(name = "response_time_minutes")
+    private Long responseTimeMinutes;
+
+    @Column(name = "breached_by_minutes")
+    private Long breachedByMinutes;
+}

--- a/api/src/main/java/com/example/api/repository/SlaConfigRepository.java
+++ b/api/src/main/java/com/example/api/repository/SlaConfigRepository.java
@@ -1,0 +1,12 @@
+package com.example.api.repository;
+
+import com.example.api.models.SlaConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SlaConfigRepository extends JpaRepository<SlaConfig, String> {
+    Optional<SlaConfig> findBySeverityLevel(String severityLevel);
+}

--- a/api/src/main/java/com/example/api/repository/TicketSlaRepository.java
+++ b/api/src/main/java/com/example/api/repository/TicketSlaRepository.java
@@ -1,0 +1,9 @@
+package com.example.api.repository;
+
+import com.example.api.models.TicketSla;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TicketSlaRepository extends JpaRepository<TicketSla, String> {
+}

--- a/api/src/main/java/com/example/api/service/TicketSlaService.java
+++ b/api/src/main/java/com/example/api/service/TicketSlaService.java
@@ -1,0 +1,75 @@
+package com.example.api.service;
+
+import com.example.api.models.SlaConfig;
+import com.example.api.models.StatusHistory;
+import com.example.api.models.Ticket;
+import com.example.api.models.TicketSla;
+import com.example.api.repository.SlaConfigRepository;
+import com.example.api.repository.TicketSlaRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+public class TicketSlaService {
+    private final SlaConfigRepository slaConfigRepository;
+    private final TicketSlaRepository ticketSlaRepository;
+
+    public TicketSlaService(SlaConfigRepository slaConfigRepository,
+                            TicketSlaRepository ticketSlaRepository) {
+        this.slaConfigRepository = slaConfigRepository;
+        this.ticketSlaRepository = ticketSlaRepository;
+    }
+
+    public TicketSla calculateAndSave(Ticket ticket, List<StatusHistory> history) {
+        if (ticket == null) return null;
+        SlaConfig config = slaConfigRepository.findBySeverityLevel(ticket.getSeverity())
+                .orElse(null);
+        long resolutionPolicy = config != null && config.getResolutionMinutes() != null
+                ? config.getResolutionMinutes() : 0L;
+        LocalDateTime dueAt = ticket.getReportedDate().plusMinutes(resolutionPolicy);
+
+        history.sort(Comparator.comparing(StatusHistory::getTimestamp));
+        LocalDateTime assignTime = history.isEmpty() ? ticket.getReportedDate() : history.get(0).getTimestamp();
+        long responseMinutes = Duration.between(ticket.getReportedDate(), assignTime).toMinutes();
+
+        long elapsed = 0L;
+        long resolution = 0L;
+        LocalDateTime prevTime = assignTime;
+        Boolean prevFlag = history.isEmpty() ? Boolean.TRUE : history.get(0).getSlaFlag();
+        for (int i = 1; i < history.size(); i++) {
+            StatusHistory sh = history.get(i);
+            long diff = Duration.between(prevTime, sh.getTimestamp()).toMinutes();
+            elapsed += diff;
+            if (Boolean.TRUE.equals(prevFlag)) {
+                resolution += diff;
+            } else {
+                dueAt = dueAt.plusMinutes(diff);
+            }
+            prevTime = sh.getTimestamp();
+            prevFlag = sh.getSlaFlag();
+        }
+        LocalDateTime endTime = ticket.getResolvedAt() != null ? ticket.getResolvedAt() : LocalDateTime.now();
+        long finalDiff = Duration.between(prevTime, endTime).toMinutes();
+        elapsed += finalDiff;
+        if (Boolean.TRUE.equals(prevFlag)) {
+            resolution += finalDiff;
+        } else {
+            dueAt = dueAt.plusMinutes(finalDiff);
+        }
+        long breachedBy = Duration.between(dueAt, endTime).toMinutes();
+
+        TicketSla ticketSla = new TicketSla();
+        ticketSla.setTicket(ticket);
+        ticketSla.setSlaConfig(config);
+        ticketSla.setDueAt(dueAt);
+        ticketSla.setResolutionTimeMinutes(resolution);
+        ticketSla.setElapsedTimeMinutes(elapsed);
+        ticketSla.setResponseTimeMinutes(responseMinutes);
+        ticketSla.setBreachedByMinutes(breachedBy);
+        return ticketSlaRepository.save(ticketSla);
+    }
+}

--- a/db/ticketing_system_dump.sql
+++ b/db/ticketing_system_dump.sql
@@ -916,6 +916,42 @@ SET character_set_client = @saved_cs_client;
 /*!50001 SET character_set_client      = @saved_cs_client */;
 /*!50001 SET character_set_results     = @saved_cs_results */;
 /*!50001 SET collation_connection      = @saved_col_connection */;
+-- Table structure for table `sla_config`
+DROP TABLE IF EXISTS `sla_config`;
+CREATE TABLE `sla_config` (
+  `sla_id` varchar(36) NOT NULL,
+  `severity_level` varchar(10) NOT NULL,
+  `response_minutes` bigint DEFAULT NULL,
+  `resolution_minutes` bigint DEFAULT NULL,
+  PRIMARY KEY (`sla_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Dumping data for table `sla_config`
+INSERT INTO `sla_config` VALUES
+('SLA-S1','S1',30,240),
+('SLA-S2','S2',60,480),
+('SLA-S3','S3',120,720),
+('SLA-S4','S4',180,1440);
+
+-- Table structure for table `ticket_sla`
+DROP TABLE IF EXISTS `ticket_sla`;
+CREATE TABLE `ticket_sla` (
+  `ticket_sla_id` varchar(36) NOT NULL,
+  `ticket_id` varchar(36) NOT NULL,
+  `sla_id` varchar(36) NOT NULL,
+  `due_at` datetime DEFAULT NULL,
+  `resolution_time_minutes` bigint DEFAULT NULL,
+  `elapsed_time_minutes` bigint DEFAULT NULL,
+  `response_time_minutes` bigint DEFAULT NULL,
+  `breached_by_minutes` bigint DEFAULT NULL,
+  PRIMARY KEY (`ticket_sla_id`),
+  KEY `fk_ticket_sla_ticket` (`ticket_id`),
+  KEY `fk_ticket_sla_sla` (`sla_id`),
+  CONSTRAINT `fk_ticket_sla_ticket` FOREIGN KEY (`ticket_id`) REFERENCES `tickets` (`ticket_id`),
+  CONSTRAINT `fk_ticket_sla_sla` FOREIGN KEY (`sla_id`) REFERENCES `sla_config` (`sla_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Dumping data for table `ticket_sla`
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;


### PR DESCRIPTION
## Summary
- track SLA metrics per ticket with new TicketSla entity and service
- configurable SLA duration per severity level
- initial SLA tables and mappings for persistence

## Testing
- `./gradlew test` *(fails: Could not resolve com.github.typesense:typesense-java:0.2.0 - status 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bf34cb5d448332a9df7b1c16af659f