### PR TITLE
Guard against missing SLA config

### DIFF
--- a/api/src/main/java/com/example/api/service/TicketSlaService.java
+++ b/api/src/main/java/com/example/api/service/TicketSlaService.java
@@ -28,7 +28,10 @@ public class TicketSlaService {
         if (ticket == null) return null;
         SlaConfig config = slaConfigRepository.findBySeverityLevel(ticket.getSeverity())
                 .orElse(null);
-        long resolutionPolicy = config != null && config.getResolutionMinutes() != null
+        if (config == null) {
+            throw new IllegalStateException("SLA configuration not found for severity: " + ticket.getSeverity());
+        }
+        long resolutionPolicy = config.getResolutionMinutes() != null
                 ? config.getResolutionMinutes() : 0L;
         LocalDateTime dueAt = ticket.getReportedDate().plusMinutes(resolutionPolicy);
 


### PR DESCRIPTION
## Summary
- throw clear exception when ticket severity lacks SLA configuration

## Testing
- `./gradlew test` *(fails: Could not resolve com.github.typesense:typesense-java:0.2.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c023a60ab0833282e60488ea79dd6b