### PR TITLE
Populate ticket severity from sub-category mapping

### DIFF
--- a/api/src/main/java/com/example/api/service/TicketService.java
+++ b/api/src/main/java/com/example/api/service/TicketService.java
@@ -7,6 +7,8 @@ import com.example.api.models.User;
 import com.example.api.models.Ticket;
 import com.example.api.models.TicketComment;
 import com.example.api.models.StatusHistory;
+import com.example.api.models.SubCategory;
+import com.example.api.models.Severity;
 import com.example.api.repository.UserRepository;
 import com.example.api.repository.TicketCommentRepository;
 import com.example.api.repository.TicketRepository;
@@ -174,6 +176,12 @@ public class TicketService {
                 ticket.setTicketStatus(TicketStatus.valueOf(code));
             }
         }
+        if (ticket.getSeverity() == null && ticket.getSubCategory() != null) {
+            subCategoryRepository.findById(ticket.getSubCategory())
+                    .map(SubCategory::getSeverity)
+                    .map(Severity::getLevel)
+                    .ifPresent(ticket::setSeverity);
+        }
         boolean isAssigned = ticket.getAssignedTo() != null && !ticket.getAssignedTo().isEmpty();
         if (!isAssigned) {
             ticket.setTicketStatus(TicketStatus.OPEN);
@@ -266,7 +274,15 @@ public class TicketService {
                 existing.setFeedbackStatus(FeedbackStatus.PENDING);
             }
         }
-        if (updated.getSubCategory() != null) existing.setSubCategory(updated.getSubCategory());
+        if (updated.getSubCategory() != null) {
+            existing.setSubCategory(updated.getSubCategory());
+            if (updated.getSeverity() == null) {
+                subCategoryRepository.findById(updated.getSubCategory())
+                        .map(SubCategory::getSeverity)
+                        .map(Severity::getLevel)
+                        .ifPresent(existing::setSeverity);
+            }
+        }
         if (updated.getPriority() != null) existing.setPriority(updated.getPriority());
         if (updated.getSeverity() != null) existing.setSeverity(updated.getSeverity());
         if (updated.getRecommendedSeverity() != null) existing.setRecommendedSeverity(updated.getRecommendedSeverity());


### PR DESCRIPTION
## Summary
- derive ticket severity from selected sub-category's mapped severity when creating a ticket
- refresh severity from sub-category if sub-category changes during updates

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./gradlew test` *(fails: Could not resolve dependencies; trust store missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c028e2f41c83328cb64b694dee13a1