### PR TITLE
Guard FileUpload state sync and stabilize attachment arrays

### DIFF
--- a/ui/src/components/RaiseTicket/TicketDetails.tsx
+++ b/ui/src/components/RaiseTicket/TicketDetails.tsx
@@ -6,7 +6,7 @@ import GenericDropdownController from "../UI/Dropdown/GenericDropdownController"
 import CustomFormInput from "../UI/Input/CustomFormInput";
 import CustomFieldset from "../CustomFieldset";
 import { useApi } from "../../hooks/useApi";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import { Checkbox, FormControlLabel } from "@mui/material";
 import { getAllUsersByLevel, getAllLevels } from "../../services/LevelService";
 import { getCategories, getSubCategories } from "../../services/CategoryService";
@@ -47,6 +47,8 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
     const { t } = useTranslation();
 
     const [assignFurther, setAssignFurther] = useState<boolean>(false);
+
+    const stableAttachments = useMemo(() => attachments ?? [], [attachments]);
 
     // useApi hook initializations
     const { data: allLevels, pending: isLevelsLoading, error: levelsError, apiHandler: getAllLevelApiHandler } = useApi();
@@ -327,7 +329,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
                         <FileUpload
                             maxSizeMB={5}
                             thumbnailSize={100}
-                            attachments={attachments || []}
+                            attachments={stableAttachments}
                             onFilesChange={(files) => {
                                 setAttachments && setAttachments(files)
                                 setValue && setValue('attachments', files)
@@ -556,7 +558,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
                         <FileUpload
                             maxSizeMB={5}
                             thumbnailSize={100}
-                            attachments={attachments || []}
+                            attachments={stableAttachments}
                             onFilesChange={(files) => {
                                 // Store temporarily in parent state for post-create upload
                                 setAttachments?.(files);

--- a/ui/src/components/TicketView.tsx
+++ b/ui/src/components/TicketView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState, useMemo } from 'react';
 import { Box, Typography, TextField, MenuItem, Select, SelectChangeEvent, Button } from '@mui/material';
 import UserAvatar from './UI/UserAvatar/UserAvatar';
 import { useApi } from '../hooks/useApi';
@@ -42,6 +42,7 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
   const [severityDetails, setSeverityDetails] = useState<SeverityInfo[]>([]);
   const [attachments, setAttachments] = useState<string[]>([]);
   const [uploadKey, setUploadKey] = useState(0);
+  const emptyFileList = useMemo<File[]>(() => [], []);
   const { t } = useTranslation();
   
   const allowEdit = checkFieldAccess('ticketDetails', 'editMode');
@@ -234,6 +235,7 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
           maxSizeMB={5}
           thumbnailSize={100}
           onFilesChange={handleAttachmentUpload}
+          attachments={emptyFileList}
         />
       </Box>
       <Box sx={{ mt: 2 }}>

--- a/ui/src/components/UI/FileUpload.tsx
+++ b/ui/src/components/UI/FileUpload.tsx
@@ -177,8 +177,10 @@ const FileUpload: React.FC<FileUploadProps> = ({ maxSizeMB, thumbnailSize, onFil
     const [error, setError] = useState<string>('');
 
     useEffect(() => {
-        setFiles(attachments);
-    }, [attachments]);
+        if (files !== attachments) {
+            setFiles(attachments);
+        }
+    }, [attachments, files]);
 
     const handleRemove = (index: number) => {
         const updated = files.filter((_, i) => i !== index);


### PR DESCRIPTION
## Summary
- prevent FileUpload from resetting files unless attachments change
- memoize attachments in parent components to avoid recreating arrays

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68c1e703a4388332a1d6b4cd75e82781