### PR TITLE
Handle missing SLA responses and conditional severity UI

### DIFF
--- a/api/src/main/java/com/example/api/config/ApiResponseBodyAdvice.java
+++ b/api/src/main/java/com/example/api/config/ApiResponseBodyAdvice.java
@@ -3,6 +3,7 @@ package com.example.api.config;
 import com.example.api.dto.ApiResponse;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -17,7 +18,8 @@ public class ApiResponseBodyAdvice implements ResponseBodyAdvice {
 
     @Override
     public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType, Class selectedConverterType, ServerHttpRequest request, ServerHttpResponse response) {
-        if(body instanceof ApiResponse) return body;
+        if (body instanceof ApiResponse) return body;
+        if (body == null && response.getStatusCode() == HttpStatus.CREATED) return null;
         return ApiResponse.success(body);
     }
 }

--- a/api/src/main/java/com/example/api/controller/TicketController.java
+++ b/api/src/main/java/com/example/api/controller/TicketController.java
@@ -11,6 +11,7 @@ import com.example.api.service.TicketSlaService;
 import lombok.AllArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -56,7 +57,7 @@ public class TicketController {
     @GetMapping("/{id}/sla")
     public ResponseEntity<TicketSla> getTicketSla(@PathVariable("id") String id) {
         TicketSla sla = ticketSlaService.getByTicketId(id);
-        if (sla == null) return ResponseEntity.notFound().build();
+        if (sla == null) return ResponseEntity.status(HttpStatus.CREATED).build();
         return ResponseEntity.ok(sla);
     }
 

--- a/ui/src/components/SlaDetails.tsx
+++ b/ui/src/components/SlaDetails.tsx
@@ -1,26 +1,12 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Box, Typography } from '@mui/material';
-import { useApi } from '../hooks/useApi';
-import { getTicketSla } from '../services/TicketService';
 import { TicketSla } from '../types';
 
 interface Props {
-  ticketId: string;
+  sla: TicketSla;
 }
 
-const SlaDetails: React.FC<Props> = ({ ticketId }) => {
-  const { data: sla, apiHandler } = useApi<any>();
-
-  useEffect(() => {
-    if (ticketId) {
-      apiHandler(() => getTicketSla(ticketId));
-    }
-  }, [ticketId, apiHandler]);
-
-  if (!sla) {
-    return <Typography color="text.secondary">No SLA data</Typography>;
-  }
-
+const SlaDetails: React.FC<Props> = ({ sla }) => {
   return (
     <Box component="table" sx={{ width: '100%', borderCollapse: 'collapse' }}>
       <tbody>


### PR DESCRIPTION
## Summary
- Return HTTP 201 without content when no SLA is stored for a ticket
- Skip wrapping 201 responses so empty bodies remain empty
- Display SLA section only when data exists and gate recommended severity editing by allowed action 11

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation)*
- `npm test -- --watchAll=false` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_68c2707f04e883329af2a4041686c94b