### PR TITLE
Restrict ticket statuses by user roles

### DIFF
--- a/api/src/main/java/com/example/api/controller/TicketStatusWorkflowController.java
+++ b/api/src/main/java/com/example/api/controller/TicketStatusWorkflowController.java
@@ -36,4 +36,10 @@ public class TicketStatusWorkflowController {
         List<Integer> ids = roles.stream().map(Integer::parseInt).toList();
         return ResponseEntity.ok(service.getMappingsByRoles(ids));
     }
+
+    @PostMapping("/allowed-statuses")
+    public ResponseEntity<List<String>> getAllowedStatusesByRoles(@RequestBody List<String> roles) {
+        List<Integer> ids = roles.stream().map(Integer::parseInt).toList();
+        return ResponseEntity.ok(service.getAllowedStatusIdListByRoles(ids));
+    }
 }

--- a/ui/src/services/StatusService.ts
+++ b/ui/src/services/StatusService.ts
@@ -16,3 +16,7 @@ export function getStatusWorkflowMappings(roles: string[]) {
 export function getStatusActions() {
     return axios.get(`${BASE_URL}/status-workflow/actions`);
 }
+
+export function getAllowedStatusListByRoles(roles: string[]) {
+    return axios.post(`${BASE_URL}/status-workflow/allowed-statuses`, roles);
+}


### PR DESCRIPTION
## Summary
- expose allowed ticket status IDs for user roles via `/status-workflow/allowed-statuses`
- filter My Tickets status options by backend-provided allowed IDs
- default ticket search to allowed statuses

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation matching 17)*
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b870198083328911688c348835b0