### PR TITLE
Add SLF4J logging example

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -42,6 +42,8 @@ dependencies {
         implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
         implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
 //      implementation 'org.springframework.ai:spring-ai-starter-vector-store-typesense'
+        implementation 'org.slf4j:slf4j-api:2.0.12'
+        runtimeOnly 'ch.qos.logback:logback-classic:1.4.14'
         compileOnly 'org.projectlombok:lombok'
         developmentOnly 'org.springframework.boot:spring-boot-devtools'
         runtimeOnly 'com.mysql:mysql-connector-j'

--- a/api/src/main/java/com/example/api/service/LoggingService.java
+++ b/api/src/main/java/com/example/api/service/LoggingService.java
@@ -1,0 +1,29 @@
+package com.example.api.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/**
+ * Demonstrates basic SLF4J logging within a Spring service.
+ */
+@Service
+public class LoggingService {
+
+    private static final Logger logger = LoggerFactory.getLogger(LoggingService.class);
+
+    /**
+     * Sample method showing logs at different levels.
+     */
+    public void performSampleTask() {
+        logger.info("Sample task started");
+        logger.debug("Processing detailed steps");
+        try {
+            throw new IllegalStateException("Demo exception");
+        } catch (IllegalStateException ex) {
+            logger.error("Encountered error", ex);
+        }
+        logger.warn("Sample task completed with warnings");
+    }
+}
+


### PR DESCRIPTION
## Summary
- add explicit SLF4J API and Logback dependencies
- provide sample Spring service that logs at multiple levels

## Testing
- `./gradlew test` *(fails: Could not get resource 'https://jitpack.io/...': status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c32ad54083329b70aaa2ca258c3f