### PR TITLE
Add AOP-based logging for controllers and services

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -33,6 +33,7 @@ ext {
 dependencies {
         implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
         implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'org.springframework.boot:spring-boot-starter-aop'
         implementation 'com.github.typesense:typesense-java:0.2.0'
         implementation 'org.springframework.boot:spring-boot-starter-freemarker'
         implementation 'org.springframework.boot:spring-boot-starter-mail'

--- a/api/src/main/java/com/example/api/aspect/LoggingAspect.java
+++ b/api/src/main/java/com/example/api/aspect/LoggingAspect.java
@@ -1,0 +1,42 @@
+package com.example.api.aspect;
+
+import java.util.Arrays;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Aspect for logging execution of controller and service beans.
+ */
+@Aspect
+@Component
+public class LoggingAspect {
+
+    private static final Logger logger = LoggerFactory.getLogger(LoggingAspect.class);
+
+    /**
+     * Logs entry, exit and exceptions for methods in controller and service packages.
+     *
+     * @param joinPoint join point for advised method
+     * @return result of method execution
+     * @throws Throwable if the advised method throws any exception
+     */
+    @Around("execution(* com.example..controller..*(..)) || execution(* com.example..service..*(..))")
+    public Object logAround(ProceedingJoinPoint joinPoint) throws Throwable {
+        String className = joinPoint.getSignature().getDeclaringTypeName();
+        String methodName = joinPoint.getSignature().getName();
+        logger.info("Entering {}.{} with arguments {}", className, methodName, Arrays.toString(joinPoint.getArgs()));
+        try {
+            Object result = joinPoint.proceed();
+            logger.info("Exiting {}.{} with result {}", className, methodName, result);
+            return result;
+        } catch (Throwable ex) {
+            logger.error("Exception in {}.{}", className, methodName, ex);
+            throw ex;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Spring AOP dependency
- log entry, exit, and exceptions for controller and service methods

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies; trustAnchors parameter must be non-empty)*

------
https://chatgpt.com/codex/tasks/task_e_68c77f97433c8332a54f7973a199de2e