### PR TITLE
Ensure tickets update last modified timestamp

### DIFF
--- a/api/src/main/java/com/example/api/service/TicketService.java
+++ b/api/src/main/java/com/example/api/service/TicketService.java
@@ -193,6 +193,7 @@ public class TicketService {
             statusMasterRepository.findById(assignId).ifPresent(ticket::setStatus);
         }
         System.out.println("TicketService: Saving the ticket to repository now...");
+        ticket.setLastModified(LocalDateTime.now());
         Ticket saved = ticketRepository.save(ticket);
 
         String openId = workflowService.getStatusIdByCode(TicketStatus.OPEN.name());
@@ -304,6 +305,7 @@ public class TicketService {
             }
         }
         if (updated.getUpdatedBy() != null) existing.setUpdatedBy(updated.getUpdatedBy());
+        existing.setLastModified(LocalDateTime.now());
         Ticket saved = ticketRepository.save(existing);
         String updatedBy = updated.getUpdatedBy() != null ? updated.getUpdatedBy() : existing.getUpdatedBy();
         if (assignmentChangeAllowed && !updated.getAssignedTo().equals(previousAssignedTo)) {


### PR DESCRIPTION
## Summary
- update ticket service to set `lastModified` whenever a ticket is created or updated
- keeps ticket queries current so IT managers can see newly submitted tickets awaiting approval

## Testing
- `./gradlew test` *(fails: Could not resolve com.github.typesense:typesense-java:0.2.0 (403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_68c782da55c48332a4c7304b4ebb8e8d