### PR TITLE
Track recommended severity approvals

### DIFF
--- a/api/src/main/java/com/example/api/dto/TicketDto.java
+++ b/api/src/main/java/com/example/api/dto/TicketDto.java
@@ -34,6 +34,8 @@ public class TicketDto {
     private String recommendedSeverity;
     private String impact;
     private String severityRecommendedBy;
+    private String recommendedSeverityStatus;
+    private String severityApprovedBy;
     private TicketStatus status;
     private String statusId;
     private String statusLabel;

--- a/api/src/main/java/com/example/api/enums/RecommendedSeverityStatus.java
+++ b/api/src/main/java/com/example/api/enums/RecommendedSeverityStatus.java
@@ -1,0 +1,6 @@
+package com.example.api.enums;
+
+public enum RecommendedSeverityStatus {
+    PENDING,
+    APPROVED
+}

--- a/api/src/main/java/com/example/api/models/RecommendedSeverityFlow.java
+++ b/api/src/main/java/com/example/api/models/RecommendedSeverityFlow.java
@@ -1,0 +1,38 @@
+package com.example.api.models;
+
+import com.example.api.enums.RecommendedSeverityStatus;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "recommended_severity_flow")
+@Getter
+@Setter
+public class RecommendedSeverityFlow {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "recommended_severity_flow_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ticket_id", referencedColumnName = "ticket_id")
+    private Ticket ticket;
+
+    @Column(name = "severity")
+    private String severity;
+
+    @Column(name = "recommended_severity")
+    private String recommendedSeverity;
+
+    @Column(name = "severity_recommended_by")
+    private String severityRecommendedBy;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "recommended_severity_status")
+    private RecommendedSeverityStatus recommendedSeverityStatus;
+
+    @Column(name = "severity_approved_by")
+    private String severityApprovedBy;
+}

--- a/api/src/main/java/com/example/api/repository/RecommendedSeverityFlowRepository.java
+++ b/api/src/main/java/com/example/api/repository/RecommendedSeverityFlowRepository.java
@@ -1,0 +1,16 @@
+package com.example.api.repository;
+
+import com.example.api.enums.RecommendedSeverityStatus;
+import com.example.api.models.RecommendedSeverityFlow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RecommendedSeverityFlowRepository extends JpaRepository<RecommendedSeverityFlow, Long> {
+
+    Optional<RecommendedSeverityFlow> findTopByTicket_IdAndRecommendedSeverityOrderByIdDesc(String ticketId, String recommendedSeverity);
+
+    Optional<RecommendedSeverityFlow> findTopByTicket_IdAndRecommendedSeverityStatusOrderByIdDesc(String ticketId, RecommendedSeverityStatus status);
+
+    Optional<RecommendedSeverityFlow> findTopByTicket_IdAndRecommendedSeverityAndRecommendedSeverityStatusOrderByIdDesc(String ticketId, String recommendedSeverity, RecommendedSeverityStatus status);
+}

--- a/db/ticketing_system_dump.sql
+++ b/db/ticketing_system_dump.sql
@@ -953,6 +953,27 @@ SET @saved_cs_client     = @@character_set_client;
 SET character_set_client = @saved_cs_client;
 
 --
+-- Table structure for table `recommended_severity_flow`
+--
+
+DROP TABLE IF EXISTS `recommended_severity_flow`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `recommended_severity_flow` (
+  `recommended_severity_flow_id` bigint NOT NULL AUTO_INCREMENT,
+  `ticket_id` varchar(36) NOT NULL,
+  `severity` varchar(50) DEFAULT NULL,
+  `recommended_severity` varchar(50) DEFAULT NULL,
+  `severity_recommended_by` varchar(100) DEFAULT NULL,
+  `recommended_severity_status` varchar(50) DEFAULT NULL,
+  `severity_approved_by` varchar(100) DEFAULT NULL,
+  PRIMARY KEY (`recommended_severity_flow_id`),
+  KEY `fk_ticket_recommended_severity_flow` (`ticket_id`),
+  CONSTRAINT `fk_ticket_recommended_severity_flow` FOREIGN KEY (`ticket_id`) REFERENCES `tickets` (`ticket_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Dumping events for database 'ticketing_system'
 --
 

--- a/ui/src/components/TicketView.tsx
+++ b/ui/src/components/TicketView.tsx
@@ -298,6 +298,16 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
       ? 'you'
       : recommendedSeverityBy
     : '';
+  const recommendedSeverityStatus = ticket?.recommendedSeverityStatus;
+  const severityApprovedBy = ticket?.severityApprovedBy;
+  const severityApprovedByText = severityApprovedBy
+    ? severityApprovedBy === currentUsername
+      ? 'you'
+      : severityApprovedBy
+    : '';
+  const recommendedSeverityApprovalText = recommendedSeverityStatus === 'APPROVED' && severityApprovedByText
+    ? `Recommended severity approved by ${severityApprovedByText}`
+    : 'Yet to be approved';
 
   const priorityInfoContent = useMemo(() =>
     <div>
@@ -416,13 +426,18 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
             </Box>}
         </Box>}
         {showRecommendedSeverity && (
-          <Box sx={{ display: 'flex', gap: 1, alignItems: 'baseline' }}>
-            <Typography className='me-2' color="text.secondary">Recommended Severity</Typography>
-            <Typography sx={{ mt: 1 }}>
-              {ticket.recommendedSeverity}
-            </Typography>
-            <Typography color="text.secondary" sx={{ mt: 1 }}>
-              {recommendedSeverityByText ? ` by ${recommendedSeverityByText}` : ''}
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+            <Box sx={{ display: 'flex', gap: 1, alignItems: 'baseline' }}>
+              <Typography className='me-2' color="text.secondary">Recommended Severity</Typography>
+              <Typography sx={{ mt: 1 }}>
+                {ticket.recommendedSeverity}
+              </Typography>
+              <Typography color="text.secondary" sx={{ mt: 1 }}>
+                {recommendedSeverityByText ? ` by ${recommendedSeverityByText}` : ''}
+              </Typography>
+            </Box>
+            <Typography color="text.secondary">
+              {recommendedSeverityApprovalText}
             </Typography>
           </Box>
         )}


### PR DESCRIPTION
## Summary
- add a recommended severity flow entity, repository, and status enum to persist recommendation/approval history
- extend the ticket service and DTO to populate approval data from the new history table and record recommendations and approvals
- update the TicketView UI to show approval messaging and add the new table definition to the database dump

## Testing
- ⚠️ `./gradlew --console=plain test` *(fails: Gradle toolchain cannot provision Java 17 in the container)*
- ⚠️ `npm run build` *(fails: build cannot resolve the `i18next` package because npm install hits peer dependency conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_68ca5baae4e483328562a547e4e0a840