### PR TITLE
Add domain-specific exceptions and handlers

### DIFF
--- a/api/src/main/java/com/example/api/exception/ForbiddenOperationException.java
+++ b/api/src/main/java/com/example/api/exception/ForbiddenOperationException.java
@@ -1,0 +1,11 @@
+package com.example.api.exception;
+
+/**
+ * Exception thrown when the current user attempts an action that is not permitted.
+ */
+public class ForbiddenOperationException extends RuntimeException {
+
+    public ForbiddenOperationException(String message) {
+        super(message);
+    }
+}

--- a/api/src/main/java/com/example/api/exception/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/example/api/exception/GlobalExceptionHandler.java
@@ -12,17 +12,29 @@ import java.time.LocalDateTime;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-    @ExceptionHandler(TicketNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handleTicketNotFound(TicketNotFoundException ex, HttpServletRequest request) {
-        ApiError apiError = new ApiError(ex.getMessage(), HttpStatus.NOT_FOUND.value(), request.getRequestURI());
-        ApiResponse<Void> response = new ApiResponse<>(false, null, apiError, LocalDateTime.now());
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleResourceNotFound(ResourceNotFoundException ex, HttpServletRequest request) {
+        return buildErrorResponse(HttpStatus.NOT_FOUND, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(ForbiddenOperationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleForbidden(ForbiddenOperationException ex, HttpServletRequest request) {
+        return buildErrorResponse(HttpStatus.FORBIDDEN, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(InvalidRequestException.class)
+    public ResponseEntity<ApiResponse<Void>> handleInvalidRequest(InvalidRequestException ex, HttpServletRequest request) {
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception ex, HttpServletRequest request) {
-        ApiError apiError = new ApiError(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR.value(), request.getRequestURI());
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), request);
+    }
+
+    private ResponseEntity<ApiResponse<Void>> buildErrorResponse(HttpStatus status, String message, HttpServletRequest request) {
+        ApiError apiError = new ApiError(message, status.value(), request.getRequestURI());
         ApiResponse<Void> response = new ApiResponse<>(false, null, apiError, LocalDateTime.now());
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+        return ResponseEntity.status(status).body(response);
     }
 }

--- a/api/src/main/java/com/example/api/exception/InvalidRequestException.java
+++ b/api/src/main/java/com/example/api/exception/InvalidRequestException.java
@@ -1,0 +1,11 @@
+package com.example.api.exception;
+
+/**
+ * Exception thrown when a request violates business rules or expectations.
+ */
+public class InvalidRequestException extends RuntimeException {
+
+    public InvalidRequestException(String message) {
+        super(message);
+    }
+}

--- a/api/src/main/java/com/example/api/exception/ResourceNotFoundException.java
+++ b/api/src/main/java/com/example/api/exception/ResourceNotFoundException.java
@@ -1,0 +1,15 @@
+package com.example.api.exception;
+
+/**
+ * Exception thrown when a requested resource cannot be located.
+ */
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(String resourceName, Object identifier) {
+        super(String.format("%s with identifier %s not found", resourceName, identifier));
+    }
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/api/src/main/java/com/example/api/exception/TicketNotFoundException.java
+++ b/api/src/main/java/com/example/api/exception/TicketNotFoundException.java
@@ -1,6 +1,6 @@
 package com.example.api.exception;
 
-public class TicketNotFoundException extends RuntimeException {
+public class TicketNotFoundException extends ResourceNotFoundException {
     public TicketNotFoundException(String id) {
         super("Ticket with id " + id + " not found");
     }

--- a/api/src/main/java/com/example/api/service/AssignmentHistoryService.java
+++ b/api/src/main/java/com/example/api/service/AssignmentHistoryService.java
@@ -1,5 +1,6 @@
 package com.example.api.service;
 
+import com.example.api.exception.TicketNotFoundException;
 import com.example.api.models.AssignmentHistory;
 import com.example.api.models.Ticket;
 import com.example.api.repository.AssignmentHistoryRepository;
@@ -17,7 +18,8 @@ public class AssignmentHistoryService {
     private final TicketRepository ticketRepository;
 
     public AssignmentHistory addHistory(String ticketId, String assignedBy, String assignedTo, String levelId, String remark) {
-        Ticket ticket = ticketRepository.findById(ticketId).orElseThrow();
+        Ticket ticket = ticketRepository.findById(ticketId)
+                .orElseThrow(() -> new TicketNotFoundException(ticketId));
         AssignmentHistory history = new AssignmentHistory();
         history.setTicket(ticket);
         history.setAssignedBy(assignedBy);
@@ -29,7 +31,8 @@ public class AssignmentHistoryService {
     }
 
     public List<AssignmentHistory> getHistoryForTicket(String ticketId) {
-        Ticket ticket = ticketRepository.findById(ticketId).orElseThrow();
+        Ticket ticket = ticketRepository.findById(ticketId)
+                .orElseThrow(() -> new TicketNotFoundException(ticketId));
         return historyRepository.findByTicketOrderByTimestampAsc(ticket);
     }
 }

--- a/api/src/main/java/com/example/api/service/DocumentService.java
+++ b/api/src/main/java/com/example/api/service/DocumentService.java
@@ -1,5 +1,6 @@
 package com.example.api.service;
 
+import com.example.api.exception.ResourceNotFoundException;
 import com.example.api.models.Document;
 import com.example.api.repository.DocumentRepository;
 import org.springframework.stereotype.Service;
@@ -23,7 +24,8 @@ public class DocumentService {
     }
 
     public Document updateDocument(String id, Document doc) {
-        Document existing = documentRepository.findById(id).orElseThrow();
+        Document existing = documentRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Document", id));
         existing.setTitle(doc.getTitle());
         existing.setDescription(doc.getDescription());
         existing.setType(doc.getType());
@@ -32,7 +34,8 @@ public class DocumentService {
     }
 
     public void softDeleteDocument(String id) {
-        Document existing = documentRepository.findById(id).orElseThrow();
+        Document existing = documentRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Document", id));
 //        existing.setIsDeleted(true);
         documentRepository.save(existing);
     }

--- a/api/src/main/java/com/example/api/service/FileStorageService.java
+++ b/api/src/main/java/com/example/api/service/FileStorageService.java
@@ -1,5 +1,6 @@
 package com.example.api.service;
 
+import com.example.api.exception.TicketNotFoundException;
 import com.example.api.models.Ticket;
 import com.example.api.models.UploadedFile;
 import com.example.api.repository.TicketRepository;
@@ -48,7 +49,8 @@ public class FileStorageService {
         }
         uf.setRelativePath(relativePath);
         uf.setUploadedBy(uploadedBy);
-        Ticket ticket = ticketRepository.findById(ticketId).orElseThrow();
+        Ticket ticket = ticketRepository.findById(ticketId)
+                .orElseThrow(() -> new TicketNotFoundException(ticketId));
         uf.setTicket(ticket);
         uploadedFileRepository.save(uf);
 

--- a/api/src/main/java/com/example/api/service/PermissionService.java
+++ b/api/src/main/java/com/example/api/service/PermissionService.java
@@ -1,5 +1,6 @@
 package com.example.api.service;
 
+import com.example.api.exception.ResourceNotFoundException;
 import com.example.api.models.Role;
 import com.example.api.permissions.PermissionsConfig;
 import com.example.api.permissions.RolePermission;
@@ -34,7 +35,8 @@ public class PermissionService {
 
     public void updateRolePermissions(Integer roleId, RolePermission permission) throws IOException {
         String json = objectMapper.writeValueAsString(permission);
-        Role existingRole = repository.findById(roleId).orElseThrow();
+        Role existingRole = repository.findById(roleId)
+                .orElseThrow(() -> new ResourceNotFoundException("Role", roleId));
 //        Role rpc = new Role();
 //        rpc.setRoleId(roleId);
         existingRole.setPermissions(json);

--- a/api/src/main/java/com/example/api/service/RoleService.java
+++ b/api/src/main/java/com/example/api/service/RoleService.java
@@ -1,6 +1,7 @@
 package com.example.api.service;
 
 import com.example.api.dto.RoleDto;
+import com.example.api.exception.ResourceNotFoundException;
 import com.example.api.mapper.DtoMapper;
 import com.example.api.models.Role;
 import com.example.api.permissions.RolePermission;
@@ -38,7 +39,8 @@ public class RoleService {
     }
 
     public RoleDto getRoleById(Integer roleId) {
-        Role role = roleRepository.findById(roleId).orElseThrow();
+        Role role = roleRepository.findById(roleId)
+                .orElseThrow(() -> new ResourceNotFoundException("Role", roleId));
         return DtoMapper.toRoleDto(role);
     }
 

--- a/api/src/main/java/com/example/api/service/StatusHistoryService.java
+++ b/api/src/main/java/com/example/api/service/StatusHistoryService.java
@@ -1,6 +1,7 @@
 package com.example.api.service;
 
 import com.example.api.dto.StatusHistoryDto;
+import com.example.api.exception.TicketNotFoundException;
 import com.example.api.mapper.DtoMapper;
 import com.example.api.models.StatusHistory;
 import com.example.api.models.Ticket;
@@ -23,7 +24,8 @@ public class StatusHistoryService {
     }
 
     public StatusHistory addHistory(String ticketId, String updatedBy, String previousStatus, String currentStatus, Boolean slaFlag, String remark) {
-        Ticket ticket = ticketRepository.findById(ticketId).orElseThrow();
+        Ticket ticket = ticketRepository.findById(ticketId)
+                .orElseThrow(() -> new TicketNotFoundException(ticketId));
         StatusHistory history = new StatusHistory();
         history.setTicket(ticket);
         history.setUpdatedBy(updatedBy);
@@ -36,7 +38,8 @@ public class StatusHistoryService {
     }
 
     public List<StatusHistoryDto> getHistoryForTicket(String ticketId) {
-        Ticket ticket = ticketRepository.findById(ticketId).orElseThrow();
+        Ticket ticket = ticketRepository.findById(ticketId)
+                .orElseThrow(() -> new TicketNotFoundException(ticketId));
         return historyRepository.findByTicketOrderByTimestampAsc(ticket).stream().map(DtoMapper::toStatusHistoryDto).collect(Collectors.toUnmodifiableList());
     }
 }

--- a/api/src/main/java/com/example/api/service/SubCategoryService.java
+++ b/api/src/main/java/com/example/api/service/SubCategoryService.java
@@ -1,6 +1,7 @@
 package com.example.api.service;
 
 import com.example.api.dto.SubCategoryDto;
+import com.example.api.exception.ResourceNotFoundException;
 import com.example.api.models.Category;
 import com.example.api.models.SubCategory;
 import com.example.api.repository.CategoryRepository;
@@ -39,7 +40,7 @@ public class SubCategoryService {
 
     public SubCategory saveSubCategory(String categoryId, SubCategory subCategory) {
         Category category = categoryRepository.findById(categoryId)
-            .orElseThrow(() -> new RuntimeException("Category not found"));
+            .orElseThrow(() -> new ResourceNotFoundException("Category", categoryId));
         subCategory.setCategory(category);
         if (subCategory.getSeverity() != null && subCategory.getSeverity().getId() != null) {
             severityRepository.findById(subCategory.getSeverity().getId())

--- a/api/src/main/java/com/example/api/service/TicketService.java
+++ b/api/src/main/java/com/example/api/service/TicketService.java
@@ -1,6 +1,7 @@
 package com.example.api.service;
 
 import com.example.api.dto.TicketDto;
+import com.example.api.exception.ResourceNotFoundException;
 import com.example.api.exception.TicketNotFoundException;
 import com.example.api.mapper.DtoMapper;
 import com.example.api.models.User;
@@ -173,7 +174,8 @@ public class TicketService {
 
         // If userId is neither null nor empty
         if (ticket.getUserId() != null && !ticket.getUserId().isEmpty()) {
-            User user = userRepository.findById(ticket.getUserId()).orElseThrow();
+            User user = userRepository.findById(ticket.getUserId())
+                    .orElseThrow(() -> new ResourceNotFoundException("User", ticket.getUserId()));
             ticket.setUser(user);
             ticket.setRequestorName(user.getUsername());
         }
@@ -458,7 +460,8 @@ public class TicketService {
     }
 
     public TicketComment updateComment(String commentId, String comment) {
-        TicketComment existing = commentRepository.findById(commentId).orElseThrow();
+        TicketComment existing = commentRepository.findById(commentId)
+                .orElseThrow(() -> new ResourceNotFoundException("TicketComment", commentId));
         existing.setComment(comment);
         return commentRepository.save(existing);
     }


### PR DESCRIPTION
## Summary
- add reusable domain exceptions for resource lookup, forbidden actions, and invalid requests, and reuse them from TicketNotFoundException
- expand the global exception handler to translate the new exceptions into consistent API error responses
- replace generic RuntimeExceptions across services with the new domain exceptions for clearer intent

## Testing
- ./gradlew test *(fails: toolchain configuration cannot locate Java 17 in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca61d8fd1883328ca058390962c5b3