### PR TITLE
Update notification entity fields for new columns

### DIFF
--- a/api/src/main/java/com/example/notification/models/Notification.java
+++ b/api/src/main/java/com/example/notification/models/Notification.java
@@ -3,6 +3,9 @@ package com.example.notification.models;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "notification")
@@ -10,7 +13,30 @@ import lombok.Setter;
 public class Notification {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
     private Long id;
 
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "type_id", nullable = false)
     private NotificationMaster type;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Lob
+    @Column(name = "message")
+    private String message;
+
+    @Column(name = "data", columnDefinition = "json")
+    private String data;
+
+    @Column(name = "ticket_id", length = 36)
+    private String ticketId;
+
+    @Column(name = "created_by")
+    private Integer createdBy;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
 }


### PR DESCRIPTION
## Summary
- map notification entity columns for title, message, data, ticket, creator, and timestamp
- configure Notification.type as a ManyToOne association to NotificationMaster with the correct join column

## Testing
- `./gradlew test --console=plain` *(fails: Cannot find a Java installation matching toolchain requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f12ab8048332a234d7881900418d