### PR TITLE
Fix notification recipient repository paging

### DIFF
--- a/api/src/main/java/com/example/notification/repository/NotificationRecipientRepository.java
+++ b/api/src/main/java/com/example/notification/repository/NotificationRecipientRepository.java
@@ -1,18 +1,17 @@
 package com.example.notification.repository;
 
 import com.example.notification.models.NotificationRecipient;
-import org.hibernate.query.Page;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import javax.swing.*;
-import java.awt.print.Pageable;
 import java.util.List;
 
 public interface NotificationRecipientRepository extends JpaRepository<NotificationRecipient, Long> {
     @Query("""
-            SELECT nr FROM notificationRecipient nr
+            SELECT nr FROM NotificationRecipient nr
             JOIN FETCH nr.notification n
             JOIN FETCH n.type t
             WHERE nr.recipient.id = :userId


### PR DESCRIPTION
## Summary
- switch the inbox query imports to use Spring Data's Page and Pageable interfaces
- align the JPQL query with the NotificationRecipient, Notification, and NotificationMaster entity names

## Testing
- ./gradlew test *(fails: Java 17 toolchain not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f51a20d08332baa3b45a95dc8bab