### PR TITLE
Ensure notifier uses enriched model map

### DIFF
--- a/api/src/main/java/com/example/notification/service/NotificationService.java
+++ b/api/src/main/java/com/example/notification/service/NotificationService.java
@@ -34,6 +34,6 @@ public class NotificationService {
             model.put("supportEmail", properties.getSupportEmail());
         }
 
-        notifier.send(templateName, dataModel, recipient);
+        notifier.send(templateName, model, recipient);
     }
 }

--- a/api/src/test/java/com/example/notification/service/NotificationServiceTest.java
+++ b/api/src/test/java/com/example/notification/service/NotificationServiceTest.java
@@ -1,0 +1,52 @@
+package com.example.notification.service;
+
+import com.example.notification.config.NotificationProperties;
+import com.example.notification.enums.ChannelType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class NotificationServiceTest {
+
+    private NotificationProperties properties;
+    private Notifier notifier;
+    private NotificationService notificationService;
+
+    @BeforeEach
+    void setUp() {
+        properties = new NotificationProperties();
+        properties.setEnabled(true);
+        properties.setSupportEmail("support@example.com");
+
+        notifier = mock(Notifier.class);
+        when(notifier.getChannel()).thenReturn(ChannelType.EMAIL);
+        when(notifier.getTemplateFolder()).thenReturn(null);
+
+        notificationService = new NotificationService(List.of(notifier), properties);
+    }
+
+    @Test
+    void shouldIncludeSupportEmailWhenSendingNotification() throws Exception {
+        Map<String, Object> dataModel = new HashMap<>();
+        dataModel.put("key", "value");
+
+        notificationService.sendNotification(ChannelType.EMAIL, "template", dataModel, "recipient@example.com");
+
+        ArgumentCaptor<Map<String, Object>> modelCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(notifier).send("template", modelCaptor.capture(), "recipient@example.com");
+
+        Map<String, Object> capturedModel = modelCaptor.getValue();
+        assertThat(capturedModel)
+                .containsEntry("supportEmail", "support@example.com")
+                .containsEntry("key", "value");
+    }
+}


### PR DESCRIPTION
## Summary
- update the notification service to pass the merged template model to the notifier
- add a notification service unit test that verifies the support email default is included when sending

## Testing
- ./gradlew test --console=plain *(fails: 403 fetching com.github.typesense:typesense-java:0.2.0 from jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f8abfd788332bbc774512879d03f