### PR TITLE
Add SMS notification template and Freemarker test

### DIFF
--- a/api/src/main/resources/notification/templates/sms/TicketCreated.ftl
+++ b/api/src/main/resources/notification/templates/sms/TicketCreated.ftl
@@ -1,0 +1,3 @@
+<#-- SMS template for ticket creation notification -->
+Ticket ${ticketId} has been created for ${requesterName?default("our valued customer")}.
+We will keep you updated. Need help? Contact us at ${supportEmail?default("support@example.com")}.

--- a/api/src/test/java/com/example/notification/config/FreemarkerConfigTest.java
+++ b/api/src/test/java/com/example/notification/config/FreemarkerConfigTest.java
@@ -1,0 +1,25 @@
+package com.example.notification.config;
+
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FreemarkerConfigTest {
+
+    private Configuration configuration;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        configuration = new FreemarkerConfig().freemarkerConfiguration();
+    }
+
+    @Test
+    void shouldLoadSmsTemplateFromResources() throws Exception {
+        Template template = configuration.getTemplate("sms/TicketCreated.ftl");
+
+        assertThat(template).isNotNull();
+    }
+}


### PR DESCRIPTION
## Summary
- add an SMS TicketCreated FreeMarker template so the notifier has a default resource
- add a unit test that ensures the FreeMarker configuration can load the SMS template

## Testing
- ./gradlew test *(fails: could not download com.github.typesense:typesense-java:0.2.0 from jitpack.io due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d10f7910d48332bc0d1e24beac49e0