### PR TITLE
Add in-app notification JSON payload and UI bell

### DIFF
--- a/api/src/main/java/com/example/notification/enums/ChannelType.java
+++ b/api/src/main/java/com/example/notification/enums/ChannelType.java
@@ -1,5 +1,5 @@
 package com.example.notification.enums;
 
 public enum ChannelType {
-    EMAIL, SMS, INAPP
+    EMAIL, SMS, IN_APP
 }

--- a/api/src/main/java/com/example/notification/service/EmailNotifier.java
+++ b/api/src/main/java/com/example/notification/service/EmailNotifier.java
@@ -11,8 +11,6 @@ import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
 
 import java.io.StringWriter;
-import java.util.Map;
-
 @Component
 public class EmailNotifier implements Notifier {
     private final Configuration freemarker;
@@ -31,16 +29,16 @@ public class EmailNotifier implements Notifier {
     }
 
     @Override
-    public void send(String templateName, Map<String, Object> data, String recipient) throws Exception {
-        Template template = freemarker.getTemplate(templateName + ".ftl");
+    public void send(NotificationRequest request) throws Exception {
+        Template template = freemarker.getTemplate(request.getTemplateName() + ".ftl");
         StringWriter out = new StringWriter();
-        template.process(data, out);
+        template.process(request.getDataModel(), out);
         String body = out.toString();
         System.out.println("Email notification sent");
 
         MimeMessage message = mailSender.createMimeMessage();
         MimeMessageHelper helper = new MimeMessageHelper(message, true);
-        helper.setTo(recipient);
+        helper.setTo(request.getRecipient());
         helper.setFrom(properties.getSenderEmail());
         helper.setSubject("Notification");
         helper.setText(body, true);

--- a/api/src/main/java/com/example/notification/service/InAppNotificationPayload.java
+++ b/api/src/main/java/com/example/notification/service/InAppNotificationPayload.java
@@ -1,0 +1,16 @@
+package com.example.notification.service;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@Builder
+public class InAppNotificationPayload {
+    private final String code;
+    private final String title;
+    private final String message;
+    private final Map<String, Object> data;
+    private final String timestamp;
+}

--- a/api/src/main/java/com/example/notification/service/InAppNotifier.java
+++ b/api/src/main/java/com/example/notification/service/InAppNotifier.java
@@ -1,38 +1,57 @@
 package com.example.notification.service;
 
-import com.example.notification.config.NotificationProperties;
 import com.example.notification.enums.ChannelType;
-import freemarker.template.Configuration;
-import freemarker.template.Template;
-import org.springframework.beans.factory.annotation.Qualifier;
+import com.example.notification.models.NotificationMaster;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
-import java.io.StringWriter;
+import java.time.Instant;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 @Component
 public class InAppNotifier implements Notifier{
-    private final Configuration freemarker;
     private final SimpMessagingTemplate messagingTemplate;
 
-    public InAppNotifier(@Qualifier("freemarkerConfiguration") Configuration freemarker, SimpMessagingTemplate messagingTemplate) {
-        this.freemarker = freemarker;
+    public InAppNotifier(SimpMessagingTemplate messagingTemplate) {
         this.messagingTemplate = messagingTemplate;
     }
 
     @Override
     public ChannelType getChannel() {
-        return ChannelType.INAPP;
+        return ChannelType.IN_APP;
     }
 
     @Override
-    public void send(String templateName, Map<String, Object> dataModel, String recipient) throws Exception {
-        Template template = freemarker.getTemplate(templateName);
-        StringWriter out = new StringWriter();
-        template.process(dataModel, out);
+    public void send(NotificationRequest request) {
+        NotificationMaster master = request.getNotificationMaster();
+        Map<String, Object> payloadData = request.getDataModel() == null
+                ? new HashMap<>()
+                : new HashMap<>(request.getDataModel());
 
-        messagingTemplate.convertAndSend("/topic/notifications/" + recipient, out.toString());
+        InAppNotificationPayload payload = InAppNotificationPayload.builder()
+                .code(master != null ? master.getCode() : null)
+                .title(resolveTemplate(master != null ? master.getDefaultTitleTpl() : null, master != null ? master.getName() : null, payloadData))
+                .message(resolveTemplate(master != null ? master.getDefaultMessageTpl() : null, master != null ? master.getDescription() : null, payloadData))
+                .data(payloadData)
+                .timestamp(Instant.now().toString())
+                .build();
+
+        messagingTemplate.convertAndSend("/topic/notifications/" + request.getRecipient(), payload);
         System.out.println("In-App notification sent");
+    }
+
+    private String resolveTemplate(String template, String fallback, Map<String, Object> data) {
+        if (template == null || template.isBlank()) {
+            return fallback;
+        }
+        String resolved = template;
+        for (Map.Entry<String, Object> entry : data.entrySet()) {
+            String value = Objects.toString(entry.getValue(), "");
+            resolved = resolved.replace("${" + entry.getKey() + "}", value);
+            resolved = resolved.replace("{{" + entry.getKey() + "}}", value);
+        }
+        return resolved;
     }
 }

--- a/api/src/main/java/com/example/notification/service/NotificationRequest.java
+++ b/api/src/main/java/com/example/notification/service/NotificationRequest.java
@@ -1,0 +1,51 @@
+package com.example.notification.service;
+
+import com.example.notification.enums.ChannelType;
+import com.example.notification.models.NotificationMaster;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class NotificationRequest {
+    private final ChannelType channel;
+    private final NotificationMaster notificationMaster;
+    private final String recipient;
+    private final String templateName;
+    private final Map<String, Object> dataModel;
+
+    public NotificationRequest(ChannelType channel,
+                               NotificationMaster notificationMaster,
+                               String recipient,
+                               String templateName,
+                               Map<String, Object> dataModel) {
+        this.channel = Objects.requireNonNull(channel, "channel must not be null");
+        this.notificationMaster = notificationMaster;
+        this.recipient = recipient;
+        this.templateName = templateName;
+        this.dataModel = dataModel == null
+                ? Collections.emptyMap()
+                : Collections.unmodifiableMap(new HashMap<>(dataModel));
+    }
+
+    public ChannelType getChannel() {
+        return channel;
+    }
+
+    public NotificationMaster getNotificationMaster() {
+        return notificationMaster;
+    }
+
+    public String getRecipient() {
+        return recipient;
+    }
+
+    public String getTemplateName() {
+        return templateName;
+    }
+
+    public Map<String, Object> getDataModel() {
+        return dataModel;
+    }
+}

--- a/api/src/main/java/com/example/notification/service/Notifier.java
+++ b/api/src/main/java/com/example/notification/service/Notifier.java
@@ -2,9 +2,7 @@ package com.example.notification.service;
 
 import com.example.notification.enums.ChannelType;
 
-import java.util.Map;
-
 public interface Notifier {
     ChannelType getChannel();
-    void send(String templateName, Map<String, Object> dataModel, String recipient) throws Exception;
+    void send(NotificationRequest request) throws Exception;
 }

--- a/api/src/main/java/com/example/notification/service/SmsNotifier.java
+++ b/api/src/main/java/com/example/notification/service/SmsNotifier.java
@@ -10,8 +10,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import java.io.StringWriter;
-import java.util.Map;
-
 @Component
 public class SmsNotifier implements Notifier {
     private final Configuration freemarker;
@@ -28,13 +26,13 @@ public class SmsNotifier implements Notifier {
     }
 
     @Override
-    public void send(String templateName, Map<String, Object> dataModel, String recipient) throws Exception {
-        Template template = freemarker.getTemplate(templateName + ".ftl");
+    public void send(NotificationRequest request) throws Exception {
+        Template template = freemarker.getTemplate(request.getTemplateName() + ".ftl");
         StringWriter out = new StringWriter();
-        template.process(dataModel, out);
+        template.process(request.getDataModel(), out);
         String body = out.toString();
         System.out.println("SMS notification sent");
 
-        Message.creator(new PhoneNumber(recipient), new PhoneNumber(twilioProperties.getFromNumber()), body).create();
+        Message.creator(new PhoneNumber(request.getRecipient()), new PhoneNumber(twilioProperties.getFromNumber()), body).create();
     }
 }

--- a/api/src/test/java/com/example/notification/service/NotificationServiceTest.java
+++ b/api/src/test/java/com/example/notification/service/NotificationServiceTest.java
@@ -52,10 +52,13 @@ class NotificationServiceTest {
 
         notificationService.sendNotification(ChannelType.EMAIL, "TICKET_CREATED", dataModel, "recipient@example.com");
 
-        ArgumentCaptor<Map<String, Object>> modelCaptor = ArgumentCaptor.forClass(Map.class);
-        verify(notifier).send("email/TicketCreated", modelCaptor.capture(), "recipient@example.com");
+        ArgumentCaptor<NotificationRequest> requestCaptor = ArgumentCaptor.forClass(NotificationRequest.class);
+        verify(notifier).send(requestCaptor.capture());
 
-        Map<String, Object> capturedModel = modelCaptor.getValue();
+        NotificationRequest capturedRequest = requestCaptor.getValue();
+        assertThat(capturedRequest.getTemplateName()).isEqualTo("email/TicketCreated");
+
+        Map<String, Object> capturedModel = capturedRequest.getDataModel();
         assertThat(capturedModel)
                 .containsEntry("supportEmail", "support@example.com")
                 .containsEntry("key", "value");

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/icons-material": "^7.1.1",
         "@mui/lab": "^7.0.0-beta.14",
         "@mui/material": "^7.1.1",
+        "@stomp/stompjs": "^7.0.0",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
@@ -35,11 +36,13 @@
         "react-router-dom": "^7.6.1",
         "react-scripts": "5.0.1",
         "sass": "^1.89.0",
+        "sockjs-client": "^1.6.1",
         "typesense": "^1.2.1",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
         "@types/react-router-dom": "^5.3.3",
+        "@types/sockjs-client": "^1.5.4",
         "typescript": "^5.8.3"
       }
     },
@@ -4270,6 +4273,12 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@stomp/stompjs": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.2.0.tgz",
+      "integrity": "sha512-+Waf/wdSxgRmXHWg7HXUt51YNK/Cp2pMhW+OELwX5fzbO6pd+O2bLrWqGmyFNC/RyeUQIMGESP7oE3L1dXXm0Q==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -5036,6 +5045,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/sockjs-client": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/sockjs-client/-/sockjs-client-1.5.4.tgz",
+      "integrity": "sha512-zk+uFZeWyvJ5ZFkLIwoGA/DfJ+pYzcZ8eH4H/EILCm2OBZyHH6Hkdna1/UWL/CFruh5wj6ES7g75SvUB0VsH5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -9160,6 +9176,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/execa": {
@@ -17347,6 +17372,34 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
+      }
+    },
+    "node_modules/sockjs-client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
+      "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "eventsource": "^2.0.2",
+        "faye-websocket": "^0.11.4",
+        "inherits": "^2.0.4",
+        "url-parse": "^1.5.10"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://tidelift.com/funding/github/npm/sockjs-client"
+      }
+    },
+    "node_modules/sockjs-client/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/source-list-map": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,6 +9,7 @@
     "@mui/icons-material": "^7.1.1",
     "@mui/lab": "^7.0.0-beta.14",
     "@mui/material": "^7.1.1",
+    "@stomp/stompjs": "^7.0.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
@@ -30,6 +31,7 @@
     "react-quill": "^2.0.0",
     "react-scripts": "5.0.1",
     "sass": "^1.89.0",
+    "sockjs-client": "^1.6.1",
     "typesense": "^1.2.1",
     "web-vitals": "^2.1.4"
   },
@@ -59,6 +61,7 @@
   },
   "devDependencies": {
     "@types/react-router-dom": "^5.3.3",
+    "@types/sockjs-client": "^1.5.4",
     "typescript": "^5.8.3"
   }
 }

--- a/ui/src/components/Layout/Header.tsx
+++ b/ui/src/components/Layout/Header.tsx
@@ -7,6 +7,7 @@ import { useTheme } from "@mui/material/styles";
 import { LanguageContext } from "../../context/LanguageContext";
 import { DevModeContext } from "../../context/DevModeContext";
 import UserMenu from "./UserMenu";
+import NotificationBell from "../Notifications/NotificationBell";
 
 interface HeaderProps {
   collapsed: boolean;
@@ -106,6 +107,7 @@ const Header: React.FC<HeaderProps> = ({ collapsed, toggleSidebar }) => {
           // icon="code"
           onClick={toggleLayout}
         />}
+        <NotificationBell iconColor={iconColor} />
         <Avatar
           sx={{
             bgcolor: theme.palette.grey[600],

--- a/ui/src/components/Notifications/NotificationBell.tsx
+++ b/ui/src/components/Notifications/NotificationBell.tsx
@@ -1,0 +1,143 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import NotificationsNoneOutlinedIcon from '@mui/icons-material/NotificationsNoneOutlined';
+import {
+  Badge,
+  Box,
+  Divider,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Menu,
+  Typography,
+} from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+
+import { useNotifications } from '../../hooks/useNotifications';
+import { NotificationItem } from '../../types/notification';
+
+const formatTimestamp = (value: string) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString();
+};
+
+const renderNotification = (notification: NotificationItem) => {
+  return (
+    <ListItem key={notification.id} alignItems="flex-start" sx={{ py: 1, px: 1.5 }}>
+      <ListItemText
+        primary={
+          <Typography variant="subtitle2" sx={{ fontWeight: notification.read ? 500 : 600 }}>
+            {notification.title || 'Notification'}
+          </Typography>
+        }
+        secondary={
+          <Box component="span" sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+            {notification.message && (
+              <Typography variant="body2" color="text.secondary">
+                {notification.message}
+              </Typography>
+            )}
+            <Typography variant="caption" color="text.secondary">
+              {formatTimestamp(notification.timestamp)}
+            </Typography>
+          </Box>
+        }
+      />
+    </ListItem>
+  );
+};
+
+interface NotificationBellProps {
+  iconColor: string;
+}
+
+const NotificationBell: React.FC<NotificationBellProps> = ({ iconColor }) => {
+  const theme = useTheme();
+  const { notifications, unreadCount, markAllAsRead } = useNotifications();
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  const menuOpen = Boolean(anchorEl);
+
+  const sortedNotifications = useMemo(
+    () =>
+      [...notifications].sort(
+        (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+      ),
+    [notifications]
+  );
+
+  const handleOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  useEffect(() => {
+    if (menuOpen && unreadCount > 0) {
+      markAllAsRead();
+    }
+  }, [menuOpen, unreadCount, markAllAsRead]);
+
+  return (
+    <>
+      <IconButton
+        onClick={handleOpen}
+        sx={{
+          color: iconColor,
+          '&:hover': {
+            color: theme.palette.mode === 'dark' ? theme.palette.success.light : theme.palette.primary.contrastText,
+          },
+        }}
+        aria-label="Notifications"
+      >
+        <Badge color="error" badgeContent={unreadCount} overlap="circular">
+          <NotificationsNoneOutlinedIcon />
+        </Badge>
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={menuOpen}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        PaperProps={{
+          sx: {
+            width: 360,
+            maxHeight: 420,
+            mt: 1,
+          },
+        }}
+      >
+        <Box sx={{ px: 2, py: 1.5 }}>
+          <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+            Notifications
+          </Typography>
+        </Box>
+        <Divider />
+        {sortedNotifications.length === 0 ? (
+          <Box sx={{ px: 2, py: 2 }}>
+            <Typography variant="body2" color="text.secondary">
+              You're all caught up!
+            </Typography>
+          </Box>
+        ) : (
+          <List dense disablePadding>
+            {sortedNotifications.map(notification => (
+              <React.Fragment key={notification.id}>
+                {renderNotification(notification)}
+                <Divider component="li" />
+              </React.Fragment>
+            ))}
+          </List>
+        )}
+      </Menu>
+    </>
+  );
+};
+
+export default NotificationBell;

--- a/ui/src/hooks/useNotifications.ts
+++ b/ui/src/hooks/useNotifications.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Client, IMessage, StompSubscription } from '@stomp/stompjs';
+import SockJS from 'sockjs-client';
+
+import { BASE_URL } from '../services/api';
+import { getCurrentUserDetails } from '../config/config';
+import { InAppNotificationPayload, NotificationItem } from '../types/notification';
+
+const WS_ENDPOINT = `${BASE_URL}/ws`;
+
+const buildNotification = (payload: InAppNotificationPayload): NotificationItem => {
+  const timestamp = payload.timestamp || new Date().toISOString();
+  const title = payload.title || payload.code || 'Notification';
+  const message = payload.message || '';
+  return {
+    id: `${payload.code || 'notification'}-${timestamp}-${Math.random().toString(36).slice(2, 8)}`,
+    code: payload.code,
+    title,
+    message,
+    data: payload.data,
+    timestamp,
+    read: false,
+  };
+};
+
+export const useNotifications = () => {
+  const [notifications, setNotifications] = useState<NotificationItem[]>([]);
+  const subscriptionsRef = useRef<StompSubscription[]>([]);
+
+  const recipientIds = useMemo(() => {
+    const user = getCurrentUserDetails();
+    if (!user) return [] as string[];
+    const ids = new Set<string>();
+    if (user.userId) ids.add(user.userId);
+    if (user.email) ids.add(user.email);
+    if (user.username) ids.add(user.username);
+    return Array.from(ids).filter(Boolean);
+  }, []);
+
+  const handleMessage = useCallback((message: IMessage) => {
+    try {
+      const payload: InAppNotificationPayload = JSON.parse(message.body);
+      setNotifications(prev => [buildNotification(payload), ...prev]);
+    } catch (error) {
+      console.error('Failed to parse notification payload', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!recipientIds.length) {
+      return undefined;
+    }
+
+    const client = new Client({
+      reconnectDelay: 5000,
+      webSocketFactory: () => new SockJS(WS_ENDPOINT),
+      onConnect: () => {
+        subscriptionsRef.current = recipientIds.map(id =>
+          client.subscribe(`/topic/notifications/${id}`, handleMessage)
+        );
+      },
+      onStompError: frame => {
+        console.error('STOMP error', frame.headers['message']);
+      },
+    });
+
+    client.activate();
+    return () => {
+      subscriptionsRef.current.forEach(sub => sub.unsubscribe());
+      subscriptionsRef.current = [];
+      client.deactivate();
+    };
+  }, [handleMessage, recipientIds]);
+
+  const unreadCount = useMemo(
+    () => notifications.filter(notification => !notification.read).length,
+    [notifications]
+  );
+
+  const markAllAsRead = useCallback(() => {
+    setNotifications(prev => prev.map(notification => ({ ...notification, read: true })));
+  }, []);
+
+  const markAsRead = useCallback((id: string) => {
+    setNotifications(prev =>
+      prev.map(notification =>
+        notification.id === id ? { ...notification, read: true } : notification
+      )
+    );
+  }, []);
+
+  return {
+    notifications,
+    unreadCount,
+    markAllAsRead,
+    markAsRead,
+  };
+};

--- a/ui/src/types/notification.ts
+++ b/ui/src/types/notification.ts
@@ -1,0 +1,17 @@
+export interface InAppNotificationPayload {
+  code?: string;
+  title?: string;
+  message?: string;
+  data?: Record<string, unknown>;
+  timestamp?: string;
+}
+
+export interface NotificationItem {
+  id: string;
+  code?: string;
+  title?: string;
+  message?: string;
+  data?: Record<string, unknown>;
+  timestamp: string;
+  read: boolean;
+}


### PR DESCRIPTION
## Summary
- rename the IN_APP notification channel and introduce NotificationRequest/InAppNotificationPayload so in-app messages are sent as JSON objects
- refactor notifiers to accept the shared request structure and publish JSON payloads to websocket subscribers
- add a websocket-driven notification bell in the header with a badge and menu fed by the new hook

## Testing
- npm run build
- ./gradlew test *(fails: missing Java 17 toolchain in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d116f28224833296ed093d28ee82e7