### PR TITLE
Ensure notification repository is discovered

### DIFF
--- a/api/src/main/java/com/example/api/Main.java
+++ b/api/src/main/java/com/example/api/Main.java
@@ -2,16 +2,19 @@ package com.example.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = "com.example")
 @ConfigurationPropertiesScan(basePackages = "com.example")
+@EnableJpaRepositories(basePackages = "com.example.notification.repository")
+@EntityScan(basePackages = "com.example.notification.models")
 //@EnableScheduling
 public class Main {
 
-	public static void main(String[] args) {
-		SpringApplication.run(Main.class, args);
-	}
-
+    public static void main(String[] args) {
+        SpringApplication.run(Main.class, args);
+    }
 }

--- a/api/src/main/java/com/example/notification/repository/NotificationMasterRepository.java
+++ b/api/src/main/java/com/example/notification/repository/NotificationMasterRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface NotificationMasterRepository extends JpaRepository<NotificationMaster, Long> {
+public interface NotificationMasterRepository extends JpaRepository<NotificationMaster, Integer> {
     Optional<NotificationMaster> findByCodeAndIsActiveTrue(String code);
 }


### PR DESCRIPTION
## Summary
- enable JPA repository and entity scanning for the notification module in the main application
- align `NotificationMasterRepository`'s identifier type with the `NotificationMaster` entity

## Testing
- ./gradlew test *(fails: required Java 17 toolchain is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d232a8d690833293b6d00f63b81005