### PR TITLE
Include API models in entity scan

### DIFF
--- a/api/src/main/java/com/example/api/Main.java
+++ b/api/src/main/java/com/example/api/Main.java
@@ -10,7 +10,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication(scanBasePackages = "com.example")
 @ConfigurationPropertiesScan(basePackages = "com.example")
 @EnableJpaRepositories(basePackages = "com.example.notification.repository")
-@EntityScan(basePackages = "com.example.notification.models")
+@EntityScan(basePackages = {"com.example.notification.models", "com.example.api.models"})
 //@EnableScheduling
 public class Main {
 


### PR DESCRIPTION
## Summary
- update the entity scanning configuration to include both the notification and API model packages so Hibernate can discover all entities

## Testing
- `./gradlew --console=plain --no-daemon bootRun` *(fails: unable to download com.github.typesense:typesense-java:0.2.0 from jitpack due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d23596925083328ae8680ea4af016f