### PR TITLE
Fix AssignmentHistory repository scan

### DIFF
--- a/api/src/main/java/com/example/api/Main.java
+++ b/api/src/main/java/com/example/api/Main.java
@@ -9,7 +9,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = "com.example")
 @ConfigurationPropertiesScan(basePackages = "com.example")
-@EnableJpaRepositories(basePackages = "com.example.notification.repository")
+@EnableJpaRepositories(basePackages = {"com.example.notification.repository", "com.example.api.repository"})
 @EntityScan(basePackages = {"com.example.notification.models", "com.example.api.models"})
 //@EnableScheduling
 public class Main {


### PR DESCRIPTION
## Summary
- include the API repository package in the JPA repository scan configuration so AssignmentHistoryRepository is discovered

## Testing
- `./gradlew test` *(fails: environment is missing Java 17 toolchain configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d23754859883328e411a2c2adb9708