### PR TITLE
Fix notification recipient queries to use string user ID

### DIFF
--- a/api/src/main/java/com/example/notification/repository/NotificationRecipientRepository.java
+++ b/api/src/main/java/com/example/notification/repository/NotificationRecipientRepository.java
@@ -14,17 +14,17 @@ public interface NotificationRecipientRepository extends JpaRepository<Notificat
             SELECT nr FROM NotificationRecipient nr
             JOIN FETCH nr.notification n
             JOIN FETCH n.type t
-            WHERE nr.recipient.id = :userId
+            WHERE nr.recipient.userId = :userId
                 AND (:unreadOnly = false OR nr.isRead = false)
                 AND nr.softDeleted = false
                 AND (:typeCodes IS NULL OR t.code IN :typeCodes)
             ORDER BY n.createdAt DESC
            """)
-    Page<NotificationRecipient> findInbox(@Param("userId") Long userId,
+    Page<NotificationRecipient> findInbox(@Param("userId") String userId,
                                           @Param("unreadOnly") boolean unreadOnly,
                                           @Param("typeCodes") List<String> typeCodes,
                                           Pageable pageable);
 
-    long countByRecipient_IdAndIsReadFalseAndSoftDeletedFalse(Long userId);
+    long countByRecipient_UserIdAndIsReadFalseAndSoftDeletedFalse(String userId);
 
 }


### PR DESCRIPTION
## Summary
- ensure notification recipient repository queries reference the correct userId property on User entities
- adjust repository method signatures to accept string user IDs consistent with the User model

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_e_68d238aab83c8332899b096c7662256d