### PR TITLE
Fix notification recipient schema mismatch and improve raise ticket UX

### DIFF
--- a/api/src/main/java/com/example/notification/models/NotificationRecipient.java
+++ b/api/src/main/java/com/example/notification/models/NotificationRecipient.java
@@ -5,7 +5,6 @@ import com.example.notification.models.Notification;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 
@@ -53,11 +52,6 @@ public class NotificationRecipient {
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
-
-    // Updated on every UPDATE
-    @UpdateTimestamp
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
 
     // Convenience helper for marking read/unread
     public void setRead(boolean read) {

--- a/ui/src/components/RaiseTicket/RequestorDetails.tsx
+++ b/ui/src/components/RaiseTicket/RequestorDetails.tsx
@@ -54,6 +54,7 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
     const emailId = useWatch({ control, name: 'emailId' });
     const requestorName = useWatch({ control, name: 'requestorName' });
     const stakeholder = useWatch({ control, name: 'stakeholder' });
+    const role = useWatch({ control, name: 'role' });
     const debouncedUserId = useDebounce(userId, 500);
 
     const allUsers = usersData || [];
@@ -88,14 +89,26 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
             setValue("requestorName", data.username);
             setValue("emailId", data.emailId);
             setValue("mobileNo", data.mobileNo);
-            if (fciUser) {
-                setValue("role", data.role);
-                setValue("office", data.office);
-            } else {
-                setValue("stakeholder", data.stakeholder)
+
+            const resolvedRole = Array.isArray(data?.role)
+                ? data.role.filter(Boolean).join(', ')
+                : Array.isArray(data?.roles)
+                    ? data.roles.filter(Boolean).join(', ')
+                    : data?.role ?? data?.roles ?? '';
+
+            setValue("role", resolvedRole);
+            setValue("office", data?.office ?? data?.officeName ?? '');
+
+            if (!fciUser) {
+                setValue("stakeholder", data.stakeholder);
             }
         }
     };
+
+    useEffect(() => {
+        register('role');
+        register('office');
+    }, [register]);
 
     useEffect(() => {
         getAllUsersApiHandler(() => getAllUsers());
@@ -328,10 +341,10 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
                                 </div>
                             ) : null}
                         </div>
-                        <div>
-                            {showRole && control._formValues?.role && renderReadOnlyField("Role", control._formValues?.role || "")}
+                        <div className="w-100">
+                            {showRole && role && renderReadOnlyField("Role", role)}
                             {showOffice && office && renderReadOnlyField("Office", office)}
-                            {showOffice && control._formValues?.office && renderReadOnlyField("Office", control._formValues?.office || "")}
+                            {selectedUser?.stakeholder && renderReadOnlyField("Stakeholder", selectedUser.stakeholder)}
                         </div>
                     </CustomFieldset>
                 </div>

--- a/ui/src/components/UI/Dropdown/GenericDropdown.tsx
+++ b/ui/src/components/UI/Dropdown/GenericDropdown.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import FormControl from '@mui/material/FormControl';
+import FormHelperText from '@mui/material/FormHelperText';
 import InputLabel from '@mui/material/InputLabel';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
@@ -16,6 +17,7 @@ export interface GenericDropdownProps {
     label?: string;
     value?: string;
     onChange: (event: SelectChangeEvent) => void;
+    onBlur?: () => void;
     options?: DropdownOption[];
     fullWidth?: boolean;
     disabled?: boolean;
@@ -25,12 +27,16 @@ export interface GenericDropdownProps {
     className?: string;
     menuItemsList?: any;
     style?: React.CSSProperties;
+    error?: boolean;
+    helperText?: string;
+    [key: string]: any;
 }
 
 const GenericDropdown: React.FC<GenericDropdownProps> = ({
     label,
     value,
     onChange,
+    onBlur,
     options,
     fullWidth = false,
     disabled = false,
@@ -40,14 +46,27 @@ const GenericDropdown: React.FC<GenericDropdownProps> = ({
     menuItemsList,
     className,
     style,
+    error = false,
+    helperText,
+    ...rest
 }) => {
     const theme = useTheme();
     const { t } = useTranslation();
     const classes = `generic-dropdown ${className ?? ''}`.trim();
     // let size: "small" | "medium" = !FciTheme ? "small" : "medium";
     let size: "small" | "medium" = "small";
+    const helperTextId = helperText ? `${id ?? name ?? 'generic-dropdown'}-helper-text` : undefined;
+    const { ref, ...restProps } = rest;
     return (
-        <FormControl fullWidth={fullWidth} disabled={disabled} required={required} style={style} className={classes} size={size}>
+        <FormControl
+            fullWidth={fullWidth}
+            disabled={disabled}
+            required={required}
+            style={style}
+            className={classes}
+            size={size}
+            error={error}
+        >
             {label && <InputLabel id={id ? `${id}-label` : undefined}>{t(label)}</InputLabel>}
             <Select
                 sx={{
@@ -66,6 +85,10 @@ const GenericDropdown: React.FC<GenericDropdownProps> = ({
                 label={label ? t(label) : undefined}
                 size={size}
                 onChange={onChange}
+                onBlur={onBlur}
+                aria-describedby={helperTextId}
+                inputRef={ref}
+                {...restProps}
             >
                 {menuItemsList
                     ? menuItemsList
@@ -73,6 +96,7 @@ const GenericDropdown: React.FC<GenericDropdownProps> = ({
                         ? options?.map((option) => <MenuItem key={option.value} value={option.value}>{t(option.label)}</MenuItem>)
                         : <MenuItem disabled>{t('No options available')}</MenuItem>}
             </Select>
+            {helperText && <FormHelperText id={helperTextId}>{helperText}</FormHelperText>}
         </FormControl>
     );
 };

--- a/ui/src/components/UI/Dropdown/GenericDropdownController.tsx
+++ b/ui/src/components/UI/Dropdown/GenericDropdownController.tsx
@@ -1,4 +1,5 @@
 import { Control, Controller, FieldValues, RegisterOptions } from "react-hook-form"
+import { SelectChangeEvent } from "@mui/material/Select"
 import GenericDropdown, { GenericDropdownProps } from "./GenericDropdown"
 
 interface GenericDropdownControllerProps<T extends FieldValues = any> extends Omit<GenericDropdownProps, "onChange"> {
@@ -12,6 +13,7 @@ const GenericDropdownController: React.FC<GenericDropdownControllerProps> = ({
     name,
     control,
     rules,
+    onChange: externalOnChange,
     ...dropdownProps
 }) => {
     return (
@@ -19,12 +21,22 @@ const GenericDropdownController: React.FC<GenericDropdownControllerProps> = ({
             name={name}
             control={control}
             rules={rules}
-            render={({ field }) => (
-                <GenericDropdown
-                    {...field}
-                    {...dropdownProps}
-                />
-            )}
+            render={({ field, fieldState }) => {
+                const handleChange = (event: SelectChangeEvent) => {
+                    field.onChange(event);
+                    externalOnChange?.(event);
+                };
+
+                return (
+                    <GenericDropdown
+                        {...dropdownProps}
+                        {...field}
+                        onChange={handleChange}
+                        error={!!fieldState.error}
+                        helperText={fieldState.error?.message}
+                    />
+                );
+            }}
         />
     )
 }


### PR DESCRIPTION
## Summary
- remove the `updated_at` column mapping from `NotificationRecipient` so the entity matches the existing table
- surface validation errors on the Category, Sub-category, and Priority dropdowns by passing react-hook-form state through the generic dropdown
- populate and display the requestor card with role, office, and stakeholder details when available

## Testing
- npm run build
- ./gradlew test *(fails: JDK 17 toolchain is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2448142b48332bb860d0379dc7543