### PR TITLE
Fix notifications loading without recipient IDs

### DIFF
--- a/ui/src/hooks/useNotifications.ts
+++ b/ui/src/hooks/useNotifications.ts
@@ -191,10 +191,9 @@ export const useNotifications = () => {
 
   useEffect(() => {
     nextPageRef.current = 0;
+
     if (!recipientIds.length) {
-      setNotifications([]);
       setHasMore(false);
-      return;
     }
 
     void loadPage(0, false);


### PR DESCRIPTION
## Summary
- allow initial notifications fetch to run even when no recipient identifiers are available so UI still loads server notifications
- keep pagination state in sync by only disabling "has more" when user identifiers are missing

## Testing
- npm test -- --watchAll=false *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68d25b32265483329ff315d92ab9d02d