### PR TITLE
Add SSE notification stream and client updates

### DIFF
--- a/api/src/main/java/com/example/notification/config/NotificationAsyncConfig.java
+++ b/api/src/main/java/com/example/notification/config/NotificationAsyncConfig.java
@@ -1,0 +1,22 @@
+package com.example.notification.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class NotificationAsyncConfig {
+
+    @Bean(name = "notificationTaskExecutor")
+    public TaskExecutor notificationTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setThreadNamePrefix("notification-stream-");
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(256);
+        executor.initialize();
+        return executor;
+    }
+}
+

--- a/api/src/main/java/com/example/notification/config/NotificationProperties.java
+++ b/api/src/main/java/com/example/notification/config/NotificationProperties.java
@@ -12,10 +12,17 @@ public class NotificationProperties {
     private String supportEmail;
     private String senderEmail;
     private Templates templates;
+    private final Sse sse = new Sse();
 
     @Data
     public static class Templates {
         private String email;
         private String sms;
+    }
+
+    @Data
+    public static class Sse {
+        private long defaultTimeoutMillis = 600000L;
+        private int maxEmittersPerRecipient = 5;
     }
 }

--- a/api/src/main/java/com/example/notification/service/InAppNotificationPublisher.java
+++ b/api/src/main/java/com/example/notification/service/InAppNotificationPublisher.java
@@ -1,0 +1,6 @@
+package com.example.notification.service;
+
+public interface InAppNotificationPublisher {
+    void publish(String recipient, InAppNotificationPayload payload);
+}
+

--- a/api/src/main/java/com/example/notification/service/NotificationStreamService.java
+++ b/api/src/main/java/com/example/notification/service/NotificationStreamService.java
@@ -1,0 +1,21 @@
+package com.example.notification.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Collection;
+
+@Service
+public class NotificationStreamService {
+
+    private final SseEmitterRegistry emitterRegistry;
+
+    public NotificationStreamService(SseEmitterRegistry emitterRegistry) {
+        this.emitterRegistry = emitterRegistry;
+    }
+
+    public SseEmitter createStream(Collection<String> recipientIds) {
+        return emitterRegistry.registerEmitter(recipientIds);
+    }
+}
+

--- a/api/src/main/java/com/example/notification/service/SseEmitterRegistry.java
+++ b/api/src/main/java/com/example/notification/service/SseEmitterRegistry.java
@@ -1,0 +1,146 @@
+package com.example.notification.service;
+
+import com.example.notification.config.NotificationProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
+@Component
+public class SseEmitterRegistry {
+
+    private static final Logger log = LoggerFactory.getLogger(SseEmitterRegistry.class);
+
+    private final Map<String, CopyOnWriteArrayList<SseEmitter>> emittersByRecipient = new ConcurrentHashMap<>();
+    private final Map<SseEmitter, Set<String>> recipientsByEmitter = new ConcurrentHashMap<>();
+    private final NotificationProperties properties;
+    private final TaskExecutor taskExecutor;
+
+    public SseEmitterRegistry(NotificationProperties properties,
+                              TaskExecutor notificationTaskExecutor) {
+        this.properties = properties;
+        this.taskExecutor = notificationTaskExecutor;
+    }
+
+    public SseEmitter registerEmitter(Collection<String> recipientIds) {
+        Set<String> sanitizedRecipients = sanitizeRecipients(recipientIds);
+        if (sanitizedRecipients.isEmpty()) {
+            throw new IllegalArgumentException("At least one recipient id is required for SSE subscription");
+        }
+
+        long timeout = properties.getSse().getDefaultTimeoutMillis();
+        SseEmitter emitter = new SseEmitter(timeout);
+        recipientsByEmitter.put(emitter, sanitizedRecipients);
+
+        sanitizedRecipients.forEach(recipient -> {
+            CopyOnWriteArrayList<SseEmitter> emitters = emittersByRecipient
+                    .computeIfAbsent(recipient, key -> new CopyOnWriteArrayList<>());
+            emitters.add(emitter);
+            enforceMaxEmitters(recipient, emitters);
+        });
+
+        emitter.onCompletion(() -> unregisterEmitter(emitter));
+        emitter.onTimeout(() -> unregisterEmitter(emitter));
+        emitter.onError(ex -> unregisterEmitter(emitter));
+
+        sendInitialHeartbeat(emitter);
+
+        return emitter;
+    }
+
+    public void sendToRecipient(String recipient, Object payload) {
+        CopyOnWriteArrayList<SseEmitter> emitters = emittersByRecipient.getOrDefault(recipient, new CopyOnWriteArrayList<>());
+        if (emitters.isEmpty()) {
+            return;
+        }
+
+        emitters.forEach(emitter -> taskExecutor.execute(() -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("notification")
+                        .data(payload)
+                        .id(String.valueOf(Instant.now().toEpochMilli())));
+            } catch (IOException ex) {
+                log.debug("Failed to send SSE notification to recipient {}", recipient, ex);
+                unregisterEmitter(emitter);
+            }
+        }));
+    }
+
+    private void unregisterEmitter(@Nullable SseEmitter emitter) {
+        if (emitter == null) {
+            return;
+        }
+
+        Set<String> recipients = recipientsByEmitter.remove(emitter);
+        if (recipients == null) {
+            return;
+        }
+
+        recipients.forEach(recipient -> {
+            CopyOnWriteArrayList<SseEmitter> emitters = emittersByRecipient.get(recipient);
+            if (emitters != null) {
+                emitters.remove(emitter);
+                if (emitters.isEmpty()) {
+                    emittersByRecipient.remove(recipient);
+                }
+            }
+        });
+    }
+
+    private void enforceMaxEmitters(String recipient, CopyOnWriteArrayList<SseEmitter> emitters) {
+        int maxEmitters = Math.max(1, properties.getSse().getMaxEmittersPerRecipient());
+        while (emitters.size() > maxEmitters) {
+            SseEmitter removed = emitters.remove(0);
+            unregisterEmitter(removed);
+            if (removed != null) {
+                try {
+                    removed.complete();
+                } catch (IllegalStateException ignored) {
+                    // Already completed
+                }
+            }
+            log.debug("Evicted excess SSE emitter for recipient {}", recipient);
+        }
+    }
+
+    private void sendInitialHeartbeat(SseEmitter emitter) {
+        taskExecutor.execute(() -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name("heartbeat")
+                        .data(Collections.singletonMap("status", "connected")));
+            } catch (IOException ex) {
+                log.debug("Failed to send initial heartbeat", ex);
+                unregisterEmitter(emitter);
+            }
+        });
+    }
+
+    @NonNull
+    private Set<String> sanitizeRecipients(@Nullable Collection<String> recipientIds) {
+        if (recipientIds == null) {
+            return Collections.emptySet();
+        }
+        return recipientIds.stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(value -> !value.isBlank())
+                .collect(Collectors.toCollection(ConcurrentHashMap::newKeySet));
+    }
+}
+

--- a/api/src/main/java/com/example/notification/service/SseInAppNotificationPublisher.java
+++ b/api/src/main/java/com/example/notification/service/SseInAppNotificationPublisher.java
@@ -1,0 +1,19 @@
+package com.example.notification.service;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class SseInAppNotificationPublisher implements InAppNotificationPublisher {
+
+    private final SseEmitterRegistry emitterRegistry;
+
+    public SseInAppNotificationPublisher(SseEmitterRegistry emitterRegistry) {
+        this.emitterRegistry = emitterRegistry;
+    }
+
+    @Override
+    public void publish(String recipient, InAppNotificationPayload payload) {
+        emitterRegistry.sendToRecipient(recipient, payload);
+    }
+}
+

--- a/api/src/main/java/com/example/notification/service/WebSocketInAppNotificationPublisher.java
+++ b/api/src/main/java/com/example/notification/service/WebSocketInAppNotificationPublisher.java
@@ -1,0 +1,20 @@
+package com.example.notification.service;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WebSocketInAppNotificationPublisher implements InAppNotificationPublisher {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public WebSocketInAppNotificationPublisher(SimpMessagingTemplate messagingTemplate) {
+        this.messagingTemplate = messagingTemplate;
+    }
+
+    @Override
+    public void publish(String recipient, InAppNotificationPayload payload) {
+        messagingTemplate.convertAndSend("/topic/notifications/" + recipient, payload);
+    }
+}
+

--- a/ui/src/components/Notifications/NotificationBell.tsx
+++ b/ui/src/components/Notifications/NotificationBell.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import NotificationsNoneOutlinedIcon from '@mui/icons-material/NotificationsNoneOutlined';
 import {
+  Alert,
   Badge,
   Box,
   Button,
@@ -10,6 +11,7 @@ import {
   ListItem,
   ListItemText,
   Menu,
+  Snackbar,
   Typography,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
@@ -74,8 +76,19 @@ interface NotificationBellProps {
 
 const NotificationBell: React.FC<NotificationBellProps> = ({ iconColor }) => {
   const theme = useTheme();
-  const { notifications, unreadCount, markAllAsRead, hasMore, loadMore, loading } = useNotifications();
+  const {
+    notifications,
+    unreadCount,
+    markAllAsRead,
+    hasMore,
+    loadMore,
+    loading,
+    latestNotification,
+    acknowledgeLatestNotification,
+  } = useNotifications();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [snackbarNotification, setSnackbarNotification] = useState<NotificationItem | null>(null);
 
   const menuOpen = Boolean(anchorEl);
 
@@ -100,6 +113,22 @@ const NotificationBell: React.FC<NotificationBellProps> = ({ iconColor }) => {
       void markAllAsRead();
     }
   }, [menuOpen, unreadCount, markAllAsRead]);
+
+  useEffect(() => {
+    if (latestNotification) {
+      setSnackbarNotification(latestNotification);
+      setSnackbarOpen(true);
+      acknowledgeLatestNotification();
+    }
+  }, [acknowledgeLatestNotification, latestNotification]);
+
+  const handleSnackbarClose = (_event?: Event | React.SyntheticEvent, reason?: string) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+    setSnackbarOpen(false);
+    setSnackbarNotification(null);
+  };
 
   const handleShowMore = () => {
     void loadMore();
@@ -179,6 +208,28 @@ const NotificationBell: React.FC<NotificationBellProps> = ({ iconColor }) => {
           </>
         )}
       </Menu>
+      <Snackbar
+        open={snackbarOpen && Boolean(snackbarNotification)}
+        autoHideDuration={6000}
+        onClose={handleSnackbarClose}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+      >
+        <Alert
+          onClose={handleSnackbarClose}
+          severity="info"
+          variant="filled"
+          sx={{ width: '100%' }}
+        >
+          <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+            {snackbarNotification?.title || 'Notification'}
+          </Typography>
+          {snackbarNotification?.message && (
+            <Typography variant="body2" sx={{ mt: 0.5 }}>
+              {snackbarNotification.message}
+            </Typography>
+          )}
+        </Alert>
+      </Snackbar>
     </>
   );
 };


### PR DESCRIPTION
## Summary
- add a dedicated SSE infrastructure with emitter registry, async executor, and stream controller while keeping the websocket notifier
- extend the notification service/controller to publish to both SSE and websocket clients
- update the React notifications hook and bell UI to subscribe via SSE and surface snackbar alerts for new messages

## Testing
- `./gradlew test --console=plain` *(fails: jitpack.io dependency returns 403 during resolution)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d2d48b55588332964a03887b5d59f4