### PR TITLE
Handle SSE responses in ApiResponse advice

### DIFF
--- a/api/src/main/java/com/example/api/config/ApiResponseBodyAdvice.java
+++ b/api/src/main/java/com/example/api/config/ApiResponseBodyAdvice.java
@@ -9,6 +9,7 @@ import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestControllerAdvice
 public class ApiResponseBodyAdvice implements ResponseBodyAdvice {
@@ -19,7 +20,15 @@ public class ApiResponseBodyAdvice implements ResponseBodyAdvice {
 
     @Override
     public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType, Class selectedConverterType, ServerHttpRequest request, ServerHttpResponse response) {
-        if (body instanceof ApiResponse) return body;
+        if (body instanceof ApiResponse) {
+            return body;
+        }
+        if (body instanceof SseEmitter) {
+            return body;
+        }
+        if (selectedContentType != null && MediaType.TEXT_EVENT_STREAM.isCompatibleWith(selectedContentType)) {
+            return body;
+        }
         if (body == null && response instanceof ServletServerHttpResponse) {
             ServletServerHttpResponse servletResponse = (ServletServerHttpResponse) response;
             if (servletResponse.getServletResponse().getStatus() == HttpStatus.CREATED.value()) {


### PR DESCRIPTION
## Summary
- prevent ApiResponseBodyAdvice from wrapping Server-Sent Event responses in ApiResponse envelopes
- return raw SseEmitter bodies whenever the response is for text/event-stream so SSE notifications keep streaming

## Testing
- ./gradlew test --console=plain *(fails: missing Java 17 toolchain in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d37796bf3883328d5bd448b8445b6f