### PR TITLE
Recalculate SLA during ticket updates

### DIFF
--- a/api/src/main/java/com/example/api/service/TicketService.java
+++ b/api/src/main/java/com/example/api/service/TicketService.java
@@ -15,6 +15,7 @@ import com.example.api.models.User;
 import com.example.api.repository.UserRepository;
 import com.example.api.repository.TicketCommentRepository;
 import com.example.api.repository.TicketRepository;
+import com.example.api.repository.StatusHistoryRepository;
 import com.example.api.repository.StatusMasterRepository;
 import com.example.api.repository.CategoryRepository;
 import com.example.api.repository.SubCategoryRepository;
@@ -56,6 +57,7 @@ public class TicketService {
     private final TicketCommentRepository commentRepository;
     private final AssignmentHistoryService assignmentHistoryService;
     private final StatusHistoryService statusHistoryService;
+    private final StatusHistoryRepository statusHistoryRepository;
     private final NotificationService notificationService;
     private final TicketStatusWorkflowService workflowService;
     private final StatusMasterRepository statusMasterRepository;
@@ -247,6 +249,11 @@ public class TicketService {
                     saved.getAssignedTo(),
                     saved.getAssignedBy() != null ? saved.getAssignedBy() : saved.getUpdatedBy()
             );
+        }
+
+        if (saved.getReportedDate() != null && saved.getSeverity() != null) {
+            List<StatusHistory> historyEntries = statusHistoryRepository.findByTicketOrderByTimestampAsc(saved);
+            ticketSlaService.calculateAndSave(saved, historyEntries);
         }
 
         return mapWithStatusId(saved);

--- a/api/src/main/java/com/example/api/service/TicketSlaService.java
+++ b/api/src/main/java/com/example/api/service/TicketSlaService.java
@@ -65,7 +65,8 @@ public class TicketSlaService {
         }
         long breachedBy = Duration.between(dueAt, endTime).toMinutes();
 
-        TicketSla ticketSla = new TicketSla();
+        TicketSla ticketSla = ticketSlaRepository.findByTicket_Id(ticket.getId())
+                .orElseGet(TicketSla::new);
         ticketSla.setTicket(ticket);
         ticketSla.setSlaConfig(config);
         ticketSla.setDueAt(dueAt);


### PR DESCRIPTION
## Summary
- ensure ticket updates recompute SLA metrics by loading full status history and invoking the SLA service
- allow TicketSlaService to update existing ticket SLA records instead of always creating new rows

## Testing
- `./gradlew test` *(fails: Java 17 toolchain unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d51ac784d48332b808fb18dd3af6d0