### PR TITLE
style: improve table and card presentation

### DIFF
--- a/ui/src/components/Layout/UserMenu.tsx
+++ b/ui/src/components/Layout/UserMenu.tsx
@@ -113,13 +113,37 @@ const UserMenu: React.FC<UserMenuProps> = ({ anchorEl, open, onClose }) => {
     label: string,
     value: React.ReactNode,
   ) => (
-    <Box>
-      <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 500, letterSpacing: 0.5 }}>
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 1.25,
+        flexWrap: "wrap",
+        width: "100%",
+      }}
+    >
+      <Typography
+        variant="caption"
+        color="text.secondary"
+        sx={{ fontWeight: 500, letterSpacing: 0.5, textTransform: "uppercase", flex: "0 0 auto" }}
+      >
         {label}
       </Typography>
-      <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+          flex: "1 1 auto",
+          minWidth: 0,
+          justifyContent: "flex-end",
+        }}
+      >
         {icon}
-        <Typography variant="body2">{value}</Typography>
+        <Typography variant="body2" sx={{ wordBreak: "break-word", textAlign: "right" }}>
+          {value}
+        </Typography>
       </Box>
     </Box>
   );

--- a/ui/src/components/RaiseTicket/RequestorDetails.tsx
+++ b/ui/src/components/RaiseTicket/RequestorDetails.tsx
@@ -280,7 +280,7 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
     }
 
     const renderReadOnlyField = (label: string, value: string) => (
-        <div className={`${formFieldValue}`}>
+        <div className={`${formFieldValue} justify-content-center text-center flex-column flex-md-row`}>
             <p className="mb-0 text-muted ts-13">{label}</p>
             <p className="mb-0 ts-13">{value}</p>
         </div>

--- a/ui/src/index.scss
+++ b/ui/src/index.scss
@@ -1,5 +1,6 @@
 :root {
   --primary-color: #1976d2;
+  --primary-color-rgb: 25, 118, 210;
   --secondary-color: #dc004e;
   --success-color: #388e3c;
   --danger-color: #d32f2f;
@@ -11,6 +12,29 @@
   background-color: var(--primary-color) !important;
   color: #fff !important;
   text-transform: none;
+}
+
+.ant-table-wrapper {
+  border-radius: 8px;
+}
+
+.ant-table-wrapper .ant-table-container {
+  border: 1px solid var(--primary-color);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.ant-table-wrapper .ant-table {
+  border-radius: 0;
+}
+
+.ant-table-wrapper .ant-table-thead > tr > th,
+.ant-table-wrapper .ant-table-tbody > tr > td {
+  border-color: rgba(var(--primary-color-rgb), 0.35);
+}
+
+.ant-table-wrapper .ant-table-thead > tr > th {
+  background-color: rgba(var(--primary-color-rgb), 0.08);
 }
 
 .generic-input .MuiInputBase-root {


### PR DESCRIPTION
## Summary
- add consistent bordered styling for all Ant Design tables using the primary theme color
- align user details in the menu so labels and values share a single row with wrapping support
- center the read-only fields within the raise ticket user card for better balance

## Testing
- npm test -- --watchAll=false *(fails: react-scripts jest cannot resolve react-router-dom@7 ESM module in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5226fd9988332ae170525adab5806