### PR TITLE
feat: add SLA progress bar component

### DIFF
--- a/ui/src/components/SlaProgressBar.tsx
+++ b/ui/src/components/SlaProgressBar.tsx
@@ -1,0 +1,85 @@
+import React, { useMemo } from 'react';
+import MultiValueProgressBar, {
+  LabelPosition,
+  MultiValueProgressSegment,
+} from './UI/MultiValueProgressBar';
+import { TicketSla } from '../types';
+
+interface SlaProgressBarProps {
+  sla?: TicketSla | null;
+  className?: string;
+}
+
+const START_LABEL_POSITION: LabelPosition = 'top';
+const END_LABEL_POSITION: LabelPosition = 'bottom';
+
+const formatMinutes = (value: number) => `${value} min${value === 1 ? '' : 's'}`;
+
+const SlaProgressBar: React.FC<SlaProgressBarProps> = ({ sla, className }) => {
+  const { segments, totalValue } = useMemo(() => {
+    if (!sla) {
+      return { segments: [] as MultiValueProgressSegment[], totalValue: 0 };
+    }
+
+    const resolution = Math.max(sla.resolutionTimeMinutes ?? 0, 0);
+    const response = Math.max(sla.responseTimeMinutes ?? 0, 0);
+    const elapsed = Math.max(sla.elapsedTimeMinutes ?? 0, 0);
+    const breached = Math.max(sla.breachedByMinutes ?? 0, 0);
+
+    const baseTotal = Math.max(resolution, response, elapsed);
+    const calculatedTotal = breached > 0 ? baseTotal + breached : baseTotal;
+
+    const progressSegments: MultiValueProgressSegment[] = [];
+
+    if (resolution > 0) {
+      progressSegments.push({
+        value: resolution,
+        color: '#4caf50',
+        endLabel: `Resolution Time (${formatMinutes(resolution)})`,
+        endLabelPosition: END_LABEL_POSITION,
+      });
+    }
+
+    if (response > 0) {
+      progressSegments.push({
+        value: response,
+        color: '#1e88e5',
+        endLabel: `Response Time (${formatMinutes(response)})`,
+        endLabelPosition: END_LABEL_POSITION,
+      });
+    }
+
+    if (elapsed > 0) {
+      progressSegments.push({
+        value: elapsed,
+        color: '#ff9800',
+        endLabel: `Elapsed Time (${formatMinutes(elapsed)})`,
+        endLabelPosition: END_LABEL_POSITION,
+      });
+    }
+
+    if (breached > 0) {
+      const breachTotal = calculatedTotal;
+      progressSegments.push({
+        value: breachTotal,
+        color: '#f44336',
+        startLabel: `Breached by ${formatMinutes(breached)}`,
+        startLabelPosition: START_LABEL_POSITION,
+        endLabel: 'Breached',
+        endLabelPosition: END_LABEL_POSITION,
+      });
+    }
+
+    return { segments: progressSegments, totalValue: calculatedTotal };
+  }, [sla]);
+
+  if (!segments.length || totalValue <= 0) {
+    return null;
+  }
+
+  return (
+    <MultiValueProgressBar segments={segments} totalValue={totalValue} className={className} />
+  );
+};
+
+export default SlaProgressBar;

--- a/ui/src/components/TicketView.tsx
+++ b/ui/src/components/TicketView.tsx
@@ -25,7 +25,7 @@ import GenericDropdown, { DropdownOption } from './UI/Dropdown/GenericDropdown';
 import GenericDropdownController from './UI/Dropdown/GenericDropdownController';
 import RemarkComponent from './UI/Remark/RemarkComponent';
 import { getDropdownOptions } from '../utils/Utils';
-import MultiValueProgressBar, { LabelPosition, MultiValueProgressSegment } from './UI/MultiValueProgressBar';
+import SlaProgressBar from './SlaProgressBar';
 
 interface TicketViewProps {
   ticketId: string;
@@ -329,15 +329,6 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
     </div>
   ), [severityList, t]);
 
-  const DUMMY_SLA_SEGMENTS: MultiValueProgressSegment[] = [
-    { value: 10, color: '#ff9800', endLabel: 'Elaspsed Time (min)', endLabelPosition: 'bottom' as LabelPosition },
-    { value: 30, color: '#0008ffff', endLabel: 'xyz Time (min)', endLabelPosition: 'bottom' as LabelPosition },
-    { value: 10, color: '#4caf50', endLabel: 'Resolution Time (min)', endLabelPosition: 'bottom' as LabelPosition },
-    // { value: sla?.resolutionTimeMinutes ?? 10, color: '#48ff00ff', endLabel: 'Resolution Time (mins)', endLabelPosition: 'bottom' as LabelPosition },
-    // { value: sla?.elapsedTimeMinutes ?? 10, color: '#00bbffff', endLabel: 'Elapsed Time (mins)', endLabelPosition: 'bottom' as LabelPosition },
-    { value: 10, color: '#f44336', endLabel: 'Breached Time (min)', endLabelPosition: 'bottom' as LabelPosition },
-  ];
-
   if (!ticket) return null;
 
   // DESIGN 1
@@ -491,8 +482,7 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
 
       {/* SLA PROGRESS BAR */}
       <Box>
-        {/* Total value is the difference of created and due datetime */}
-        <MultiValueProgressBar segments={DUMMY_SLA_SEGMENTS} totalValue={60} />
+        <SlaProgressBar sla={sla} />
       </Box>
 
       {/* SLA */}


### PR DESCRIPTION
## Summary
- add an SlaProgressBar component that renders the SLA metrics with the existing multi-value progress bar
- replace the placeholder SLA progress bar in the ticket view with the new API-driven component

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d6326e79008332bf5b220e423627c0