### PR TITLE
Fix global CORS configuration for API

### DIFF
--- a/api/src/main/java/com/example/api/config/CorsProperties.java
+++ b/api/src/main/java/com/example/api/config/CorsProperties.java
@@ -18,4 +18,5 @@ public class CorsProperties {
     private List<String> allowedHeaders = List.of("Authorization", "Content-Type", "Accept", "X-Requested-With", "Origin");
     private List<String> exposedHeaders = List.of("Authorization");
     private long maxAge = 3600;
+    private boolean allowCredentials = true;
 }

--- a/api/src/main/java/com/example/api/config/SecurityConfig.java
+++ b/api/src/main/java/com/example/api/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
 
 import java.util.List;
 
@@ -51,21 +52,32 @@ public class SecurityConfig {
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", buildCorsConfiguration());
+        return source;
+    }
+
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", buildCorsConfiguration());
+        return new CorsFilter(source);
+    }
+
+    private CorsConfiguration buildCorsConfiguration() {
         CorsConfiguration configuration = new CorsConfiguration();
         List<String> allowedOrigins = corsProperties.getAllowedOrigins();
         if (allowedOrigins == null || allowedOrigins.isEmpty()) {
             configuration.setAllowedOriginPatterns(List.of("*"));
         } else {
             configuration.setAllowedOrigins(allowedOrigins);
+            configuration.setAllowedOriginPatterns(allowedOrigins);
         }
         configuration.setAllowedMethods(corsProperties.getAllowedMethods());
         configuration.setAllowedHeaders(corsProperties.getAllowedHeaders());
         configuration.setExposedHeaders(corsProperties.getExposedHeaders());
-        configuration.setAllowCredentials(true);
+        configuration.setAllowCredentials(corsProperties.isAllowCredentials());
         configuration.setMaxAge(corsProperties.getMaxAge());
-
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-        return source;
+        return configuration;
     }
 }

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -23,6 +23,7 @@ security:
     exposed-headers:
       - Authorization
     max-age: 3600
+    allow-credentials: true
 
 ---
 spring:


### PR DESCRIPTION
## Summary
- add a configurable allow-credentials flag to the shared CORS properties and surface it in application.yml
- centralize CORS configuration logic and register a global CorsFilter so that headers are sent on every request

## Testing
- `./gradlew test` *(fails: missing Java 17 toolchain in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d663bb3eac83328c9ca65ba783a620