### PR TITLE
Open sidebar for recommend escalation and add table border

### DIFF
--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -48,9 +48,10 @@ interface TicketsTableProps {
     statusWorkflows: Record<string, TicketStatusWorkflow[]>;
     sortBy: string;
     onSortChange: (value: string) => void;
+    onRecommendEscalation?: (id: string) => void;
 }
 
-const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowClick, searchCurrentTicketsPaginatedApi, refreshingTicketId, statusWorkflows, sortBy, onSortChange }) => {
+const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowClick, searchCurrentTicketsPaginatedApi, refreshingTicketId, statusWorkflows, sortBy, onSortChange, onRecommendEscalation }) => {
     const { t } = useTranslation();
 
     const navigate = useNavigate();
@@ -126,6 +127,11 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
     };
 
     const handleActionClick = (wf: TicketStatusWorkflow, ticketId: string) => {
+        if (wf.action === 'Recommend Escalation') {
+            onRecommendEscalation?.(ticketId);
+            handleClose();
+            return;
+        }
         setSelectedAction({ action: wf, ticketId });
         setCurrentTicketId(ticketId);
         setExpandedRowKeys([ticketId]);
@@ -299,6 +305,7 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
                 />
             </div>
             <GenericTable
+                className="tickets-table"
                 dataSource={tickets}
                 columns={columns as any}
                 rowKey="id"

--- a/ui/src/components/AllTickets/ViewTicket.tsx
+++ b/ui/src/components/AllTickets/ViewTicket.tsx
@@ -22,9 +22,11 @@ interface ViewTicketProps {
   ticketId: string | null;
   open: boolean;
   onClose: () => void;
+  focusRecommendSeverity?: boolean;
+  onRecommendSeverityFocusHandled?: () => void;
 }
 
-const ViewTicket: React.FC<ViewTicketProps> = ({ ticketId, open, onClose }) => {
+const ViewTicket: React.FC<ViewTicketProps> = ({ ticketId, open, onClose, focusRecommendSeverity, onRecommendSeverityFocusHandled }) => {
   const { data: ticket, apiHandler: getTicketHandler } = useApi<any>();
   const { apiHandler: updateTicketHandler } = useApi<any>();
   const [editing, setEditing] = useState(false);
@@ -157,7 +159,14 @@ const ViewTicket: React.FC<ViewTicketProps> = ({ ticketId, open, onClose }) => {
       </Box>
       {ticket && (
         <Box sx={{ width: 400, position: 'relative', p: 2, display: 'flex', flexDirection: 'column', height: '100%' }}>
-          {ticketId && <TicketView ticketId={ticketId} showHistory />}
+          {ticketId && (
+            <TicketView
+              ticketId={ticketId}
+              showHistory
+              focusRecommendSeverity={focusRecommendSeverity}
+              onRecommendSeverityFocusHandled={onRecommendSeverityFocusHandled}
+            />
+          )}
           {/* <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
               <UserAvatar name={ticket.assignedTo || 'NA'} size={32} />

--- a/ui/src/components/TicketView.tsx
+++ b/ui/src/components/TicketView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState, use } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Box, Typography, TextField, MenuItem, Select, SelectChangeEvent, Button } from '@mui/material';
 import UserAvatar from './UI/UserAvatar/UserAvatar';
 import { useApi } from '../hooks/useApi';
@@ -31,9 +31,11 @@ interface TicketViewProps {
   ticketId: string;
   showHistory?: boolean;
   sidebar?: boolean;
+  focusRecommendSeverity?: boolean;
+  onRecommendSeverityFocusHandled?: () => void;
 }
 
-const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, sidebar = false }) => {
+const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, sidebar = false, focusRecommendSeverity, onRecommendSeverityFocusHandled }) => {
   const { t } = useTranslation();
 
   // USEAPI INITIALIZATIONS
@@ -62,6 +64,7 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
   const [statusWorkflows, setStatusWorkflows] = useState<any>({});
   const [severityToRecommendSeverity, setSeverityToRecommendSeverity] = useState<boolean>(false);
   const [showRecommendRemark, setShowRecommendRemark] = useState(false);
+  const recommendSeverityButtonRef = useRef<HTMLButtonElement | null>(null);
 
   const emptyFileList = useMemo<File[]>(() => [], []);
 
@@ -135,6 +138,13 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
       setStatusWorkflows(workflowData);
     }
   }, [workflowData]);
+
+  useEffect(() => {
+    if (focusRecommendSeverity && showSeverity && !showSeverityToRecommendSeverity && recommendSeverityButtonRef.current) {
+      recommendSeverityButtonRef.current.focus();
+      onRecommendSeverityFocusHandled?.();
+    }
+  }, [focusRecommendSeverity, showSeverity, showSeverityToRecommendSeverity, onRecommendSeverityFocusHandled]);
 
   const updateTicketDetails = async (remark?: string) => {
     if (!ticketId) return;
@@ -402,6 +412,7 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
                 variant="contained"
                 size="small"
                 onClick={() => setSeverityToRecommendSeverity(true)}
+                ref={recommendSeverityButtonRef}
               >
                 {t('Recommend Severity')}
               </GenericButton>

--- a/ui/src/components/UI/Button/index.tsx
+++ b/ui/src/components/UI/Button/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, forwardRef } from 'react';
 import Button, { ButtonProps } from '@mui/material/Button';
 import { useTranslation } from 'react-i18next';
 
@@ -7,19 +7,15 @@ interface GenericButtonProps extends ButtonProps {
     children?: ReactNode;
 }
 
-const GenericButton: React.FC<GenericButtonProps> = ({
-    textKey,
-    children,
-    className,
-    color = "success",
-    ...props
-}) => {
+const GenericButton = forwardRef<HTMLButtonElement, GenericButtonProps>(({ textKey, children, className, color = "success", ...props }, ref) => {
     const { t } = useTranslation();
     return (
-        <Button color={color} {...props}>
+        <Button ref={ref} color={color} className={className} {...props}>
             {textKey ? t(textKey) : children}
         </Button>
     );
-};
+});
+
+GenericButton.displayName = 'GenericButton';
 
 export default GenericButton;

--- a/ui/src/fci-index.scss
+++ b/ui/src/fci-index.scss
@@ -135,6 +135,17 @@ $font-size: 8;
   border: 1px solid #d9d9d9;
 }
 
+.tickets-table {
+  .ant-table {
+    border-radius: 8px;
+  }
+
+  .ant-table-container {
+    border: 1px solid #d0d5dd;
+    border-radius: 8px;
+  }
+}
+
 .table-dark-theme {
   .ant-table {
     background-color: #1e1e1e;

--- a/ui/src/pages/AllTickets.tsx
+++ b/ui/src/pages/AllTickets.tsx
@@ -84,10 +84,18 @@ const AllTickets: React.FC = () => {
         if (id) {
             setSelectedTicketId(id);
             setSidebarOpen(true);
+            setFocusRecommendSeverityTicketId(null);
         }
     }
 
+    const handleRecommendEscalation = (id: string) => {
+        setSelectedTicketId(id);
+        setSidebarOpen(true);
+        setFocusRecommendSeverityTicketId(id);
+    };
+
     const [refreshingTicketId, setRefreshingTicketId] = useState<string | null>(null);
+    const [focusRecommendSeverityTicketId, setFocusRecommendSeverityTicketId] = useState<string | null>(null);
 
     const searchCurrentTicketsPaginatedApi = useCallback(
         async (id: string) => {
@@ -191,6 +199,7 @@ const AllTickets: React.FC = () => {
                                 setSortBy(value as 'reportedDate' | 'lastModified');
                                 setPage(1);
                             }}
+                            onRecommendEscalation={handleRecommendEscalation}
                         />
                         <div className="d-flex justify-content-between align-items-center mt-3">
                             <PaginationControls page={page} totalPages={totalPages} onChange={(_, val) => setPage(val)} />
@@ -227,7 +236,7 @@ const AllTickets: React.FC = () => {
                                         priorityConfig={priorityConfig}
                                         statusWorkflows={workflowMap}
                                         searchCurrentTicketsPaginatedApi={searchCurrentTicketsPaginatedApi}
-                                        onClick={() => { setSelectedTicketId(t.id); setSidebarOpen(true); }}
+                                        onClick={() => { setSelectedTicketId(t.id); setSidebarOpen(true); setFocusRecommendSeverityTicketId(null); }}
                                     />
                                 </div>
                             ))}
@@ -257,7 +266,17 @@ const AllTickets: React.FC = () => {
                     </div>
                 )}
             </div>
-            <ViewTicket ticketId={selectedTicketId} open={sidebarOpen} onClose={() => { setSidebarOpen(false); setSelectedTicketId(null); }} />
+            <ViewTicket
+                ticketId={selectedTicketId}
+                open={sidebarOpen}
+                onClose={() => {
+                    setSidebarOpen(false);
+                    setSelectedTicketId(null);
+                    setFocusRecommendSeverityTicketId(null);
+                }}
+                focusRecommendSeverity={selectedTicketId !== null && selectedTicketId === focusRecommendSeverityTicketId}
+                onRecommendSeverityFocusHandled={() => setFocusRecommendSeverityTicketId(null)}
+            />
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- open the ticket sidebar when the Recommend Escalation action is clicked from the tickets table
- focus the Recommend Severity button inside the sidebar ticket view to guide escalation flow
- add a gray border style to the tickets table for clearer separation

## Testing
- `npm test -- --watchAll=false` *(fails: jest cannot resolve react-router-dom in the current setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d6724ec80483328a7353c87ec7f5b9