### PR TITLE
Show running error icon only on breached tickets

### DIFF
--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -37,6 +37,7 @@ export interface TicketRow {
     statusLabel?: string;
     assignedTo?: string;
     feedbackStatus?: 'PENDING' | 'PROVIDED' | 'NOT_PROVIDED';
+    breachedByMinutes?: number;
 }
 
 interface TicketsTableProps {
@@ -182,7 +183,9 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
                     <div className="d-flex align-items-center" onClick={() => onIdClick(record.id)} style={{ cursor: 'pointer' }}>
                         {truncateWithEllipsis(record.id, 12)}
                         {record.isMaster && <MasterIcon />}
-                        <CustomIconButton icon="runningWithErrors" color='error' />
+                        {(record.breachedByMinutes ?? 0) > 0 && (
+                            <CustomIconButton icon="runningWithErrors" color='error' />
+                        )}
                     </div>
                 ),
             },


### PR DESCRIPTION
## Summary
- add `breachedByMinutes` tracking to ticket table rows
- only render the running-with-errors icon when a ticket has a positive breach time

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6797b478883328814c3a3ca42d595