### PR TITLE
Stop embedding permissions in JWT tokens

### DIFF
--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -127,7 +127,7 @@ const Login: FC = () => {
             }
 
             const decoded = !jwtBypass ? getDecodedAuthDetails() : null;
-            const permissions: RolePermission | undefined = decoded?.permissions ?? loginData.permissions;
+            const permissions: RolePermission | undefined = loginData.permissions;
             if (permissions) {
                 setPermissions(permissions);
             }

--- a/ui/src/types/auth.ts
+++ b/ui/src/types/auth.ts
@@ -22,5 +22,4 @@ export interface UserDetails {
 
 export interface DecodedAuthDetails {
   user: UserDetails;
-  permissions?: RolePermission;
 }

--- a/ui/src/utils/Utils.ts
+++ b/ui/src/utils/Utils.ts
@@ -5,7 +5,6 @@ import { UserDetails } from "../types/auth";
 import {
   clearStoredToken,
   getDecodedAuthDetails,
-  getPermissionsFromToken,
   isJwtBypassEnabled,
 } from "./authToken";
 import { logoutUser } from "../services/AuthService";
@@ -43,13 +42,6 @@ export function setUserPermissions(perm: any) {
 }
 
 export function getUserPermissions(): any {
-  if (!isJwtBypassEnabled()) {
-    const permissions = getPermissionsFromToken();
-    if (permissions) {
-      return permissions;
-    }
-  }
-
   const data = sessionStorage.getItem(PERM_KEY);
   return data ? JSON.parse(data) : null;
 }

--- a/ui/src/utils/authToken.ts
+++ b/ui/src/utils/authToken.ts
@@ -1,5 +1,5 @@
 import { jwtDecode, JwtPayload } from "jwt-decode";
-import { DecodedAuthDetails, RolePermission, UserDetails } from "../types/auth";
+import { DecodedAuthDetails, UserDetails } from "../types/auth";
 
 const TOKEN_KEY = "authToken";
 const BYPASS_KEY = "jwtBypass";
@@ -10,7 +10,6 @@ interface ExtendedJwtPayload extends JwtPayload {
   name?: string;
   roles?: string[];
   levels?: string[];
-  permissions?: RolePermission;
   allowedStatusActionIds?: string[];
 }
 
@@ -70,16 +69,12 @@ export function getDecodedAuthDetails(): DecodedAuthDetails | null {
       allowedStatusActionIds: claims.allowedStatusActionIds ?? undefined,
     };
 
-    decodedCache = { user, permissions: claims.permissions };
+    decodedCache = { user };
     return decodedCache;
   } catch (error) {
     clearStoredToken();
     return null;
   }
-}
-
-export function getPermissionsFromToken(): RolePermission | undefined {
-  return getDecodedAuthDetails()?.permissions ?? undefined;
 }
 
 export function clearDecodedCache() {


### PR DESCRIPTION
## Summary
- stop serializing the permissions object into JWT claims to keep tokens small
- adjust the React auth helpers to no longer decode permissions from the token
- rely on the login response to persist permissions in session storage for UI access control

## Testing
- ./gradlew test *(fails: Java 17 toolchain not available in the environment)*
- npm run build *(fails: missing `react-i18next` dependency in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d68d6f3b508332a4d8f8e470982901