### PR TITLE
Improve SLA progress bar label formatting

### DIFF
--- a/ui/src/components/SlaDetails.tsx
+++ b/ui/src/components/SlaDetails.tsx
@@ -15,6 +15,10 @@ const SlaDetails: React.FC<Props> = ({ sla }) => {
           <td><Typography>{sla.dueAt ? new Date(sla.dueAt).toLocaleString() : '-'}</Typography></td>
         </tr>
         <tr>
+          <td><Typography color="text.secondary">Time Till Due Date (mins)</Typography></td>
+          <td><Typography>{typeof sla.timeTillDueDate === 'number' ? sla.timeTillDueDate : '-'}</Typography></td>
+        </tr>
+        <tr>
           <td><Typography color="text.secondary">Resolution Time (mins)</Typography></td>
           <td><Typography>{sla.resolutionTimeMinutes ?? '-'}</Typography></td>
         </tr>

--- a/ui/src/components/SlaProgressBar.tsx
+++ b/ui/src/components/SlaProgressBar.tsx
@@ -16,6 +16,53 @@ const BOTTOM_LABEL_POSITION: LabelPosition = 'bottom';
 
 const formatMinutes = (value: number) => `${value} min${value === 1 ? '' : 's'}`;
 
+const formatDuration = (value: number) => {
+  const totalMinutes = Math.max(Math.floor(value), 0);
+  const days = Math.floor(totalMinutes / (24 * 60));
+  const hours = Math.floor((totalMinutes % (24 * 60)) / 60);
+  const minutes = totalMinutes % 60;
+
+  const parts: string[] = [];
+  if (days > 0) {
+    parts.push(`${days} day${days > 1 ? 's' : ''}`);
+  }
+  if (hours > 0) {
+    parts.push(`${hours} hr${hours > 1 ? 's' : ''}`);
+  }
+  if (minutes > 0 || parts.length === 0) {
+    parts.push(`${minutes} min${minutes !== 1 ? 's' : ''}`);
+  }
+
+  return parts.join(' ');
+};
+
+const formatDateInWords = (value?: string) => {
+  if (!value) return '-';
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '-';
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  }).format(date);
+};
+
+const createLabelContent = (title: string, value: string, helper?: string) => (
+  <span className="multi-progress__label-text">
+    <span className="multi-progress__label-title">{title}</span>
+    <span className="multi-progress__label-value">{value}</span>
+    {helper ? <span className="multi-progress__label-helper">{helper}</span> : null}
+  </span>
+);
+
 const SlaProgressBar: React.FC<SlaProgressBarProps> = ({ sla, className }) => {
   const { segments, totalValue } = useMemo(() => {
     if (!sla) {
@@ -26,9 +73,18 @@ const SlaProgressBar: React.FC<SlaProgressBarProps> = ({ sla, className }) => {
     const response = Math.max(sla.responseTimeMinutes ?? 0, 0);
     const elapsed = Math.max(sla.elapsedTimeMinutes ?? 0, 0);
     const totalSlaTime = Math.max(sla.totalSlaMinutes ?? 0, 0);
-    const breached = Math.max(sla.breachedByMinutes ?? 0, 0);
+    const rawBreached = sla.breachedByMinutes ?? 0;
+    const breached = Math.max(rawBreached, 0);
     const dueDate = sla?.dueAt;
     const createdDate = sla?.createdAt;
+    const timeTillDueDate = Math.max(sla.timeTillDueDate ?? 0, rawBreached < 0 ? Math.abs(rawBreached) : 0);
+
+    const dueDateLabel = createLabelContent(
+      'Due Date',
+      formatDateInWords(dueDate),
+      timeTillDueDate > 0 ? `${formatDuration(timeTillDueDate)} remaining` : undefined,
+    );
+    const createdDateLabel = createLabelContent('Created Date', formatDateInWords(createdDate));
 
 
     const progressSegments: MultiValueProgressSegment[] = [];
@@ -36,13 +92,12 @@ const SlaProgressBar: React.FC<SlaProgressBarProps> = ({ sla, className }) => {
     const calculatedTotal = breached > 0 ? totalSlaTime + breached : totalSlaTime;
 
     if (breached <= 0) {
-      console.log({ breached, dueDate, calculatedTotal })
       progressSegments.push({
         value: calculatedTotal,
         color: 'rgb(255 255 255 / 0)',
-        endLabel: `Due Date ${dueDate}`,
+        endLabel: dueDateLabel,
         endLabelPosition: TOP_LABEL_POSITION,
-        startLabel: `Created At ${createdDate}`,
+        startLabel: createdDateLabel,
         startLabelPosition: TOP_LABEL_POSITION,
         marker: { right: true, left: true, color: '#000000', size: 3 } as MultiValueProgressMarker,
       });
@@ -58,9 +113,9 @@ const SlaProgressBar: React.FC<SlaProgressBarProps> = ({ sla, className }) => {
       progressSegments.push({
         value: totalSlaTime,
         color: '#fc429fe0',
-        endLabel: `Due Date ${dueDate}`,
+        endLabel: dueDateLabel,
         endLabelPosition: TOP_LABEL_POSITION,
-        startLabel: `Created At ${createdDate}`,
+        startLabel: createdDateLabel,
         startLabelPosition: TOP_LABEL_POSITION,
         marker: { right: true, left: true, color: '#000000', size: 3 } as MultiValueProgressMarker,
 
@@ -89,7 +144,7 @@ const SlaProgressBar: React.FC<SlaProgressBarProps> = ({ sla, className }) => {
       progressSegments.push({
         value: elapsed,
         color: '#ff9800',
-        endLabel: `Elapsed Time (${formatMinutes(elapsed)})`,
+        endLabel: createLabelContent('Elapsed Time', formatDuration(elapsed)),
         endLabelPosition: BOTTOM_LABEL_POSITION,
       });
     }

--- a/ui/src/components/TicketView.tsx
+++ b/ui/src/components/TicketView.tsx
@@ -35,6 +35,22 @@ interface TicketViewProps {
   onRecommendSeverityFocusHandled?: () => void;
 }
 
+const normaliseSla = (slaData: TicketSla | null): TicketSla | null => {
+  if (!slaData) {
+    return null;
+  }
+
+  const rawBreached = slaData.breachedByMinutes ?? 0;
+  const breachedByMinutes = rawBreached < 0 ? 0 : rawBreached;
+  const timeTillDueDate = rawBreached < 0 ? Math.abs(rawBreached) : slaData.timeTillDueDate ?? 0;
+
+  return {
+    ...slaData,
+    breachedByMinutes,
+    timeTillDueDate,
+  };
+};
+
 const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, sidebar = false, focusRecommendSeverity, onRecommendSeverityFocusHandled }) => {
   const { t } = useTranslation();
 
@@ -104,7 +120,9 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
       getTicketSla(ticketId)
         .then(res => {
           const body = res.data?.body ?? res.data;
-          setSla(res.status === 200 ? body?.data ?? null : null);
+          const slaData = res.status === 200 ? body?.data ?? null : null;
+          const normalised = normaliseSla(slaData && typeof slaData === 'object' ? slaData as TicketSla : null);
+          setSla(normalised);
         })
         .catch(() => setSla(null));
     }

--- a/ui/src/components/UI/MultiValueProgressBar/MultiValueProgressBar.scss
+++ b/ui/src/components/UI/MultiValueProgressBar/MultiValueProgressBar.scss
@@ -43,8 +43,8 @@
   &__label {
     position: absolute;
     font-size: 12px;
-    line-height: 1.2;
-    white-space: nowrap;
+    line-height: 1.3;
+    white-space: normal;
     padding: 2px 6px;
     border-radius: 4px;
     background-color: #ffffff;
@@ -52,6 +52,31 @@
     border: 1px solid #d1d5db;
     box-shadow: 0 1px 2px rgba(15, 23, 42, 0.12);
     pointer-events: none;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 2px;
+    max-width: 220px;
+  }
+
+  &__label-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  &__label-title {
+    font-weight: 600;
+  }
+
+  &__label-value {
+    font-weight: 500;
+  }
+
+  &__label-helper {
+    font-size: 11px;
+    color: #4b5563;
   }
 
   &__label--start {

--- a/ui/src/components/UI/MultiValueProgressBar/index.tsx
+++ b/ui/src/components/UI/MultiValueProgressBar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, ReactNode } from 'react';
 import './MultiValueProgressBar.scss';
 
 export type LabelPosition = 'top' | 'bottom' | 'hover';
@@ -23,9 +23,9 @@ export interface MultiValueProgressSegment {
   /** Background colour for the segment. */
   color: string;
   /** Optional label rendered where the segment begins. */
-  startLabel?: string;
+  startLabel?: ReactNode;
   /** Optional label rendered where the segment ends. */
-  endLabel?: string;
+  endLabel?: ReactNode;
   /** Controls the vertical position of the starting label. */
   startLabelPosition?: LabelPosition;
   /** Controls the vertical position of the ending label. */
@@ -96,11 +96,11 @@ const MultiValueProgressBar: React.FC<MultiValueProgressBarProps> = ({
   const containerClassName = ['multi-progress', className].filter(Boolean).join(' ');
 
   const renderLabel = (
-    label: string | undefined,
+    label: ReactNode | undefined,
     position: LabelPosition | undefined,
     type: 'start' | 'end',
   ) => {
-    if (!label) return null;
+    if (label === undefined || label === null) return null;
     const labelPosition = position ?? defaultLabelPosition;
     return (
       <span

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -98,6 +98,7 @@ export interface TicketSla {
     totalSlaMinutes?: number;
     dueDate?: string;
     createdAt?: string;
+    timeTillDueDate?: number;
 }
 
 export interface Faq {


### PR DESCRIPTION
## Summary
- render SLA progress markers with multi-line React nodes so created/due dates and elapsed time appear on their own lines with friendly wording
- normalise SLA data to convert negative breach values into a new `timeTillDueDate` field while clamping the breach minutes to zero
- surface the computed `timeTillDueDate` inside the SLA details table alongside existing metrics

## Testing
- ⚠️ `CI=true npm run build` *(hangs during CRA build, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b84b3694833295b4a13759e52a03