### PR TITLE
Fix feedback modal viewing state and cancellation behavior

### DIFF
--- a/ui/src/components/Feedback/StarRating.tsx
+++ b/ui/src/components/Feedback/StarRating.tsx
@@ -12,18 +12,25 @@ const labels: Record<number, string> = {
 interface StarRatingProps {
   label: string;
   value: number | null;
-  onChange: (value: number) => void;
+  onChange?: (value: number) => void;
+  readOnly?: boolean;
 }
 
-const StarRating: React.FC<StarRatingProps> = ({ label, value, onChange }) => {
+const StarRating: React.FC<StarRatingProps> = ({ label, value, onChange, readOnly = false }) => {
+  const handleChange = (_: React.SyntheticEvent<Element, Event>, newValue: number | null) => {
+    if (readOnly || !onChange) return;
+    onChange(newValue || 0);
+  };
+
   return (
     <Box sx={{ display: 'flex', alignItems: 'center', mt: 2 }}>
       <Typography sx={{ width: 220 }}>{label}</Typography>
       <Rating
         value={value}
-        onChange={(_, newValue) => onChange(newValue || 0)}
+        onChange={handleChange}
+        readOnly={readOnly}
       />
-      {value !== null && <Box sx={{ ml: 2 }}>{labels[value]}</Box>}
+      {value ? <Box sx={{ ml: 2 }}>{labels[value]}</Box> : null}
     </Box>
   );
 };


### PR DESCRIPTION
## Summary
- restore the modal-specific customer satisfaction form so viewing feedback populates the saved ratings in read-only mode
- let the shared star rating component support read-only display for previously submitted feedback
- refresh the standalone feedback form to always load ticket feedback, hide submit/cancel after submission, and navigate back on cancel/close

## Testing
- npm test -- --watchAll=false *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*
- npm run build *(fails: Can't resolve 'react-i18next')*

------
https://chatgpt.com/codex/tasks/task_e_68d974a5c2dc833293554962cc0d4320