### PR TITLE
Hide expandable column in tickets table

### DIFF
--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -299,7 +299,7 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
                 rowKey="id"
                 pagination={false}
                 rowClassName={(record: any) => record.id === refreshingTicketId ? 'refreshing-row' : ''}
-                expandable={{ expandedRowRender, expandedRowKeys, expandIcon: () => null }}
+                expandable={{ expandedRowRender, expandedRowKeys, expandIcon: () => null, showExpandColumn: false }}
             />
             <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
                 {actions.map(a => {


### PR DESCRIPTION
## Summary
- configure the tickets table to hide the default expandable column rendered by Ant Design

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9c6417efc8332ab5733430f0ee2e6