### PR TITLE
Update browser title based on page and notifications

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -16,6 +16,7 @@ import MyTickets from './pages/MyTickets';
 import Faq from './pages/Faq';
 import FaqForm from './pages/FaqForm';
 import { getUserDetails, getUserPermissions } from './utils/Utils';
+import { NotificationProvider } from './context/NotificationContext';
 
 const RequireAuth: React.FC<{ children: JSX.Element }> = ({ children }) => {
   const user = getUserDetails();
@@ -30,7 +31,16 @@ function App() {
   return (
     <Routes>
       <Route path="/login" element={<Login />} />
-      <Route path="/" element={<RequireAuth><SidebarLayout /></RequireAuth>}>
+      <Route
+        path="/"
+        element={(
+          <RequireAuth>
+            <NotificationProvider>
+              <SidebarLayout />
+            </NotificationProvider>
+          </RequireAuth>
+        )}
+      >
         <Route index element={<Navigate to="/my-tickets" replace />} />  // Default route
         <Route path="create-ticket" element={<RaiseTicket />} />
         <Route path="tickets" element={<AllTickets />} />

--- a/ui/src/components/Layout/SidebarLayout.tsx
+++ b/ui/src/components/Layout/SidebarLayout.tsx
@@ -5,6 +5,7 @@ import Header from "./Header";
 import Drawer from "@mui/material/Drawer";
 import { useTheme, useMediaQuery } from "@mui/material";
 import { useAuthGuard } from "../../hooks/useAuthGuard";
+import { usePageTitle } from "../../hooks/usePageTitle";
 
 const SidebarLayout: React.FC = () => {
   useAuthGuard();
@@ -12,6 +13,8 @@ const SidebarLayout: React.FC = () => {
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const [collapsedState, setCollapsedState] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
+
+  usePageTitle();
 
   const toggleSidebar = () => {
     if (isMobile) {

--- a/ui/src/components/Notifications/NotificationBell.tsx
+++ b/ui/src/components/Notifications/NotificationBell.tsx
@@ -17,8 +17,8 @@ import {
 import { useTheme } from '@mui/material/styles';
 import type { Theme } from '@mui/material/styles';
 
-import { useNotifications } from '../../hooks/useNotifications';
-import { NotificationItem } from '../../types/notification';
+import { useNotificationContext } from '../../context/NotificationContext';
+import type { NotificationItem } from '../../types/notification';
 
 const formatTimestamp = (value: string) => {
   const date = new Date(value);
@@ -85,7 +85,7 @@ const NotificationBell: React.FC<NotificationBellProps> = ({ iconColor }) => {
     loading,
     latestNotification,
     acknowledgeLatestNotification,
-  } = useNotifications();
+  } = useNotificationContext();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [snackbarNotification, setSnackbarNotification] = useState<NotificationItem | null>(null);

--- a/ui/src/context/NotificationContext.tsx
+++ b/ui/src/context/NotificationContext.tsx
@@ -1,0 +1,25 @@
+import React, { createContext, ReactNode, useContext } from 'react';
+
+import { useNotifications } from '../hooks/useNotifications';
+
+type NotificationContextValue = ReturnType<typeof useNotifications>;
+
+const NotificationContext = createContext<NotificationContextValue | undefined>(undefined);
+
+interface NotificationProviderProps {
+  children: ReactNode;
+}
+
+export const NotificationProvider: React.FC<NotificationProviderProps> = ({ children }) => {
+  const value = useNotifications();
+
+  return <NotificationContext.Provider value={value}>{children}</NotificationContext.Provider>;
+};
+
+export const useNotificationContext = (): NotificationContextValue => {
+  const context = useContext(NotificationContext);
+  if (!context) {
+    throw new Error('useNotificationContext must be used within a NotificationProvider');
+  }
+  return context;
+};

--- a/ui/src/hooks/usePageTitle.ts
+++ b/ui/src/hooks/usePageTitle.ts
@@ -1,0 +1,58 @@
+import { useEffect, useMemo } from 'react';
+import { matchPath, useLocation } from 'react-router-dom';
+
+import { useNotificationContext } from '../context/NotificationContext';
+
+interface RouteTitle {
+  path: string;
+  title: string;
+  end?: boolean;
+}
+
+const DEFAULT_TITLE = 'Ticketing System';
+
+const ROUTE_TITLES: RouteTitle[] = [
+  { path: '/tickets/:ticketId/feedback', title: 'Ticket Feedback' },
+  { path: '/tickets/:ticketId', title: 'Ticket Details' },
+  { path: '/create-ticket', title: 'Raise Ticket' },
+  { path: '/tickets', title: 'All Tickets' },
+  { path: '/my-tickets', title: 'My Tickets' },
+  { path: '/faq/new', title: 'New FAQ' },
+  { path: '/faq', title: 'FAQ' },
+  { path: '/knowledge-base', title: 'Knowledge Base' },
+  { path: '/categories-master', title: 'Categories Master' },
+  { path: '/escalation-master', title: 'Escalation Master' },
+  { path: '/role-master/:roleId', title: 'Role Details' },
+  { path: '/role-master', title: 'Role Master' },
+];
+
+const deriveTitle = (pathname: string): string => {
+  for (const route of ROUTE_TITLES) {
+    const match = matchPath({ path: route.path, end: route.end ?? true }, pathname);
+    if (match) {
+      return route.title;
+    }
+  }
+
+  // Attempt a loose match for paths that may extend beyond the configured routes.
+  for (const route of ROUTE_TITLES) {
+    const match = matchPath({ path: route.path, end: false }, pathname);
+    if (match) {
+      return route.title;
+    }
+  }
+
+  return DEFAULT_TITLE;
+};
+
+export const usePageTitle = () => {
+  const location = useLocation();
+  const { unreadCount } = useNotificationContext();
+
+  const baseTitle = useMemo(() => deriveTitle(location.pathname), [location.pathname]);
+
+  useEffect(() => {
+    const title = unreadCount > 0 ? `(${unreadCount}) ${baseTitle}` : baseTitle;
+    document.title = title;
+  }, [baseTitle, unreadCount]);
+};

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -117,6 +117,10 @@ const Login: FC = () => {
     const { data: loginData, error: loginError, apiHandler: loginApiHandler } = useApi<LoginResponse>();
 
     useEffect(() => {
+        document.title = "Login";
+    }, []);
+
+    useEffect(() => {
         const persistLoginData = async () => {
             if (!loginData) {
                 return;


### PR DESCRIPTION
## Summary
- add a notification context provider so header consumers share a single notification stream
- update the sidebar layout to sync the document title with the active route and unread notification count
- set the login page title explicitly for unauthenticated sessions

## Testing
- `npm run build` *(fails: Module not found: Error: Can't resolve 'i18next')*

------
https://chatgpt.com/codex/tasks/task_e_68da023f00ac833296b97e2eebd258ff