### PR TITLE
Add stacked SLA timeline chart using Apache ECharts

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -27,6 +27,8 @@
         "axios": "^0.27.2",
         "bcryptjs": "^2.4.3",
         "bootstrap": "^5.3.6",
+        "echarts": "^5.5.1",
+        "echarts-for-react": "^3.0.2",
         "i18next": "^25.5.2",
         "jwt-decode": "^4.0.0",
         "react": "^19.1.0",
@@ -8188,6 +8190,36 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
+    },
+    "node_modules/echarts": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
+      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "5.6.1"
+      }
+    },
+    "node_modules/echarts-for-react": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/echarts-for-react/-/echarts-for-react-3.0.2.tgz",
+      "integrity": "sha512-DRwIiTzx8JfwPOVgGttDytBqdp5VzCSyMRIxubgU/g2n9y3VLUmF2FK7Icmg/sNVkv4+rktmrLN9w22U2yy3fA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "size-sensor": "^1.0.1"
+      },
+      "peerDependencies": {
+        "echarts": "^3.0.0 || ^4.0.0 || ^5.0.0",
+        "react": "^15.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -17364,6 +17396,12 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/size-sensor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.2.tgz",
+      "integrity": "sha512-2NCmWxY7A9pYKGXNBfteo4hy14gWu47rg5692peVMst6lQLPKrVjhY+UTEsPI5ceFRJSl3gVgMYaUi/hKuaiKw==",
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -19978,6 +20016,21 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zrender": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
+      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     }
   }
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -22,6 +22,8 @@
     "axios": "^0.27.2",
     "bcryptjs": "^2.4.3",
     "bootstrap": "^5.3.6",
+    "echarts": "^5.5.1",
+    "echarts-for-react": "^3.0.2",
     "i18next": "^25.5.2",
     "jwt-decode": "^4.0.0",
     "react": "^19.1.0",

--- a/ui/src/components/SlaProgressChart.tsx
+++ b/ui/src/components/SlaProgressChart.tsx
@@ -1,0 +1,154 @@
+import React, { useMemo } from 'react';
+import ReactECharts from 'echarts-for-react';
+import { TicketSla } from '../types';
+
+interface SlaProgressChartProps {
+  sla?: TicketSla | null;
+  className?: string;
+}
+
+const formatDuration = (value: number) => {
+  const totalMinutes = Math.max(Math.floor(value), 0);
+  const days = Math.floor(totalMinutes / (24 * 60));
+  const hours = Math.floor((totalMinutes % (24 * 60)) / 60);
+  const minutes = totalMinutes % 60;
+
+  const parts: string[] = [];
+
+  if (days > 0) {
+    parts.push(`${days} day${days > 1 ? 's' : ''}`);
+  }
+
+  if (hours > 0) {
+    parts.push(`${hours} hr${hours > 1 ? 's' : ''}`);
+  }
+
+  if (minutes > 0 || parts.length === 0) {
+    parts.push(`${minutes} min${minutes !== 1 ? 's' : ''}`);
+  }
+
+  return parts.join(' ');
+};
+
+const SlaProgressChart: React.FC<SlaProgressChartProps> = ({ sla, className }) => {
+  const option = useMemo(() => {
+    if (!sla) {
+      return null;
+    }
+
+    const response = Math.max(sla.responseTimeMinutes ?? 0, 0);
+    const idle = Math.max(sla.idleTimeMinutes ?? 0, 0);
+    const resolution = Math.max(sla.resolutionTimeMinutes ?? 0, 0);
+    const elapsed = Math.max(sla.elapsedTimeMinutes ?? 0, 0);
+    const totalSlaTime = Math.max(sla.totalSlaMinutes ?? 0, elapsed);
+    const rawBreached = sla.breachedByMinutes ?? 0;
+    const breached = Math.max(rawBreached, 0);
+
+    const knownElapsed = response + idle + resolution;
+    const otherElapsed = Math.max(elapsed - knownElapsed, 0);
+
+    const remaining = rawBreached > 0 ? 0 : Math.max(totalSlaTime - elapsed, 0);
+
+    const segments = [
+      {
+        name: 'Response Time',
+        value: response,
+        color: '#1e88e5',
+      },
+      {
+        name: 'Idle Time',
+        value: idle,
+        color: '#9e9e9e',
+      },
+      {
+        name: 'Resolution Time',
+        value: resolution,
+        color: '#4caf50',
+      },
+      {
+        name: 'Other Elapsed',
+        value: otherElapsed,
+        color: '#ffb74d',
+      },
+      {
+        name: 'Remaining Time',
+        value: remaining,
+        color: '#9575cd',
+      },
+      {
+        name: 'Breached Time',
+        value: breached,
+        color: '#f44336',
+      },
+    ].filter((segment) => segment.value > 0);
+
+    if (!segments.length) {
+      return null;
+    }
+
+    type TooltipParam = {
+      value: number;
+      seriesName: string;
+      marker: string;
+    };
+
+    return {
+      tooltip: {
+        trigger: 'axis',
+        axisPointer: { type: 'shadow' },
+        formatter: (params: TooltipParam[]) => {
+          const lines = params
+            .filter((param) => param.value > 0)
+            .map((param) => `${param.marker} ${param.seriesName}: ${formatDuration(param.value)}`);
+
+          const total = params.reduce((sum, param) => sum + (Number(param.value) || 0), 0);
+          lines.push(`<strong>Total: ${formatDuration(total)}</strong>`);
+
+          return lines.join('<br />');
+        },
+      },
+      legend: {
+        data: segments.map((segment) => segment.name),
+      },
+      grid: {
+        left: '3%',
+        right: '4%',
+        bottom: '3%',
+        containLabel: true,
+      },
+      xAxis: {
+        type: 'value',
+        name: 'Minutes',
+        boundaryGap: [0, 0.01],
+      },
+      yAxis: {
+        type: 'category',
+        data: ['Timeline'],
+      },
+      series: segments.map((segment) => ({
+        name: segment.name,
+        type: 'bar',
+        stack: 'total',
+        emphasis: { focus: 'series' },
+        itemStyle: { color: segment.color },
+        data: [segment.value],
+      })),
+    };
+  }, [sla]);
+
+  if (!option) {
+    return null;
+  }
+
+  return (
+    <ReactECharts
+      className={className}
+      option={option}
+      style={{ height: 320, width: '100%' }}
+      notMerge
+      lazyUpdate
+    />
+  );
+};
+
+export default SlaProgressChart;

--- a/ui/src/components/TicketView.tsx
+++ b/ui/src/components/TicketView.tsx
@@ -26,6 +26,7 @@ import GenericDropdownController from './UI/Dropdown/GenericDropdownController';
 import RemarkComponent from './UI/Remark/RemarkComponent';
 import { getDropdownOptions, getStatusNameById } from '../utils/Utils';
 import SlaProgressBar from './SlaProgressBar';
+import SlaProgressChart from './SlaProgressChart';
 
 interface TicketViewProps {
   ticketId: string;
@@ -649,6 +650,9 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
           {/* SLA PROGRESS BAR */}
           <Box sx={{ mt: 4, width: { xs: '100%', md: '70%' }, mx: 'auto', display: 'flex', justifyContent: 'center' }}>
             <SlaProgressBar sla={sla} className="w-100" />
+          </Box>
+          <Box sx={{ mt: 4, width: { xs: '100%', md: '70%' }, mx: 'auto', display: 'flex', justifyContent: 'center' }}>
+            <SlaProgressChart sla={sla} className="w-100" />
           </Box>
           <SlaDetails sla={sla} />
         </CustomFieldset>


### PR DESCRIPTION
## Summary
- add Apache ECharts dependencies and new SlaProgressChart component
- render the stacked SLA timeline chart beneath the existing SLA progress bar

## Testing
- npm install --legacy-peer-deps

------
https://chatgpt.com/codex/tasks/task_e_68da21e1280c8332a2eea3f793f5b323