### PR TITLE
Freeze ticket SLA updates after resolution

### DIFF
--- a/api/src/main/java/com/example/api/service/TicketService.java
+++ b/api/src/main/java/com/example/api/service/TicketService.java
@@ -348,6 +348,7 @@ public class TicketService {
             }
         }
         if (isReopenedStatus) {
+            existing.setResolvedAt(null);
             existing.setAssignedTo(null);
             existing.setAssignedToLevel(null);
             existing.setLevelId(null);

--- a/api/src/main/java/com/example/api/service/TicketSlaService.java
+++ b/api/src/main/java/com/example/api/service/TicketSlaService.java
@@ -59,7 +59,8 @@ public class TicketSlaService {
         }
 
         LocalDateTime reportedDate = ticket.getReportedDate();
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime resolvedAt = ticket.getResolvedAt();
+        LocalDateTime calculationTime = resolvedAt != null ? resolvedAt : LocalDateTime.now();
 
         long resolutionPolicy = config.getResolutionMinutes() != null
                 ? config.getResolutionMinutes() : 0L;
@@ -84,7 +85,7 @@ public class TicketSlaService {
             responseMinutes = Math.max(Duration.between(reportedDate, assignTime).toMinutes(), 0L);
         }
 
-        LocalDateTime endTime = ticket.getResolvedAt() != null ? ticket.getResolvedAt() : now;
+        LocalDateTime endTime = resolvedAt != null ? resolvedAt : calculationTime;
         long elapsed = 0L;
         if (reportedDate != null) {
             elapsed = Math.max(Duration.between(reportedDate, endTime).toMinutes(), 0L);
@@ -160,7 +161,7 @@ public class TicketSlaService {
         long breachedBy = resolution - allowedMinutes;
         Long timeTillDueDate = null;
         if (currentDueAt != null) {
-            timeTillDueDate = Duration.between(now, currentDueAt).toMinutes();
+            timeTillDueDate = Duration.between(calculationTime, currentDueAt).toMinutes();
         }
 
         ticketSla.setTicket(ticket);


### PR DESCRIPTION
## Summary
- use the ticket's resolution timestamp when calculating SLA metrics so values stop changing after closure
- clear the resolved timestamp when a ticket is reopened so SLA tracking resumes from the new lifecycle

## Testing
- ./gradlew test *(fails: Java 17 toolchain is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da3e3950a48332bb2e204b0c9d5a1a