### PR TITLE
Expose stakeholder names in ticket responses and tweak SLA chart

### DIFF
--- a/api/src/main/java/com/example/api/dto/TicketDto.java
+++ b/api/src/main/java/com/example/api/dto/TicketDto.java
@@ -22,6 +22,7 @@ public class TicketDto {
     private String requestorEmailId;
     private String requestorMobileNo;
     private String stakeholder;
+    private String stakeholderId;
     private String subject;
     private String description;
     private String category;

--- a/api/src/main/java/com/example/api/dto/UserDto.java
+++ b/api/src/main/java/com/example/api/dto/UserDto.java
@@ -16,5 +16,6 @@ public class UserDto {
     private String office;
     private String roles;
     private String stakeholder;
+    private String stakeholderId;
     private List<String> levels;
 }

--- a/api/src/main/java/com/example/api/mapper/DtoMapper.java
+++ b/api/src/main/java/com/example/api/mapper/DtoMapper.java
@@ -74,6 +74,7 @@ public class DtoMapper {
         dto.setRequestorEmailId(ticket.getRequestorEmailId());
         dto.setRequestorMobileNo(ticket.getRequestorMobileNo());
         dto.setStakeholder(ticket.getStakeholder());
+        dto.setStakeholderId(ticket.getStakeholder());
         dto.setSubject(ticket.getSubject());
         dto.setDescription(ticket.getDescription());
         dto.setCategory(ticket.getCategory());
@@ -140,6 +141,7 @@ public class DtoMapper {
         userDto.setOffice(user.getOffice());
         userDto.setRoles(user.getRoles());
         userDto.setStakeholder(user.getStakeholder());
+        userDto.setStakeholderId(user.getStakeholder());
         if (user.getUserLevel() != null && user.getUserLevel().getLevelIds() != null) {
             List<String> levels = Arrays.asList(user.getUserLevel().getLevelIds().split("\\|"));
             userDto.setLevels(levels);

--- a/api/src/main/java/com/example/api/service/TicketService.java
+++ b/api/src/main/java/com/example/api/service/TicketService.java
@@ -21,6 +21,7 @@ import com.example.api.repository.CategoryRepository;
 import com.example.api.repository.SubCategoryRepository;
 import com.example.api.repository.PriorityRepository;
 import com.example.api.repository.UploadedFileRepository;
+import com.example.api.repository.StakeholderRepository;
 import com.example.api.repository.RecommendedSeverityFlowRepository;
 import com.example.api.service.AssignmentHistoryService;
 import com.example.api.service.StatusHistoryService;
@@ -65,6 +66,7 @@ public class TicketService {
     private final SubCategoryRepository subCategoryRepository;
     private final PriorityRepository priorityRepository;
     private final UploadedFileRepository uploadedFileRepository;
+    private final StakeholderRepository stakeholderRepository;
     private final TicketSlaService ticketSlaService;
     private final RecommendedSeverityFlowRepository recommendedSeverityFlowRepository;
 
@@ -126,12 +128,34 @@ public class TicketService {
                     });
         }
 
+        if (ticket.getStakeholder() != null && !ticket.getStakeholder().isBlank()) {
+            dto.setStakeholderId(ticket.getStakeholder());
+            dto.setStakeholder(resolveStakeholderName(ticket.getStakeholder()));
+        } else {
+            dto.setStakeholderId(null);
+            dto.setStakeholder(null);
+        }
+
         if (ticket.getAssignedTo() != null && !ticket.getAssignedTo().isBlank()) {
             dto.setAssignedToName(resolveUserDisplayName(ticket.getAssignedTo()));
         } else {
             dto.setAssignedToName(null);
         }
         return dto;
+    }
+
+    private String resolveStakeholderName(String stakeholderId) {
+        if (stakeholderId == null || stakeholderId.isBlank()) {
+            return null;
+        }
+        try {
+            Integer id = Integer.valueOf(stakeholderId);
+            return stakeholderRepository.findById(id)
+                    .map(com.example.api.models.Stakeholder::getDescription)
+                    .orElse(stakeholderId);
+        } catch (NumberFormatException ex) {
+            return stakeholderId;
+        }
     }
 
     public Page<TicketDto> getTickets(String priority, Pageable pageable) {

--- a/ui/src/components/RaiseTicket/RequestorDetails.tsx
+++ b/ui/src/components/RaiseTicket/RequestorDetails.tsx
@@ -58,9 +58,9 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
     const debouncedUserId = useDebounce(userId, 500);
 
     const allUsers = usersData || [];
-    const filteredUsers = allUsers.filter((u: any) => !stakeholder || u.stakeholder === stakeholder);
+    const filteredUsers = allUsers.filter((u: any) => !stakeholder || u.stakeholderId === stakeholder);
     const stakeholderOptions: DropdownOption[] = Array.isArray(stakeholderData)
-        ? stakeholderData.map((s: any) => ({ label: s.description, value: s.id }))
+        ? stakeholderData.map((s: any) => ({ label: s.description, value: String(s.id) }))
         : [];
 
     let showRequestorDetails = true;
@@ -100,7 +100,7 @@ const RequestorDetails: React.FC<RequestorDetailsProps> = ({ register, errors, s
             setValue("office", data?.office ?? data?.officeName ?? '');
 
             if (!fciUser) {
-                setValue("stakeholder", data.stakeholder);
+                setValue("stakeholder", data.stakeholderId ?? data.stakeholder);
             }
         }
     };

--- a/ui/src/components/SlaProgressChart.tsx
+++ b/ui/src/components/SlaProgressChart.tsx
@@ -132,6 +132,7 @@ const SlaProgressChart: React.FC<SlaProgressChartProps> = ({ sla, className }) =
         name: segment.name,
         type: 'bar',
         stack: 'total',
+        barWidth: 20,
         emphasis: { focus: 'series' },
         itemStyle: { color: segment.color },
         data: [segment.value],

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -52,6 +52,8 @@ export interface Ticket {
     requestorName?: string;
     requestorEmailId?: string;
     requestorMobileNo?: string;
+    stakeholder?: string;
+    stakeholderId?: string;
     reportedDate?: string; // ISO-8601 datetime
     statusId?: string;
     statusLabel?: string;


### PR DESCRIPTION
## Summary
- add stakeholderId to ticket and user DTOs while looking up stakeholder names on read
- update services and requestor details UI to use stakeholder names and preserve ids for filtering
- reduce the SLA progress chart bar width for a leaner visual

## Testing
- ./gradlew test *(fails: required Java 17 toolchain is unavailable in the environment)*
- npm run build *(fails: react-i18next dependency missing in build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da447275748332afce035560a8ea94