### PR TITLE
Add backend and UI support for root cause analysis workflow

### DIFF
--- a/api/src/main/java/com/example/api/controller/RootCauseAnalysisController.java
+++ b/api/src/main/java/com/example/api/controller/RootCauseAnalysisController.java
@@ -1,0 +1,64 @@
+package com.example.api.controller;
+
+import com.example.api.dto.PaginationResponse;
+import com.example.api.dto.RootCauseAnalysisDto;
+import com.example.api.dto.TicketDto;
+import com.example.api.service.RootCauseAnalysisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequestMapping("/root-cause-analysis")
+@CrossOrigin(origins = "http://localhost:3000")
+@RequiredArgsConstructor
+public class RootCauseAnalysisController {
+
+    private final RootCauseAnalysisService rootCauseAnalysisService;
+
+    @GetMapping("/tickets")
+    public ResponseEntity<PaginationResponse<TicketDto>> getTickets(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam String username,
+            @RequestParam(required = false) List<String> roles) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "lastModified"));
+        PaginationResponse<TicketDto> response = rootCauseAnalysisService.getTicketsForRootCauseAnalysis(username, roles, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{ticketId}")
+    public ResponseEntity<RootCauseAnalysisDto> getRootCauseAnalysis(@PathVariable String ticketId) {
+        RootCauseAnalysisDto dto = rootCauseAnalysisService.getRootCauseAnalysis(ticketId);
+        return ResponseEntity.ok(dto);
+    }
+
+    @PostMapping(value = "/{ticketId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<RootCauseAnalysisDto> saveRootCauseAnalysis(
+            @PathVariable String ticketId,
+            @RequestParam(required = false) String descriptionOfCause,
+            @RequestParam(required = false) String resolutionDescription,
+            @RequestParam(required = false) String updatedBy,
+            @RequestParam(value = "attachments", required = false) MultipartFile[] attachments) throws IOException {
+        RootCauseAnalysisDto dto = rootCauseAnalysisService.save(ticketId, descriptionOfCause, resolutionDescription, updatedBy, attachments);
+        return ResponseEntity.status(HttpStatus.OK).body(dto);
+    }
+
+    @DeleteMapping("/{ticketId}/attachments")
+    public ResponseEntity<RootCauseAnalysisDto> deleteAttachment(
+            @PathVariable String ticketId,
+            @RequestParam String path,
+            @RequestParam(required = false) String updatedBy) throws IOException {
+        RootCauseAnalysisDto dto = rootCauseAnalysisService.removeAttachment(ticketId, path, updatedBy);
+        return ResponseEntity.ok(dto);
+    }
+}

--- a/api/src/main/java/com/example/api/dto/RootCauseAnalysisDto.java
+++ b/api/src/main/java/com/example/api/dto/RootCauseAnalysisDto.java
@@ -1,0 +1,21 @@
+package com.example.api.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+public class RootCauseAnalysisDto {
+    private String ticketId;
+    private String severityId;
+    private String severityLabel;
+    private String severityDisplay;
+    private String descriptionOfCause;
+    private String resolutionDescription;
+    private List<String> attachments;
+    private String updatedBy;
+    private LocalDateTime updatedAt;
+}

--- a/api/src/main/java/com/example/api/dto/TicketDto.java
+++ b/api/src/main/java/com/example/api/dto/TicketDto.java
@@ -32,6 +32,8 @@ public class TicketDto {
     private String priority;
     private String priorityId;
     private String severity;
+    private String severityId;
+    private String severityLabel;
     private String recommendedSeverity;
     private String impact;
     private String severityRecommendedBy;

--- a/api/src/main/java/com/example/api/mapper/DtoMapper.java
+++ b/api/src/main/java/com/example/api/mapper/DtoMapper.java
@@ -82,6 +82,8 @@ public class DtoMapper {
         dto.setPriority(ticket.getPriority());
         dto.setPriorityId(ticket.getPriority());
         dto.setSeverity(ticket.getSeverity());
+        dto.setSeverityId(ticket.getSeverity());
+        dto.setSeverityLabel(ticket.getSeverity());
         dto.setRecommendedSeverity(ticket.getRecommendedSeverity());
         dto.setImpact(ticket.getImpact());
         dto.setSeverityRecommendedBy(ticket.getSeverityRecommendedBy());

--- a/api/src/main/java/com/example/api/models/RootCauseAnalysis.java
+++ b/api/src/main/java/com/example/api/models/RootCauseAnalysis.java
@@ -1,0 +1,58 @@
+package com.example.api.models;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "root_cause_analysis")
+@Getter
+@Setter
+public class RootCauseAnalysis {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "rca_id")
+    private String id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ticket_id", referencedColumnName = "ticket_id", unique = true)
+    private Ticket ticket;
+
+    @Column(name = "severity_id")
+    private String severityId;
+
+    @Column(name = "description_of_cause", columnDefinition = "TEXT")
+    private String descriptionOfCause;
+
+    @Column(name = "resolution_description", columnDefinition = "TEXT")
+    private String resolutionDescription;
+
+    @Column(name = "attachment_paths", columnDefinition = "TEXT")
+    private String attachmentPaths;
+
+    @Column(name = "created_by")
+    private String createdBy;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_by")
+    private String updatedBy;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = this.createdAt;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/api/src/main/java/com/example/api/repository/RootCauseAnalysisRepository.java
+++ b/api/src/main/java/com/example/api/repository/RootCauseAnalysisRepository.java
@@ -1,0 +1,10 @@
+package com.example.api.repository;
+
+import com.example.api.models.RootCauseAnalysis;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RootCauseAnalysisRepository extends JpaRepository<RootCauseAnalysis, String> {
+    Optional<RootCauseAnalysis> findByTicket_Id(String ticketId);
+}

--- a/api/src/main/java/com/example/api/repository/TicketRepository.java
+++ b/api/src/main/java/com/example/api/repository/TicketRepository.java
@@ -25,6 +25,16 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
 
     Page<Ticket> findByPriority(String priority, Pageable pageable);
 
+    @Query("SELECT t FROM Ticket t " +
+            "WHERE t.ticketStatus = :status " +
+            "AND t.severity IS NOT NULL " +
+            "AND LOWER(t.severity) IN (:severityTokens) " +
+            "AND (:updatedBy IS NULL OR LOWER(t.updatedBy) = LOWER(:updatedBy))")
+    Page<Ticket> findClosedTicketsForRootCauseAnalysis(@Param("status") TicketStatus status,
+                                                       @Param("severityTokens") java.util.Collection<String> severityTokens,
+                                                       @Param("updatedBy") String updatedBy,
+                                                       Pageable pageable);
+
     @Query("SELECT t FROM Ticket t LEFT JOIN t.status s " +
 //            "WHERE (:statusId IS NULL OR s.statusId = :statusId) " +
 //            "WHERE (:statusId IS NULL OR function(FIND_IN_SET, s.statusId, :statusId) > 0)" +

--- a/api/src/main/java/com/example/api/service/RootCauseAnalysisStorageService.java
+++ b/api/src/main/java/com/example/api/service/RootCauseAnalysisStorageService.java
@@ -1,0 +1,43 @@
+package com.example.api.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+@Service
+public class RootCauseAnalysisStorageService {
+
+    @Value("${file.storage.base-dir}")
+    private String baseDir;
+
+    public String save(MultipartFile file, String ticketId) throws IOException {
+        Path basePath = Paths.get(baseDir).toAbsolutePath().normalize();
+        Path dirPath = basePath.resolve(Paths.get("rca", ticketId)).normalize();
+        Files.createDirectories(dirPath);
+        String original = StringUtils.cleanPath(file.getOriginalFilename());
+        String filename = UUID.randomUUID() + "_" + original;
+        Path filePath = dirPath.resolve(filename);
+        Files.copy(file.getInputStream(), filePath, StandardCopyOption.REPLACE_EXISTING);
+        return Paths.get("rca", ticketId, filename).toString().replace('\\', '/');
+    }
+
+    public void delete(String relativePath) throws IOException {
+        if (relativePath == null || relativePath.isBlank()) {
+            return;
+        }
+        Path basePath = Paths.get(baseDir).toAbsolutePath().normalize();
+        Path filePath = basePath.resolve(relativePath).normalize();
+        if (!filePath.startsWith(basePath)) {
+            throw new IOException("Invalid file path");
+        }
+        Files.deleteIfExists(filePath);
+    }
+}

--- a/api/src/main/java/com/example/api/service/TicketService.java
+++ b/api/src/main/java/com/example/api/service/TicketService.java
@@ -75,7 +75,7 @@ public class TicketService {
         return ticketRepository.findAll();
     }
 
-    private TicketDto mapWithStatusId(Ticket ticket) {
+    public TicketDto mapWithStatusId(Ticket ticket) {
         TicketDto dto = DtoMapper.toTicketDto(ticket);
         // category names
         if (ticket.getCategory() != null) {

--- a/db/ticketing_system_dump.sql
+++ b/db/ticketing_system_dump.sql
@@ -868,6 +868,30 @@ INSERT INTO `ticket_feedback` VALUES (1,'050f176d-30ad-4144-a6cb-3741c141ab32','
 UNLOCK TABLES;
 
 --
+-- Table structure for table `root_cause_analysis`
+--
+
+DROP TABLE IF EXISTS `root_cause_analysis`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `root_cause_analysis` (
+  `rca_id` varchar(36) NOT NULL,
+  `ticket_id` varchar(36) NOT NULL,
+  `severity_id` varchar(10) DEFAULT NULL,
+  `description_of_cause` text,
+  `resolution_description` text,
+  `attachment_paths` text,
+  `created_by` varchar(100) DEFAULT NULL,
+  `created_at` datetime DEFAULT CURRENT_TIMESTAMP,
+  `updated_by` varchar(100) DEFAULT NULL,
+  `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`rca_id`),
+  UNIQUE KEY `uk_root_cause_ticket` (`ticket_id`),
+  CONSTRAINT `fk_root_cause_ticket` FOREIGN KEY (`ticket_id`) REFERENCES `tickets` (`ticket_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `ticket_sla`
 --
 

--- a/ui/src/services/RootCauseAnalysisService.ts
+++ b/ui/src/services/RootCauseAnalysisService.ts
@@ -1,0 +1,26 @@
+import axios from 'axios';
+import { BASE_URL } from './api';
+
+export function getRootCauseAnalysisTickets(page: number, size: number, username: string, roles: string[]) {
+  const params = new URLSearchParams({ page: String(page), size: String(size), username });
+  roles.forEach((role) => params.append('roles', role));
+  return axios.get(`${BASE_URL}/root-cause-analysis/tickets?${params.toString()}`);
+}
+
+export function getRootCauseAnalysis(ticketId: string) {
+  return axios.get(`${BASE_URL}/root-cause-analysis/${ticketId}`);
+}
+
+export function saveRootCauseAnalysis(ticketId: string, payload: FormData) {
+  return axios.post(`${BASE_URL}/root-cause-analysis/${ticketId}`, payload, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+}
+
+export function deleteRootCauseAnalysisAttachment(ticketId: string, path: string, updatedBy?: string) {
+  const params = new URLSearchParams({ path });
+  if (updatedBy) {
+    params.append('updatedBy', updatedBy);
+  }
+  return axios.delete(`${BASE_URL}/root-cause-analysis/${ticketId}/attachments?${params.toString()}`);
+}

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -72,6 +72,18 @@ export interface TicketStatusWorkflow {
     nextStatus: number;
 }
 
+export interface RootCauseAnalysis {
+    ticketId: string;
+    severityId?: string;
+    severityLabel?: string;
+    severityDisplay?: string;
+    descriptionOfCause?: string;
+    resolutionDescription?: string;
+    attachments?: string[];
+    updatedBy?: string;
+    updatedAt?: string;
+}
+
 export interface ToggleOption {
     icon?: string; // optional
     value: string;


### PR DESCRIPTION
## Summary
- add a root cause analysis entity, repository, service, storage helper, and controller to manage RCA data and attachments
- extend ticket DTO/repository plus the database dump with severity metadata and a root_cause_analysis table to support RCA queries
- expose RCA capabilities on the UI with new services, severity-aware ticket listings, and an editable RCA section in the ticket view

## Testing
- `./gradlew test --console=plain` *(fails: Java 17 toolchain not available in container)*
- `npm run build` *(fails: missing dependencies; npm install blocked by peer dependency conflict for react-quill vs React 19)*

------
https://chatgpt.com/codex/tasks/task_e_68da790d5e2c833287dda1a1a2aa862c