### PR TITLE
Fix infinite fetch loop on Root Cause Analysis page

### DIFF
--- a/ui/src/pages/RootCauseAnalysis.tsx
+++ b/ui/src/pages/RootCauseAnalysis.tsx
@@ -40,17 +40,17 @@ const RootCauseAnalysis: React.FC = () => {
   const currentUser = getCurrentUserDetails();
   const currentUsername = currentUser?.username || currentUser?.userId || '';
   const currentRoles = useMemo(() => {
-    const roles = currentUser?.role || [];
-    return Array.isArray(roles) ? roles : [roles];
-  }, [currentUser?.role]);
+    const roles = currentUser?.role;
+    const normalized = Array.isArray(roles) ? roles : roles ? [roles] : [];
+    return normalized.filter((role): role is string => typeof role === 'string' && role.trim().length > 0);
+  }, [JSON.stringify(currentUser?.role ?? [])]);
 
   const fetchTickets = useCallback(() => {
     if (!currentUsername) {
       return Promise.resolve();
     }
-    const paramsRoles = currentRoles.filter((role): role is string => typeof role === 'string' && role.trim().length > 0);
     return apiHandler(() =>
-      getRootCauseAnalysisTickets(page - 1, pageSize, currentUsername, paramsRoles),
+      getRootCauseAnalysisTickets(page - 1, pageSize, currentUsername, currentRoles),
     );
   }, [apiHandler, currentRoles, currentUsername, page, pageSize]);
 


### PR DESCRIPTION
## Summary
- stabilize the derived user roles on the Root Cause Analysis page so fetch requests stop looping
- reuse the filtered roles when calling the tickets API to avoid repeated recalculation

## Testing
- npm test -- --watchAll=false *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68da9e9445c483329528a86a3f293b8d