### PR TITLE
Fix repeated ticket detail API requests

### DIFF
--- a/ui/src/components/TicketView.tsx
+++ b/ui/src/components/TicketView.tsx
@@ -107,13 +107,17 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
   const currentUserDetails = getCurrentUserDetails();
   const currentUsername = currentUserDetails?.username || '';
   const currentUserId = currentUserDetails?.userId || '';
-  const roles = currentUserDetails?.role || [];
+  const rawRoles = currentUserDetails?.role;
   const roleList = useMemo<string[]>(() => {
-    const raw = Array.isArray(roles) ? roles : [roles];
+    const raw = Array.isArray(rawRoles)
+      ? rawRoles
+      : rawRoles
+        ? [rawRoles]
+        : [];
     return raw
       .map(role => (role == null ? '' : role.toString()))
       .filter(role => role.trim().length > 0);
-  }, [roles]);
+  }, [rawRoles]);
   const normalizedRoles = useMemo(() => roleList.map(role => role.toUpperCase()), [roleList]);
   const isItManager = roleList.includes('9');
   const isRno = roleList.includes('4');


### PR DESCRIPTION
## Summary
- ensure the current user's roles memoization does not change on every render in TicketView
- stop the status workflow, SLA and feedback fetch effects from re-triggering continuously when there are no roles

## Testing
- npm run build *(fails: react-scripts not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc135abf548332a68bfc9e9d46f165