### PR TITLE
Fix missing terminator in tickets insert script

### DIFF
--- a/db/ticketing_system_dump.sql
+++ b/db/ticketing_system_dump.sql
@@ -1162,7 +1162,7 @@ INSERT INTO `tickets` VALUES ('016ad004-f2bd-4534-9469-bdf74bcafdef','2025-08-28
 ('f77a5bba-6b3e-4027-b599-44da05afad25','2025-09-24 04:34:17','Self','216','teaml1','team.lead1@example.com','1212121212','Testing 44','Testing notif','1','1003','P1',0,NULL,'2025-09-24 04:34:18','OPEN',NULL,NULL,NULL,'teaml1','S2',NULL,NULL,NULL,NULL,'1',NULL,NULL,'teaml1'),
 ('fcde0444-8169-4bdb-b1f1-7041a4505339','2025-09-10 17:25:01','Self','211','guest','guest@example.com','6135712345','Testing creation 39','Testing sla','1','1003','P1',0,NULL,'2025-09-18 10:57:53','ESCALATED',NULL,NULL,NULL,'guest','High - S2','Medium - S3','rnoharshv',NULL,NULL,'11',NULL,NULL,'rnoharshv'),
 ('fe21a3d3-09f5-45c9-b332-6456b13e67e6','2025-09-29 13:18:17','Self','203','chirags','chirag.shah@example.com','9123456782','Testing new SLA','logic updated','5','5006','P1',0,NULL,'2025-09-29 08:04:40','CLOSED','L1','L1','garimaj','chirags','S3',NULL,NULL,NULL,'2','8','2025-10-01 13:36:20','PENDING','garimaj'),
-('fe6fea66-64ed-441d-b93c-1eebed31f966','2025-08-28 17:56:21','Self','216','teaml1','team.lead1@example.com','1212121212','Testing creation 23','Testing uploading files','9','9002','P1',0,NULL,'2025-09-25 07:16:37','OPEN',NULL,NULL,NULL,'teaml1','S4',NULL,NULL,NULL,NULL,'1',NULL,'PENDING','teaml1')
+('fe6fea66-64ed-441d-b93c-1eebed31f966','2025-08-28 17:56:21','Self','216','teaml1','team.lead1@example.com','1212121212','Testing creation 23','Testing uploading files','9','9002','P1',0,NULL,'2025-09-25 07:16:37','OPEN',NULL,NULL,NULL,'teaml1','S4',NULL,NULL,NULL,NULL,'1',NULL,'PENDING','teaml1');
 /*!40000 ALTER TABLE `tickets` ENABLE KEYS */;
 UNLOCK TABLES;
 


### PR DESCRIPTION
## Summary
- add the missing semicolon terminator to the final row in the tickets insert block of the SQL dump

## Testing
- docker run --rm -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=ticketing_system -v $(pwd)/db/ticketing_system_dump.sql:/docker-entrypoint-initdb.d/dump.sql mysql:8.0 --default-authentication-plugin=mysql_native_password *(fails: `docker` not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd45dfcecc8332ac5a46ff03aa8499