### PR TITLE
Ensure RCA ticket detail fetch enforces eligibility

### DIFF
--- a/api/src/main/java/com/example/api/controller/RootCauseAnalysisController.java
+++ b/api/src/main/java/com/example/api/controller/RootCauseAnalysisController.java
@@ -41,6 +41,7 @@ public class RootCauseAnalysisController {
     @GetMapping("/tickets/{ticketId}")
     public ResponseEntity<TicketDto> getRCATicketById(@PathVariable String ticketId) {
         TicketDto ticketDto = rootCauseAnalysisService.getTicketForRootCauseAnalysisById(ticketId);
+        return ResponseEntity.ok(ticketDto);
     }
 
     @GetMapping("/{ticketId}")

--- a/ui/src/services/RootCauseAnalysisService.ts
+++ b/ui/src/services/RootCauseAnalysisService.ts
@@ -17,6 +17,10 @@ export function getRootCauseAnalysisTickets(page: number, size: number, username
   return axios.get(`${BASE_URL}/root-cause-analysis/tickets?${params.toString()}`);
 }
 
+export function getRootCauseAnalysisTicketById(ticketId: string) {
+  return axios.get(`${BASE_URL}/root-cause-analysis/tickets/${ticketId}`);
+}
+
 export async function getRootCauseAnalysis(ticketId: string): Promise<RootCauseAnalysis | null> {
   const response = await axios.get(`${BASE_URL}/root-cause-analysis/${ticketId}`);
   return extractPayload(response);


### PR DESCRIPTION
## Summary
- validate that RCA ticket detail requests only return closed tickets with eligible severities while mapping severity display data
- return the ticket payload from the RCA controller endpoint and expose a client helper for fetching RCA ticket details
- update the ticket view to call the RCA-specific API when on the RCA page and rely on the response-provided RCA status

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd832c16308332a3584af3b1766a85