### PR TITLE
Open RCA modal from RootCauseAnalysis list

### DIFF
--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -52,9 +52,10 @@ interface TicketsTableProps {
     statusWorkflows: Record<string, TicketStatusWorkflow[]>;
     onRecommendEscalation?: (id: string) => void;
     showSeverityColumn?: boolean;
+    onRcaClick?: (id: string, status?: TicketRow['rcaStatus']) => void;
 }
 
-const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowClick, searchCurrentTicketsPaginatedApi, refreshingTicketId, statusWorkflows, onRecommendEscalation, showSeverityColumn = false }) => {
+const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowClick, searchCurrentTicketsPaginatedApi, refreshingTicketId, statusWorkflows, onRecommendEscalation, showSeverityColumn = false, onRcaClick }) => {
     const { t } = useTranslation();
 
     const navigate = useNavigate();
@@ -298,8 +299,15 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
                     if (record.rcaStatus) {
                         const isSubmitted = record.rcaStatus === 'SUBMITTED';
                         const label = isSubmitted ? t('View RCA') : t('Submit RCA');
+                        const handleClick = () => {
+                            if (onRcaClick) {
+                                onRcaClick(record.id, record.rcaStatus);
+                                return;
+                            }
+                            onRowClick(record.id);
+                        };
                         return (
-                            <Button size="small" onClick={() => onRowClick(record.id)}>
+                            <Button size="small" onClick={handleClick}>
                                 {label}
                             </Button>
                         );

--- a/ui/src/pages/RootCauseAnalysis.tsx
+++ b/ui/src/pages/RootCauseAnalysis.tsx
@@ -8,6 +8,7 @@ import { TicketStatusWorkflow } from '../types';
 import { getStatusWorkflowMappings } from '../services/StatusService';
 import { getCurrentUserDetails } from '../config/config';
 import { getRootCauseAnalysisTickets } from '../services/RootCauseAnalysisService';
+import RootCauseAnalysisModal from '../components/RootCauseAnalysisModal';
 
 const formatSeverityText = (severity?: string, label?: string): string => {
   const source = (severity || label || '').trim();
@@ -37,6 +38,9 @@ const RootCauseAnalysis: React.FC = () => {
   const [pageSize] = useState(10);
   const [refreshingTicketId, setRefreshingTicketId] = useState<string | null>(null);
   const [statusWorkflows, setStatusWorkflows] = useState<Record<string, TicketStatusWorkflow[]>>({});
+  const [isRcaModalOpen, setIsRcaModalOpen] = useState(false);
+  const [selectedTicketId, setSelectedTicketId] = useState<string | null>(null);
+  const [selectedRcaStatus, setSelectedRcaStatus] = useState<string>('PENDING');
   const currentUser = getCurrentUserDetails();
   const currentUsername = currentUser?.username || currentUser?.userId || '';
   const currentRoles = useMemo(() => {
@@ -99,6 +103,18 @@ const RootCauseAnalysis: React.FC = () => {
     [fetchTickets],
   );
 
+  const handleOpenRcaModal = useCallback((ticketId: string, status?: TicketRow['rcaStatus']) => {
+    setSelectedTicketId(ticketId);
+    setSelectedRcaStatus(status ?? 'PENDING');
+    setIsRcaModalOpen(true);
+  }, []);
+
+  const handleRcaModalClose = useCallback(() => {
+    setIsRcaModalOpen(false);
+    setSelectedTicketId(null);
+    fetchTickets();
+  }, [fetchTickets]);
+
   return (
     <div className="container">
       <Title textKey="Root Cause Analysis" />
@@ -110,6 +126,7 @@ const RootCauseAnalysis: React.FC = () => {
         refreshingTicketId={refreshingTicketId}
         statusWorkflows={statusWorkflows}
         showSeverityColumn
+        onRcaClick={handleOpenRcaModal}
       />
       <div className="d-flex justify-content-between align-items-center mt-3">
         <PaginationControls
@@ -118,6 +135,15 @@ const RootCauseAnalysis: React.FC = () => {
           onChange={(_, value) => setPage(value)}
         />
       </div>
+      {selectedTicketId && (
+        <RootCauseAnalysisModal
+          open={isRcaModalOpen}
+          onClose={handleRcaModalClose}
+          rcaStatus={selectedRcaStatus}
+          ticketId={selectedTicketId}
+          updatedBy={currentUsername}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- allow the root cause analysis ticket table to use a dedicated handler when View/Submit RCA is clicked
- open the RootCauseAnalysisModal directly from the RootCauseAnalysis page using the selected ticket details
- refresh the ticket list when the modal closes so the table reflects updates

## Testing
- npm run build *(fails: Module not found: Error: Can't resolve 'i18next')*


------
https://chatgpt.com/codex/tasks/task_e_68dd9e409244833289f8c69f47d2ff5f