### PR TITLE
Add dedicated exception handling for feedback and root cause APIs

### DIFF
--- a/api/src/main/java/com/example/api/controller/RootCauseAnalysisController.java
+++ b/api/src/main/java/com/example/api/controller/RootCauseAnalysisController.java
@@ -16,7 +16,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
 import java.util.List;
 
 @RestController
@@ -56,7 +55,7 @@ public class RootCauseAnalysisController {
             @RequestParam(required = false) String descriptionOfCause,
             @RequestParam(required = false) String resolutionDescription,
             @RequestParam(required = false) String updatedBy,
-            @RequestParam(value = "attachments", required = false) MultipartFile[] attachments) throws IOException {
+            @RequestParam(value = "attachments", required = false) MultipartFile[] attachments) {
         RootCauseAnalysisDto dto = rootCauseAnalysisService.save(ticketId, descriptionOfCause, resolutionDescription, updatedBy, attachments);
         return ResponseEntity.status(HttpStatus.OK).body(dto);
     }
@@ -65,7 +64,7 @@ public class RootCauseAnalysisController {
     public ResponseEntity<RootCauseAnalysisDto> deleteAttachment(
             @PathVariable String ticketId,
             @RequestParam String path,
-            @RequestParam(required = false) String updatedBy) throws IOException {
+            @RequestParam(required = false) String updatedBy) {
         RootCauseAnalysisDto dto = rootCauseAnalysisService.removeAttachment(ticketId, path, updatedBy);
         return ResponseEntity.ok(dto);
     }

--- a/api/src/main/java/com/example/api/controller/TicketFeedbackController.java
+++ b/api/src/main/java/com/example/api/controller/TicketFeedbackController.java
@@ -40,9 +40,7 @@ public class TicketFeedbackController {
     @GetMapping("/tickets/{ticketId}/feedback")
     public ResponseEntity<TicketFeedbackResponse> getFeedback(@PathVariable String ticketId,
                                                               @RequestHeader("X-USER-ID") String userId) {
-        return feedbackService.getFeedback(ticketId, userId)
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+        return ResponseEntity.ok(feedbackService.getFeedback(ticketId, userId));
     }
 
     @GetMapping("/feedback")

--- a/api/src/main/java/com/example/api/exception/FeedbackNotFoundException.java
+++ b/api/src/main/java/com/example/api/exception/FeedbackNotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.api.exception;
+
+/**
+ * Exception thrown when feedback for a ticket cannot be located.
+ */
+public class FeedbackNotFoundException extends ResourceNotFoundException {
+
+    public FeedbackNotFoundException(String ticketId) {
+        super(String.format("Feedback for ticket id %s not found", ticketId));
+    }
+}

--- a/api/src/main/java/com/example/api/exception/FeedbackSubmissionException.java
+++ b/api/src/main/java/com/example/api/exception/FeedbackSubmissionException.java
@@ -1,0 +1,11 @@
+package com.example.api.exception;
+
+/**
+ * Exception thrown when feedback submission fails unexpectedly.
+ */
+public class FeedbackSubmissionException extends RuntimeException {
+
+    public FeedbackSubmissionException(String ticketId, Throwable cause) {
+        super(String.format("Error during submission of feedback for ticket id %s", ticketId), cause);
+    }
+}

--- a/api/src/main/java/com/example/api/exception/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/example/api/exception/GlobalExceptionHandler.java
@@ -12,6 +12,17 @@ import java.time.LocalDateTime;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+    @ExceptionHandler(FeedbackNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleFeedbackNotFound(FeedbackNotFoundException ex, HttpServletRequest request) {
+        return buildErrorResponse(HttpStatus.NOT_FOUND, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(RootCauseAnalysisNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleRootCauseNotFound(RootCauseAnalysisNotFoundException ex,
+                                                                     HttpServletRequest request) {
+        return buildErrorResponse(HttpStatus.NOT_FOUND, ex.getMessage(), request);
+    }
+
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<ApiResponse<Void>> handleResourceNotFound(ResourceNotFoundException ex, HttpServletRequest request) {
         return buildErrorResponse(HttpStatus.NOT_FOUND, ex.getMessage(), request);
@@ -25,6 +36,18 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(InvalidRequestException.class)
     public ResponseEntity<ApiResponse<Void>> handleInvalidRequest(InvalidRequestException ex, HttpServletRequest request) {
         return buildErrorResponse(HttpStatus.BAD_REQUEST, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(FeedbackSubmissionException.class)
+    public ResponseEntity<ApiResponse<Void>> handleFeedbackSubmission(FeedbackSubmissionException ex,
+                                                                      HttpServletRequest request) {
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(RootCauseAnalysisProcessingException.class)
+    public ResponseEntity<ApiResponse<Void>> handleRootCauseProcessing(RootCauseAnalysisProcessingException ex,
+                                                                       HttpServletRequest request) {
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, ex.getMessage(), request);
     }
 
     @ExceptionHandler(Exception.class)

--- a/api/src/main/java/com/example/api/exception/RootCauseAnalysisNotFoundException.java
+++ b/api/src/main/java/com/example/api/exception/RootCauseAnalysisNotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.api.exception;
+
+/**
+ * Exception thrown when a root cause analysis entry cannot be located for a ticket.
+ */
+public class RootCauseAnalysisNotFoundException extends ResourceNotFoundException {
+
+    public RootCauseAnalysisNotFoundException(String ticketId) {
+        super(String.format("Root cause analysis for ticket id %s not found", ticketId));
+    }
+}

--- a/api/src/main/java/com/example/api/exception/RootCauseAnalysisProcessingException.java
+++ b/api/src/main/java/com/example/api/exception/RootCauseAnalysisProcessingException.java
@@ -1,0 +1,11 @@
+package com.example.api.exception;
+
+/**
+ * Exception thrown when root cause analysis operations fail unexpectedly.
+ */
+public class RootCauseAnalysisProcessingException extends RuntimeException {
+
+    public RootCauseAnalysisProcessingException(String ticketId, Throwable cause) {
+        super(String.format("Error while processing root cause analysis for ticket id %s", ticketId), cause);
+    }
+}


### PR DESCRIPTION
## Summary
- add feedback and root cause analysis specific exception types with clear messages and hook them into the global handler
- update the feedback controller/service to surface not found and submission failures through the new exceptions
- wrap root cause analysis retrieval, persistence, and attachment updates with tailored exceptions for missing data and processing errors

## Testing
- `./gradlew test` *(fails: required Java 17 toolchain is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de42ad1c10833298a76496c1da4992