### PR TITLE
Upgrade Node.js setup in FileGator Dockerfile

### DIFF
--- a/filegator/Dockerfile
+++ b/filegator/Dockerfile
@@ -3,7 +3,7 @@
 #################################
 FROM php:8.3-apache-bullseye AS builder
 
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 
 RUN apt-get update > /dev/null
 RUN apt-get install -y git libzip-dev nodejs python2 libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb


### PR DESCRIPTION
## Summary
- update the NodeSource setup script in the FileGator builder image to install Node.js 18 prior to npm install

## Testing
- not run (docker command not available in environment)

------
https://chatgpt.com/codex/tasks/task_e_68de7cd0e93c8332820bba8ceb0baa53