### PR TITLE
Allow team leads to view open workload and confirm custom dates

### DIFF
--- a/ui/src/components/Filters/DateRangeFilter.tsx
+++ b/ui/src/components/Filters/DateRangeFilter.tsx
@@ -1,10 +1,11 @@
-import React from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Box } from "@mui/material";
 import DropdownController from "../UI/Dropdown/DropdownController";
 import GenericInput from "../UI/Input/GenericInput";
 import { useTranslation } from "react-i18next";
-import { buildApiDateParams, DATE_RANGE_OPTIONS, DateRangePreset, DateRangeState, ensureCustomPreset, getPresetDateRange } from 
+import { buildApiDateParams, DATE_RANGE_OPTIONS, DateRangePreset, DateRangeState, ensureCustomPreset, getPresetDateRange } from
     "../../utils/dateUtils";
+import CustomIconButton from "../UI/IconButton/CustomIconButton";
 
 type DateRangeFilterProps = {
     value: DateRangeState;
@@ -18,6 +19,24 @@ export const getDateRangeApiParams = buildApiDateParams;
 const DateRangeFilter: React.FC<DateRangeFilterProps> = ({ value, onChange, style, className }) => {
     const { t } = useTranslation();
 
+    const [customRange, setCustomRange] = useState<{ fromDate: string; toDate: string }>({
+        fromDate: value.fromDate ?? "",
+        toDate: value.toDate ?? "",
+    });
+
+    const isCustomPresetSelected = useMemo(() => value.preset === "CUSTOM", [value.preset]);
+
+    useEffect(() => {
+        if (isCustomPresetSelected) {
+            setCustomRange((prev) => ({
+                fromDate: value.fromDate ?? prev.fromDate,
+                toDate: value.toDate ?? prev.toDate,
+            }));
+        } else {
+            setCustomRange({ fromDate: "", toDate: "" });
+        }
+    }, [isCustomPresetSelected, value.fromDate, value.toDate]);
+
     const handlePresetChange = (selected: string) => {
         const preset = selected as DateRangePreset;
         if (preset === "ALL") {
@@ -25,6 +44,10 @@ const DateRangeFilter: React.FC<DateRangeFilterProps> = ({ value, onChange, styl
             return;
         }
         if (preset === "CUSTOM") {
+            setCustomRange({
+                fromDate: value.fromDate ?? "",
+                toDate: value.toDate ?? "",
+            });
             onChange({ ...value, preset: "CUSTOM" });
             return;
         }
@@ -33,15 +56,32 @@ const DateRangeFilter: React.FC<DateRangeFilterProps> = ({ value, onChange, styl
     };
 
     const handleFromDateChange = (newDate: string) => {
-        onChange(ensureCustomPreset(value, { fromDate: newDate }));
+        setCustomRange((prev) => ({ ...prev, fromDate: newDate }));
     };
 
     const handleToDateChange = (newDate: string) => {
-        onChange(ensureCustomPreset(value, { toDate: newDate }));
+        setCustomRange((prev) => ({ ...prev, toDate: newDate }));
+    };
+
+    const handleSubmit = () => {
+        if (!isCustomPresetSelected) {
+            return;
+        }
+
+        onChange(ensureCustomPreset(value, {
+            fromDate: customRange.fromDate || undefined,
+            toDate: customRange.toDate || undefined,
+        }));
     };
 
     return (
-        <Box display="flex" alignItems="center" className={className} style={style}>
+        <Box
+            display="flex"
+            flexDirection={isCustomPresetSelected ? "column" : "row"}
+            alignItems={isCustomPresetSelected ? "flex-start" : "center"}
+            className={className}
+            style={style}
+        >
             <DropdownController
                 label={t("Date Range")}
                 value={value.preset}
@@ -52,12 +92,12 @@ const DateRangeFilter: React.FC<DateRangeFilterProps> = ({ value, onChange, styl
                 }))}
                 style={{ width: 200, marginRight: 8 }}
             />
-            {value.preset === "CUSTOM" && (
-                <Box display="flex" alignItems="center" gap={1}>
+            {isCustomPresetSelected && (
+                <Box display="flex" alignItems="center" gap={1} mt={1}>
                     <GenericInput
                         type="date"
                         label={t("From")}
-                        value={value.fromDate ?? ""}
+                        value={customRange.fromDate}
                         onChange={(event) => handleFromDateChange(event.target.value)}
                         size="small"
                         InputLabelProps={{ shrink: true }}
@@ -65,11 +105,12 @@ const DateRangeFilter: React.FC<DateRangeFilterProps> = ({ value, onChange, styl
                     <GenericInput
                         type="date"
                         label={t("To")}
-                        value={value.toDate ?? ""}
+                        value={customRange.toDate}
                         onChange={(event) => handleToDateChange(event.target.value)}
                         size="small"
                         InputLabelProps={{ shrink: true }}
                     />
+                    <CustomIconButton icon="check" size="small" onClick={handleSubmit} />
                 </Box>
             )}
         </Box>

--- a/ui/src/pages/MyWorkload.tsx
+++ b/ui/src/pages/MyWorkload.tsx
@@ -188,12 +188,14 @@ const MyWorkload: React.FC = () => {
         if (data) {
             const resp = data;
             let items = resp.items || resp;
-            const roles = getCurrentUserDetails()?.role || [];
-            if (roles.includes("4")) {
-                items = items.filter((t: TicketRow) => t.statusId === '1' || t.statusId === '2');
+            const roles = (getCurrentUserDetails()?.role || []).map(String);
+            if (roles.some(role => role === "4" || role === "TEAM_LEAD")) {
+                const teamLeadStatuses = new Set(["1", "2", "OPEN", "ASSIGNED"]);
+                items = items.filter((t: TicketRow) => teamLeadStatuses.has(String(t.statusId ?? "")));
             }
             if (roles.includes("9")) {
-                items = items.filter((t: TicketRow) => t.statusId === '6');
+                const escalatedStatuses = new Set(["6", "ESCALATED"]);
+                items = items.filter((t: TicketRow) => escalatedStatuses.has(String(t.statusId ?? "")));
             }
             setTotalPages(resp.totalPages || 1);
             setFiltered(items);


### PR DESCRIPTION
## Summary
- ensure team leads keep open tickets in their workload filter while still respecting existing role-based status filters
- update the custom date range UI to show date inputs on a second row and provide a confirmation button for submitting the selection

## Testing
- npm run build *(fails: Can't resolve 'i18next')*

------
https://chatgpt.com/codex/tasks/task_e_68debb67b0f08332b45a234c07998013