### PR TITLE
Add category filters to ticket tables and fix user contact info

### DIFF
--- a/ui/src/hooks/useCategoryFilters.ts
+++ b/ui/src/hooks/useCategoryFilters.ts
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useState } from 'react';
+import { DropdownOption } from '../components/UI/Dropdown/GenericDropdown';
+import { getCategories, getSubCategories } from '../services/CategoryService';
+import { getDropdownOptions } from '../utils/Utils';
+
+const parseResponseList = (response: any): any[] => {
+    const rawPayload = response?.data ?? response;
+    const payload = rawPayload?.body ?? rawPayload;
+    if (Array.isArray(payload?.data)) {
+        return payload.data as any[];
+    }
+    return Array.isArray(payload) ? payload : [];
+};
+
+const defaultAllOption: DropdownOption = { label: 'All', value: 'All' };
+
+export const useCategoryFilters = () => {
+    const [categoryOptions, setCategoryOptions] = useState<DropdownOption[]>([defaultAllOption]);
+    const [subCategoryOptions, setSubCategoryOptions] = useState<DropdownOption[]>([defaultAllOption]);
+
+    useEffect(() => {
+        getCategories()
+            .then((response) => {
+                const categories = parseResponseList(response);
+                const options = getDropdownOptions(categories, 'category', 'categoryId');
+                setCategoryOptions([defaultAllOption, ...options]);
+            })
+            .catch(() => {
+                setCategoryOptions([defaultAllOption]);
+            });
+    }, []);
+
+    const loadSubCategories = useCallback(async (categoryId?: string) => {
+        if (!categoryId) {
+            setSubCategoryOptions([defaultAllOption]);
+            return;
+        }
+
+        try {
+            const response = await getSubCategories(categoryId);
+            const subCategories = parseResponseList(response);
+            const options = getDropdownOptions(subCategories, 'subCategory', 'subCategoryId');
+            setSubCategoryOptions([defaultAllOption, ...options]);
+        } catch (error) {
+            setSubCategoryOptions([defaultAllOption]);
+        }
+    }, []);
+
+    return {
+        categoryOptions,
+        subCategoryOptions,
+        loadSubCategories,
+        resetSubCategories: () => setSubCategoryOptions([defaultAllOption]),
+    };
+};
+
+export type UseCategoryFiltersReturn = ReturnType<typeof useCategoryFilters>;

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -98,6 +98,18 @@ interface LoginResponse {
     levels?: string[];
     name?: string;
     allowedStatusActionIds?: string[];
+    email?: string;
+    emailId?: string;
+    emailID?: string;
+    mail?: string;
+    contactNumber?: string;
+    contact?: string;
+    phone?: string;
+    mobile?: string;
+    mobileNo?: string;
+    userEmail?: string;
+    userMail?: string;
+    userPhone?: string;
     [key: string]: any;
 }
 
@@ -137,13 +149,34 @@ const Login: FC = () => {
             }
 
             const submittedUserId = userId.trim();
+            const decodedUser = decoded?.user;
+            const emailFromResponse = decodedUser?.email
+                ?? loginData.email
+                ?? loginData.emailId
+                ?? loginData.emailID
+                ?? loginData.mail
+                ?? loginData.userEmail
+                ?? loginData.userMail
+                ?? loginData.user?.email
+                ?? undefined;
+            const phoneFromResponse = decodedUser?.phone
+                ?? loginData.phone
+                ?? loginData.contactNumber
+                ?? loginData.contact
+                ?? loginData.mobile
+                ?? loginData.mobileNo
+                ?? loginData.userPhone
+                ?? loginData.user?.phone
+                ?? undefined;
             const details: UserDetails = {
-                userId: decoded?.user.userId || loginData.userId || submittedUserId,
-                username: decoded?.user.username || loginData.username || submittedUserId,
-                role: decoded?.user.role ?? loginData.roles ?? [],
-                levels: decoded?.user.levels ?? loginData.levels ?? [],
-                name: decoded?.user.name || loginData.name,
-                allowedStatusActionIds: decoded?.user.allowedStatusActionIds ?? loginData.allowedStatusActionIds ?? [],
+                userId: decodedUser?.userId || loginData.userId || submittedUserId,
+                username: decodedUser?.username || loginData.username || submittedUserId,
+                role: decodedUser?.role ?? loginData.roles ?? [],
+                levels: decodedUser?.levels ?? loginData.levels ?? [],
+                name: decodedUser?.name || loginData.name,
+                email: emailFromResponse,
+                phone: phoneFromResponse,
+                allowedStatusActionIds: decodedUser?.allowedStatusActionIds ?? loginData.allowedStatusActionIds ?? [],
             };
             setUserDetails(details);
 

--- a/ui/src/pages/MyTickets.tsx
+++ b/ui/src/pages/MyTickets.tsx
@@ -23,6 +23,7 @@ import { getCurrentUserDetails } from "../config/config";
 import { useNavigate } from "react-router-dom";
 import DateRangeFilter, { getDateRangeApiParams } from "../components/Filters/DateRangeFilter";
 import { DateRangeState } from "../utils/dateUtils";
+import { useCategoryFilters } from "../hooks/useCategoryFilters";
 
 const getDropdownOptions = <T,>(arr: any, labelKey: keyof T, valueKey: keyof T): DropdownOption[] =>
     Array.isArray(arr)
@@ -64,6 +65,9 @@ const MyTickets: React.FC = () => {
     const sortDirection: 'asc' | 'desc' = 'desc';
     const [dateRange, setDateRange] = useState<DateRangeState>({ preset: "ALL" });
     const dateRangeParams = useMemo(() => getDateRangeApiParams(dateRange), [dateRange]);
+    const { categoryOptions, subCategoryOptions, loadSubCategories } = useCategoryFilters();
+    const [selectedCategory, setSelectedCategory] = useState<string>('All');
+    const [selectedSubCategory, setSelectedSubCategory] = useState<string>('All');
 
     const showSearchBar = checkMyTicketsAccess('searchBar');
     const showStatusFilter = checkMyTicketsAccess('statusFilter');
@@ -88,7 +92,16 @@ const MyTickets: React.FC = () => {
 
     const debouncedSearch = useDebounce(search, 300);
 
-    const searchTicketsPaginatedApi = (query: string, statusName?: string, master?: boolean, page: number = 0, size: number = 5) => {
+    const normalizedCategory = selectedCategory !== 'All' ? selectedCategory : undefined;
+    const normalizedSubCategory = selectedSubCategory !== 'All' ? selectedSubCategory : undefined;
+
+    const searchTicketsPaginatedApi = (
+        query: string,
+        statusName?: string,
+        master?: boolean,
+        page: number = 0,
+        size: number = 5,
+    ) => {
         const user = getCurrentUserDetails();
         const username = user?.username || user?.userId || "";
         const userId = user?.userId || "";
@@ -118,7 +131,9 @@ const MyTickets: React.FC = () => {
                 undefined,
                 createdBy,
                 dateRangeParams.fromDate,
-                dateRangeParams.toDate
+                dateRangeParams.toDate,
+                normalizedCategory,
+                normalizedSubCategory,
             )
         );
     };
@@ -137,11 +152,53 @@ const MyTickets: React.FC = () => {
         async (id: string) => {
             setRefreshingTicketId(id);
 
-            await searchTicketsPaginatedApi(debouncedSearch, statusFilter === 'All' ? undefined : statusFilter, masterOnly ? true : undefined, page - 1, pageSize);
+            const user = getCurrentUserDetails();
+            const username = user?.username || user?.userId || '';
+            const userId = user?.userId || '';
+
+            let statusParam: string | undefined = statusFilter === 'All' ? undefined : statusFilter;
+            if (!statusParam && allowedStatuses.length > 0) {
+                statusParam = allowedStatuses.join(',');
+            }
+
+            await searchTicketsPaginatedApiHandler(() =>
+                searchTicketsPaginated(
+                    debouncedSearch,
+                    statusParam,
+                    masterOnly ? true : undefined,
+                    page - 1,
+                    pageSize,
+                    undefined,
+                    levelFilter,
+                    undefined,
+                    userId || undefined,
+                    sortBy,
+                    sortDirection,
+                    undefined,
+                    username || undefined,
+                    dateRangeParams.fromDate,
+                    dateRangeParams.toDate,
+                    normalizedCategory,
+                    normalizedSubCategory,
+                ),
+            );
             setRefreshingTicketId(null);
         },
-        [debouncedSearch, statusFilter, masterOnly, levelFilter, page, pageSize, sortBy, sortDirection, dateRangeParams.fromDate, dateRangeParams.toDate]
+        [debouncedSearch, statusFilter, masterOnly, levelFilter, page, pageSize, sortBy, sortDirection, dateRangeParams.fromDate, dateRangeParams.toDate, normalizedCategory, normalizedSubCategory, allowedStatuses]
     );
+
+    const handleCategoryChange = (value: string) => {
+        setSelectedCategory(value);
+        setSelectedSubCategory('All');
+        const categoryId = value === 'All' ? undefined : value;
+        loadSubCategories(categoryId);
+        setPage(1);
+    };
+
+    const handleSubCategoryChange = (value: string) => {
+        setSelectedSubCategory(value);
+        setPage(1);
+    };
 
     useEffect(() => {
         searchTicketsPaginatedApi(
@@ -161,7 +218,7 @@ const MyTickets: React.FC = () => {
             0,
             pageSize
         );
-    }, [debouncedSearch, statusFilter, masterOnly, levelFilter, pageSize, allowedStatuses, dateRangeParams.fromDate, dateRangeParams.toDate]);
+    }, [debouncedSearch, statusFilter, masterOnly, levelFilter, pageSize, allowedStatuses, dateRangeParams.fromDate, dateRangeParams.toDate, selectedCategory, selectedSubCategory]);
 
     useEffect(() => {
         const roles = getCurrentUserDetails()?.role || [];
@@ -224,6 +281,22 @@ const MyTickets: React.FC = () => {
                             onChange={setStatusFilter}
                             options={statusFilterOptions}
                             style={{ width: 180, marginRight: 8 }}
+                        />
+                    )}
+                    <DropdownController
+                        label="Category"
+                        value={selectedCategory}
+                        onChange={handleCategoryChange}
+                        options={categoryOptions}
+                        style={{ width: 200 }}
+                    />
+                    {selectedCategory !== 'All' && (
+                        <DropdownController
+                            label="Sub Category"
+                            value={selectedSubCategory}
+                            onChange={handleSubCategoryChange}
+                            options={subCategoryOptions}
+                            style={{ width: 220 }}
                         />
                     )}
                     <DateRangeFilter value={dateRange} onChange={setDateRange} />

--- a/ui/src/services/RootCauseAnalysisService.ts
+++ b/ui/src/services/RootCauseAnalysisService.ts
@@ -11,7 +11,16 @@ const extractPayload = (response: any): RootCauseAnalysis | null => {
   return (body ?? null) as RootCauseAnalysis | null;
 };
 
-export function getRootCauseAnalysisTickets(page: number, size: number, username: string, roles: string[], fromDate?: string, toDate?: string) {
+export function getRootCauseAnalysisTickets(
+  page: number,
+  size: number,
+  username: string,
+  roles: string[],
+  fromDate?: string,
+  toDate?: string,
+  categoryId?: string,
+  subCategoryId?: string,
+) {
   const params = new URLSearchParams({ page: String(page), size: String(size), username });
   roles.forEach((role) => params.append('roles', role));
   if (fromDate) {
@@ -19,6 +28,12 @@ export function getRootCauseAnalysisTickets(page: number, size: number, username
   }
   if (toDate) {
     params.append('toDate', toDate);
+  }
+  if (categoryId) {
+    params.append('categoryId', categoryId);
+  }
+  if (subCategoryId) {
+    params.append('subCategoryId', subCategoryId);
   }
   return axios.get(`${BASE_URL}/root-cause-analysis/tickets?${params.toString()}`);
 }

--- a/ui/src/services/TicketService.ts
+++ b/ui/src/services/TicketService.ts
@@ -84,7 +84,9 @@ export function searchTicketsPaginated(
     severity?: string,
     createdBy?: string,
     fromDate?: string,
-    toDate?: string
+    toDate?: string,
+    categoryId?: string,
+    subCategoryId?: string,
 ) {
     const params = new URLSearchParams({ query, page: String(page), size: String(size) });
     if (statusName) params.append('status', statusName);
@@ -99,5 +101,7 @@ export function searchTicketsPaginated(
     if (createdBy) params.append('createdBy', createdBy);
     if (fromDate) params.append('fromDate', fromDate);
     if (toDate) params.append('toDate', toDate);
+    if (categoryId) params.append('categoryId', categoryId);
+    if (subCategoryId) params.append('subCategoryId', subCategoryId);
     return axios.get(`${BASE_URL}/tickets/search?${params.toString()}`);
 }

--- a/ui/src/utils/authToken.ts
+++ b/ui/src/utils/authToken.ts
@@ -11,6 +11,15 @@ interface ExtendedJwtPayload extends JwtPayload {
   roles?: string[];
   levels?: string[];
   allowedStatusActionIds?: string[];
+  email?: string;
+  emailId?: string;
+  emailID?: string;
+  mail?: string;
+  contactNumber?: string;
+  contact?: string;
+  phone?: string;
+  mobile?: string;
+  mobileNo?: string;
 }
 
 let decodedCache: DecodedAuthDetails | null = null;
@@ -66,6 +75,8 @@ export function getDecodedAuthDetails(): DecodedAuthDetails | null {
       role: claims.roles ?? undefined,
       levels: claims.levels ?? undefined,
       name: claims.name ?? undefined,
+      email: claims.email ?? claims.emailId ?? claims.emailID ?? claims.mail ?? undefined,
+      phone: claims.phone ?? claims.contactNumber ?? claims.contact ?? claims.mobile ?? claims.mobileNo ?? undefined,
       allowedStatusActionIds: claims.allowedStatusActionIds ?? undefined,
     };
 


### PR DESCRIPTION
## Summary
- add a reusable hook for loading ticket categories and sub-categories
- surface category and sub-category dropdowns wherever the TicketsTable component is used
- include category filters in ticket search APIs and the RCA ticket fetcher
- persist user email and phone from login/token data so they appear in the logout menu

## Testing
- npm run build *(fails: Module not found: Error: Can't resolve 'i18next')*

------
https://chatgpt.com/codex/tasks/task_e_68df57a31e2c8332b02603e203a0e237