### PR TITLE
Add sub-category filter support to ticket search API

### DIFF
--- a/api/src/main/java/com/example/api/controller/TicketController.java
+++ b/api/src/main/java/com/example/api/controller/TicketController.java
@@ -164,14 +164,15 @@ public class TicketController {
             @RequestParam(required = false) String severity,
             @RequestParam(required = false) String createdBy,
             @RequestParam(required = false) String category,
+            @RequestParam(required = false) String subCategory,
             @RequestParam(required = false) String fromDate,
             @RequestParam(required = false) String toDate,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "id") String sortBy,
             @RequestParam(defaultValue = "ASC") String direction) {
-        logger.info("Request to search tickets query={} status={} master={} assignedTo={} assignedBy={} requestorId={} levelId={} priority={} severity={} createdBy={} category={} fromDate={} toDate={} page={} size={} sortBy={} direction={}",
-                query, statusId, master, assignedTo, assignedBy, requestorId, levelId, priority, severity, createdBy, category, fromDate, toDate, page, size, sortBy, direction);
+        logger.info("Request to search tickets query={} status={} master={} assignedTo={} assignedBy={} requestorId={} levelId={} priority={} severity={} createdBy={} category={} subCategory={} fromDate={} toDate={} page={} size={} sortBy={} direction={}",
+                query, statusId, master, assignedTo, assignedBy, requestorId, levelId, priority, severity, createdBy, category, subCategory, fromDate, toDate, page, size, sortBy, direction);
         Page<TicketDto> p = ticketService.searchTickets(
                 query,
                 statusId,
@@ -184,6 +185,7 @@ public class TicketController {
                 severity,
                 createdBy,
                 category,
+                subCategory,
                 fromDate,
                 toDate,
                 PageRequest.of(page, size, Sort.by(Sort.Direction.fromString(direction), sortBy))

--- a/api/src/main/java/com/example/api/repository/TicketRepository.java
+++ b/api/src/main/java/com/example/api/repository/TicketRepository.java
@@ -48,7 +48,8 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
             "AND (:levelId IS NULL OR t.levelId = :levelId) " +
             "AND (:priority IS NULL OR t.priority = :priority) " +
             "AND (:severities IS NULL OR t.severity IN (:severities)) " +
-            "AND (:category IS NULL OR t.category = :category)" +
+            "AND (:category IS NULL OR t.category = :category) " +
+            "AND (:subCategory IS NULL OR t.subCategory = :subCategory)" +
             "AND ((:assignedTo IS NULL AND :assignedBy IS NULL AND :requestorId IS NULL AND :createdBy IS NULL) " +
             "OR (:assignedTo IS NOT NULL AND LOWER(t.assignedTo) = LOWER(:assignedTo)) " +
             "OR (:assignedBy IS NOT NULL AND LOWER(t.assignedBy) = LOWER(:assignedBy)) " +
@@ -68,6 +69,7 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
                                @Param("severities") List<String> severities,
                                @Param("createdBy") String createdBy,
                                @Param("category") String category,
+                               @Param("subCategory") String subCategory,
                                @Param("fromDate") LocalDateTime fromDate,
                                @Param("toDate") LocalDateTime toDate,
                                Pageable pageable);

--- a/api/src/main/java/com/example/api/service/TicketService.java
+++ b/api/src/main/java/com/example/api/service/TicketService.java
@@ -265,7 +265,7 @@ public class TicketService {
 
     public Page<TicketDto> searchTickets(String query, String statusId, Boolean master,
                                          String assignedTo, String assignedBy, String requestorId, String levelId, String priority,
-                                         String severity, String createdBy, String category, String fromDate, String toDate, Pageable pageable) {
+                                         String severity, String createdBy, String category, String subCategory, String fromDate, String toDate, Pageable pageable) {
         ArrayList<String> statusIds = (statusId == null || statusId.isBlank())
                 ? null
                 : Arrays.stream(statusId.split(","))
@@ -279,7 +279,7 @@ public class TicketService {
                     .toList();
         LocalDateTime from = DateTimeUtils.parseToLocalDateTime(fromDate);
         LocalDateTime to = DateTimeUtils.parseToLocalDateTime(toDate);
-        Page<Ticket> page = ticketRepository.searchTickets(query, statusIds, master, assignedTo, assignedBy, requestorId, levelId, priority, severityFilters, createdBy, category, from, to, pageable);
+        Page<Ticket> page = ticketRepository.searchTickets(query, statusIds, master, assignedTo, assignedBy, requestorId, levelId, priority, severityFilters, createdBy, category, subCategory, from, to, pageable);
         return page.map(this::mapWithStatusId);
     }
 


### PR DESCRIPTION
## Summary
- allow the ticket search endpoint to accept an optional sub-category filter and include it in request logging
- propagate the sub-category filter through the ticket service layer
- update the ticket repository query to constrain results by sub-category when supplied

## Testing
- ./gradlew test *(fails: toolchain auto-provisioning is not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa2077b8c83329bc764c9a91f41a7