### PR TITLE
Refactor pagination controls to manage page size selection

### DIFF
--- a/ui/src/components/AllTickets/TicketsList.tsx
+++ b/ui/src/components/AllTickets/TicketsList.tsx
@@ -1,7 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { Chip, IconButton } from "@mui/material";
-import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
-import ArrowDropUpIcon from "@mui/icons-material/ArrowDropUp";
+import { Chip } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { useApi } from "../../hooks/useApi";
 import { useDebounce } from "../../hooks/useDebounce";
@@ -15,7 +13,6 @@ import TicketsTable, { TicketRow } from "./TicketsTable";
 import TicketCard from "./TicketCard";
 import ViewTicket from "./ViewTicket";
 import ViewToggle from "../UI/ViewToggle";
-import GenericInput from "../UI/Input/GenericInput";
 import DropdownController from "../UI/Dropdown/DropdownController";
 import { DropdownOption } from "../UI/Dropdown/GenericDropdown";
 import PaginationControls from "../PaginationControls";
@@ -487,30 +484,14 @@ const TicketsList: React.FC<TicketsListProps> = ({
                             onRcaClick={tableOptions?.onRcaClick}
                             permissionPathPrefix={tableOptions?.permissionPathPrefix ?? permissionPathPrefix}
                         />
-                        <div className="d-flex justify-content-between align-items-center mt-3">
-                            <PaginationControls page={page} totalPages={totalPages} onChange={(_, val) => setPage(val)} />
-                            <div className="d-flex align-items-center">
-                                <IconButton size="small" onClick={() => setTablePageSize(ps => ps > 1 ? ps - 1 : 1)}>
-                                    <ArrowDropDownIcon />
-                                </IconButton>
-                                <GenericInput
-                                    type="number"
-                                    value={tablePageSize}
-                                    onChange={(e) => {
-                                        const value = parseInt(e.target.value, 10);
-                                        if (!isNaN(value) && value > 0) {
-                                            setTablePageSize(value);
-                                        }
-                                    }}
-                                    size="small"
-                                    sx={{ width: 60, mx: 1 }}
-                                />
-                                <span>/ page</span>
-                                <IconButton size="small" onClick={() => setTablePageSize(ps => ps + 1)}>
-                                    <ArrowDropUpIcon />
-                                </IconButton>
-                            </div>
-                        </div>
+                        <PaginationControls
+                            className="justify-content-between align-items-center mt-3 w-100"
+                            page={page}
+                            totalPages={totalPages}
+                            onChange={(_, val) => setPage(val)}
+                            pageSize={tablePageSize}
+                            onPageSizeChange={(value) => setTablePageSize(value)}
+                        />
                     </div>
                 )}
                 {viewMode === "grid" && showGridPermission && (
@@ -529,30 +510,14 @@ const TicketsList: React.FC<TicketsListProps> = ({
                                 </div>
                             ))}
                         </div>
-                        <div className="d-flex justify-content-between align-items-center mt-3">
-                            <PaginationControls page={page} totalPages={totalPages} onChange={(_, val) => setPage(val)} />
-                            <div className="d-flex align-items-center">
-                                <IconButton size="small" onClick={() => setGridPageSize(ps => ps > 1 ? ps - 1 : 1)}>
-                                    <ArrowDropDownIcon />
-                                </IconButton>
-                                <GenericInput
-                                    type="number"
-                                    value={gridPageSize}
-                                    onChange={(e) => {
-                                        const value = parseInt(e.target.value, 10);
-                                        if (!isNaN(value) && value > 0) {
-                                            setGridPageSize(value);
-                                        }
-                                    }}
-                                    size="small"
-                                    sx={{ width: 60, mx: 1 }}
-                                />
-                                <span>/ page</span>
-                                <IconButton size="small" onClick={() => setGridPageSize(ps => ps + 1)}>
-                                    <ArrowDropUpIcon />
-                                </IconButton>
-                            </div>
-                        </div>
+                        <PaginationControls
+                            className="justify-content-between align-items-center mt-3 w-100"
+                            page={page}
+                            totalPages={totalPages}
+                            onChange={(_, val) => setPage(val)}
+                            pageSize={gridPageSize}
+                            onPageSizeChange={(value) => setGridPageSize(value)}
+                        />
                     </div>
                 )}
             </div>

--- a/ui/src/components/PaginationControls.tsx
+++ b/ui/src/components/PaginationControls.tsx
@@ -1,15 +1,85 @@
-import React from 'react';
-import { Pagination, PaginationItem } from '@mui/material';
+import React, { ChangeEvent, useCallback } from "react";
+import { IconButton, Pagination } from "@mui/material";
+import ArrowDropDownIcon from "@mui/icons-material/ArrowDropDown";
+import ArrowDropUpIcon from "@mui/icons-material/ArrowDropUp";
+import GenericInput from "./UI/Input/GenericInput";
 
 interface PaginationControlsProps {
     page: number;
     totalPages: number;
-    onChange: (event: React.ChangeEvent<unknown>, value: number) => void;
+    onChange: (event: ChangeEvent<unknown>, value: number) => void;
     className?: string;
+    pageSize?: number;
+    onPageSizeChange?: (value: number) => void;
+    pageSizeLabel?: string;
 }
 
-const PaginationControls: React.FC<PaginationControlsProps> = ({ page, totalPages, onChange, className }) => (
-    <Pagination count={totalPages} page={page} onChange={onChange} className={className} color="primary" />
-);
+const PaginationControls: React.FC<PaginationControlsProps> = ({
+    page,
+    totalPages,
+    onChange,
+    className,
+    pageSize,
+    onPageSizeChange,
+    pageSizeLabel = "/ page",
+}) => {
+    const handlePageSizeChange = useCallback(
+        (event: ChangeEvent<HTMLInputElement>) => {
+            if (!onPageSizeChange) {
+                return;
+            }
+
+            const value = parseInt(event.target.value, 10);
+            if (!Number.isNaN(value) && value > 0) {
+                onPageSizeChange(value);
+            }
+        },
+        [onPageSizeChange],
+    );
+
+    const decreasePageSize = useCallback(() => {
+        if (!onPageSizeChange || typeof pageSize !== "number") {
+            return;
+        }
+
+        onPageSizeChange(Math.max(1, pageSize - 1));
+    }, [onPageSizeChange, pageSize]);
+
+    const increasePageSize = useCallback(() => {
+        if (!onPageSizeChange || typeof pageSize !== "number") {
+            return;
+        }
+
+        onPageSizeChange(pageSize + 1);
+    }, [onPageSizeChange, pageSize]);
+
+    const containerClasses = ["d-flex align-items-center", className]
+        .filter(Boolean)
+        .join(" ");
+
+    return (
+        <div className={containerClasses}>
+            <Pagination count={totalPages} page={page} onChange={onChange} color="primary" />
+            {typeof pageSize === "number" && onPageSizeChange && (
+                <div className="d-flex align-items-center ms-3">
+                    <IconButton size="small" onClick={decreasePageSize}>
+                        <ArrowDropDownIcon />
+                    </IconButton>
+                    <GenericInput
+                        type="number"
+                        value={pageSize}
+                        onChange={handlePageSizeChange}
+                        size="small"
+                        sx={{ width: 60, mx: 1 }}
+                    />
+                    <span>{pageSizeLabel}</span>
+                    <IconButton size="small" onClick={increasePageSize}>
+                        <ArrowDropUpIcon />
+                    </IconButton>
+                </div>
+            )}
+        </div>
+    );
+};
 
 export default PaginationControls;


### PR DESCRIPTION
## Summary
- extend the shared PaginationControls component to manage optional page-size inputs and increment/decrement logic
- update TicketsList to delegate both table and grid page-size controls to the shared pagination component

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfac8e5e648332bc0dc6ed42401a06