### PR TITLE
Add developer login shortcut

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { JSX } from 'react';
+import React, { JSX, useContext } from 'react';
 import './App.css';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import RaiseTicket from './pages/RaiseTicket';
@@ -12,6 +12,7 @@ import RoleMaster from './pages/RoleMaster';
 import RoleDetails from './pages/RoleDetails';
 import SidebarLayout from './components/Layout/SidebarLayout';
 import Login from './pages/Login';
+import DevLogin from './pages/DevLogin';
 import MyTickets from './pages/MyTickets';
 import MyWorkload from './pages/MyWorkload';
 import Faq from './pages/Faq';
@@ -19,6 +20,7 @@ import FaqForm from './pages/FaqForm';
 import RootCauseAnalysis from './pages/RootCauseAnalysis';
 import { getUserDetails, getUserPermissions } from './utils/Utils';
 import { NotificationProvider } from './context/NotificationContext';
+import { DevModeContext } from './context/DevModeContext';
 
 const RequireAuth: React.FC<{ children: JSX.Element }> = ({ children }) => {
   const user = getUserDetails();
@@ -29,10 +31,15 @@ const RequireAuth: React.FC<{ children: JSX.Element }> = ({ children }) => {
   return children;
 };
 
+const LoginRoute: React.FC = () => {
+  const { devMode } = useContext(DevModeContext);
+  return devMode ? <DevLogin /> : <Login />;
+};
+
 function App() {
   return (
     <Routes>
-      <Route path="/login" element={<Login />} />
+      <Route path="/login" element={<LoginRoute />} />
       <Route
         path="/"
         element={(

--- a/ui/src/pages/DevLogin.tsx
+++ b/ui/src/pages/DevLogin.tsx
@@ -1,0 +1,290 @@
+import { FC, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import DeveloperModeIcon from "@mui/icons-material/DeveloperMode";
+import CircularProgress from "@mui/material/CircularProgress";
+import { DevModeContext } from "../context/DevModeContext";
+import { useSnackbar } from "../context/SnackbarContext";
+import { getAllUsers } from "../services/UserService";
+import { getRoleSummaries, getRolePermission } from "../services/RoleService";
+import { setPermissions } from "../utils/permissions";
+import { RoleLookupItem, setRoleLookup, setUserDetails } from "../utils/Utils";
+import { RolePermission, UserDetails } from "../types/auth";
+
+interface ApiUser {
+    userId?: string;
+    username?: string;
+    name?: string;
+    role?: string | string[];
+    roles?: string[];
+    [key: string]: any;
+}
+
+const normalizeResponse = <T,>(response: any, fallback: T): T => {
+    const raw = response?.data ?? response ?? fallback;
+    const body = raw?.body ?? raw;
+    const data = body?.data ?? body;
+    return (data ?? fallback) as T;
+};
+
+const DevLogin: FC = () => {
+    const navigate = useNavigate();
+    const { showMessage } = useSnackbar();
+    const { devMode, toggleDevMode, jwtBypass, setJwtBypass } = useContext(DevModeContext);
+    const [users, setUsers] = useState<ApiUser[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [loadingPermission, setLoadingPermission] = useState(false);
+    const roleLookupLoaded = useRef(false);
+
+    const loadRoleLookup = useCallback(async () => {
+        if (roleLookupLoaded.current) {
+            return;
+        }
+
+        try {
+            const response = await getRoleSummaries();
+            const payload = normalizeResponse<RoleLookupItem[]>(response, []);
+            if (Array.isArray(payload)) {
+                const normalized = payload
+                    .map((item: any) => ({
+                        roleId: item?.roleId ?? item?.role_id ?? item?.id,
+                        role: item?.role ?? item?.roleName ?? item?.name ?? "",
+                    }))
+                    .filter((item) => item.roleId != null && item.role);
+                setRoleLookup(normalized);
+            }
+            roleLookupLoaded.current = true;
+        } catch (error) {
+            console.error("Failed to load role summaries", error);
+        }
+    }, []);
+
+    const loadUsers = useCallback(async () => {
+        setLoading(true);
+        try {
+            const response = await getAllUsers();
+            const payload = normalizeResponse<ApiUser[]>(response, []);
+            if (Array.isArray(payload)) {
+                setUsers(payload);
+            } else {
+                setUsers([]);
+            }
+        } catch (error: any) {
+            console.error("Failed to load users", error);
+            const message = error?.response?.data?.message
+                || error?.message
+                || "Unable to load users";
+            showMessage(message, "error");
+        } finally {
+            setLoading(false);
+        }
+    }, [showMessage]);
+
+    useEffect(() => {
+        if (!devMode) {
+            navigate("/login", { replace: true });
+            return;
+        }
+
+        document.title = "Developer Login";
+        if (!jwtBypass) {
+            setJwtBypass(true);
+        }
+
+        void loadUsers();
+        void loadRoleLookup();
+    }, [devMode, jwtBypass, loadUsers, loadRoleLookup, navigate, setJwtBypass]);
+
+    const primaryRole = useCallback((user: ApiUser): string | undefined => {
+        if (Array.isArray(user.role) && user.role.length > 0) {
+            return String(user.role[0]);
+        }
+        if (Array.isArray(user.roles) && user.roles.length > 0) {
+            return String(user.roles[0]);
+        }
+        if (typeof user.role === "string") {
+            return user.role;
+        }
+        return undefined;
+    }, []);
+
+    const sortedUsers = useMemo(() => {
+        return [...users].sort((a, b) => {
+            const roleA = (primaryRole(a) || "").toLowerCase();
+            const roleB = (primaryRole(b) || "").toLowerCase();
+            if (roleA === roleB) {
+                const nameA = (a.username || a.name || a.userId || "").toLowerCase();
+                const nameB = (b.username || b.name || b.userId || "").toLowerCase();
+                return nameA.localeCompare(nameB);
+            }
+            return roleA.localeCompare(roleB);
+        });
+    }, [users, primaryRole]);
+
+    const handleUserSelection = useCallback(async (user: ApiUser) => {
+        const userId = user.userId || user.username || user.name;
+        if (!userId) {
+            showMessage("Unable to determine user id", "error");
+            return;
+        }
+
+        setLoadingPermission(true);
+        try {
+            const details: UserDetails = {
+                userId: String(userId),
+                username: user.username ?? user.name ?? String(userId),
+                role: Array.isArray(user.role)
+                    ? user.role.map(String)
+                    : Array.isArray(user.roles)
+                        ? user.roles.map(String)
+                        : user.role
+                            ? [String(user.role)]
+                            : [],
+                levels: Array.isArray(user.levels) ? user.levels.map(String) : [],
+                name: user.name ?? user.username ?? undefined,
+                email: user.email ?? undefined,
+                phone: user.phone ?? user.contactNumber ?? undefined,
+                allowedStatusActionIds: Array.isArray(user.allowedStatusActionIds)
+                    ? user.allowedStatusActionIds.map(String)
+                    : [],
+            };
+
+            setUserDetails(details);
+
+            const role = primaryRole(user);
+            if (role) {
+                try {
+                    const response = await getRolePermission(role);
+                    const payload = normalizeResponse<RolePermission | null>(response, null);
+                    if (payload) {
+                        setPermissions(payload);
+                    } else {
+                        setPermissions({} as RolePermission);
+                    }
+                } catch (error) {
+                    console.error("Failed to load permissions for role", role, error);
+                    setPermissions({} as RolePermission);
+                }
+            } else {
+                setPermissions({} as RolePermission);
+            }
+
+            navigate("/");
+        } finally {
+            setLoadingPermission(false);
+        }
+    }, [navigate, primaryRole, showMessage]);
+
+    if (!devMode) {
+        return null;
+    }
+
+    return (
+        <div style={{ minHeight: "100vh", background: "#10131a", color: "#f0f3ff", padding: "2rem" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "2rem" }}>
+                <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
+                    <DeveloperModeIcon style={{ fontSize: "2rem", color: "#90caf9" }} />
+                    <div>
+                        <h1 style={{ margin: 0, fontSize: "1.75rem" }}>Developer Login</h1>
+                        <p style={{ margin: 0, color: "#c5cae9" }}>Select a user to quickly sign in without hitting the auth service.</p>
+                    </div>
+                </div>
+                <button
+                    type="button"
+                    onClick={toggleDevMode}
+                    style={{
+                        background: "transparent",
+                        border: "1px solid #90caf9",
+                        color: "#90caf9",
+                        padding: "0.5rem 1rem",
+                        borderRadius: "999px",
+                        cursor: "pointer",
+                        fontWeight: 600,
+                        letterSpacing: "0.05em",
+                    }}
+                >
+                    Exit Dev Mode
+                </button>
+            </div>
+            <div style={{ marginBottom: "1.5rem", color: "#90caf9" }}>
+                {jwtBypass ? "JWT bypass is enabled for session storage login." : "JWT bypass was forced on for dev login."}
+            </div>
+            {loading ? (
+                <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minHeight: "40vh" }}>
+                    <CircularProgress style={{ color: "#90caf9" }} />
+                </div>
+            ) : (
+                <div
+                    style={{
+                        display: "grid",
+                        gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+                        gap: "1.25rem",
+                    }}
+                >
+                    {sortedUsers.map((user) => {
+                        const role = primaryRole(user) ?? "Unknown";
+                        const username = user.username ?? user.name ?? user.userId ?? "";
+                        return (
+                            <button
+                                key={`${user.userId ?? user.username ?? username}`}
+                                onClick={() => void handleUserSelection(user)}
+                                style={{
+                                    textAlign: "left",
+                                    border: "1px solid rgba(144, 202, 249, 0.4)",
+                                    borderRadius: "12px",
+                                    background: "rgba(13, 71, 161, 0.25)",
+                                    padding: "1.25rem",
+                                    cursor: "pointer",
+                                    color: "inherit",
+                                    boxShadow: "0 10px 25px rgba(0,0,0,0.2)",
+                                    transition: "transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease",
+                                }}
+                                onMouseOver={(e) => {
+                                    e.currentTarget.style.transform = "translateY(-4px)";
+                                    e.currentTarget.style.boxShadow = "0 14px 30px rgba(0,0,0,0.3)";
+                                    e.currentTarget.style.borderColor = "#90caf9";
+                                }}
+                                onMouseOut={(e) => {
+                                    e.currentTarget.style.transform = "translateY(0)";
+                                    e.currentTarget.style.boxShadow = "0 10px 25px rgba(0,0,0,0.2)";
+                                    e.currentTarget.style.borderColor = "rgba(144, 202, 249, 0.4)";
+                                }}
+                            >
+                                <div style={{ fontSize: "0.85rem", textTransform: "uppercase", color: "#90caf9", letterSpacing: "0.08em" }}>
+                                    {role}
+                                </div>
+                                <div style={{ fontSize: "1.3rem", fontWeight: 600, marginTop: "0.5rem" }}>
+                                    {username}
+                                </div>
+                            </button>
+                        );
+                    })}
+                    {!loading && sortedUsers.length === 0 && (
+                        <div style={{ gridColumn: "1 / -1", textAlign: "center", color: "#c5cae9" }}>
+                            No users available.
+                        </div>
+                    )}
+                </div>
+            )}
+            {loadingPermission && (
+                <div
+                    style={{
+                        position: "fixed",
+                        inset: 0,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        background: "rgba(10, 14, 25, 0.65)",
+                        zIndex: 1000,
+                    }}
+                >
+                    <div style={{ padding: "1.5rem 2rem", background: "#0d1b2a", borderRadius: "12px", textAlign: "center", color: "#f0f3ff" }}>
+                        <CircularProgress size={32} style={{ color: "#90caf9", marginBottom: "1rem" }} />
+                        <div>Fetching permissions & preparing session…</div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default DevLogin;

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -7,6 +7,7 @@ import { useApi } from "../hooks/useApi";
 import { DevModeContext } from "../context/DevModeContext";
 import PersonIcon from "@mui/icons-material/Person";
 import LockIcon from "@mui/icons-material/Lock";
+import DeveloperModeIcon from "@mui/icons-material/DeveloperMode";
 import { getRoleSummaries } from "../services/RoleService";
 import { storeToken, getDecodedAuthDetails } from "../utils/authToken";
 import { RolePermission, UserDetails } from "../types/auth";
@@ -124,7 +125,7 @@ const Login: FC = () => {
     const [themeIdx, setThemeIdx] = useState(0);
     const [selectedPortal, setSelectedPortal] = useState<PortalType | null>(null);
     const navigate = useNavigate();
-    const { devMode, jwtBypass, toggleJwtBypass } = useContext(DevModeContext);
+    const { devMode, jwtBypass, toggleJwtBypass, toggleDevMode } = useContext(DevModeContext);
 
     const { data: loginData, error: loginError, apiHandler: loginApiHandler } = useApi<LoginResponse>();
 
@@ -231,6 +232,33 @@ const Login: FC = () => {
 
     const errorMessage = useMemo(() => (loginError ? String(loginError) : undefined), [loginError]);
 
+    const devModeToggle = (
+        <button
+            type="button"
+            onClick={toggleDevMode}
+            title={devMode ? "Disable developer mode" : "Enable developer mode"}
+            style={{
+                position: "fixed",
+                top: "20px",
+                right: "20px",
+                width: "44px",
+                height: "44px",
+                borderRadius: "50%",
+                border: "none",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                background: devMode ? "#1b5e20" : "rgba(0,0,0,0.65)",
+                color: "#fff",
+                boxShadow: "0 6px 20px rgba(0,0,0,0.2)",
+                cursor: "pointer",
+                zIndex: 10,
+            }}
+        >
+            <DeveloperModeIcon />
+        </button>
+    );
+
     const bypassToggle = (
         <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "0.5rem" }}>
             <label style={{ display: "flex", alignItems: "center", gap: "0.5rem", cursor: "pointer" }}>
@@ -315,11 +343,17 @@ const Login: FC = () => {
     );
 
     if (!selectedPortal) {
-        return renderPortalSelection();
+        return (
+            <>
+                {devModeToggle}
+                {renderPortalSelection()}
+            </>
+        );
     }
 
     return (
         <>
+            {devModeToggle}
             {renderTheme()}
             {devMode && (
                 <div style={{ position: "fixed", bottom: "20px", width: "100%", display: "flex", justifyContent: "space-between", padding: "0 20px" }}>


### PR DESCRIPTION
## Summary
- add a dedicated DevLogin page that lists all users in sortable cards and allows one-click sign-in during dev mode
- wire the router to load the developer login experience whenever dev mode is enabled and surface a dev toggle on the standard login screen
- persist role lookups and permissions when selecting a user so the session mirrors a normal login

## Testing
- npm run build *(fails: react-scripts not installed because dependencies are unresolved in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e166d4a5108332b44108ce0b4a2fba