### PR TITLE
Add role names to user DTO responses

### DIFF
--- a/api/src/main/java/com/example/api/dto/UserDto.java
+++ b/api/src/main/java/com/example/api/dto/UserDto.java
@@ -15,6 +15,7 @@ public class UserDto {
     private String mobileNo;
     private String office;
     private String roles;
+    private List<String> roleNames;
     private String stakeholder;
     private String stakeholderId;
     private List<String> levels;


### PR DESCRIPTION
## Summary
- add a `roleNames` field to `UserDto` so clients receive role names along with ids
- resolve user role names via `RoleRepository` when mapping entities to DTOs

## Testing
- ./gradlew test *(fails: required Java 17 toolchain is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e16a520400833283c65237d37178af