### PR TITLE
Update permission chip to reflect child selection state

### DIFF
--- a/ui/src/components/Permissions/components/AllChildrenChip.tsx
+++ b/ui/src/components/Permissions/components/AllChildrenChip.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Chip } from '@mui/material';
+
+export type AllChildrenState = 'neutral' | 'all' | 'none';
+
+interface AllChildrenChipProps {
+    state: AllChildrenState;
+    onClick: () => void;
+    disabled?: boolean;
+}
+
+const getChipConfig = (state: AllChildrenState): { color: 'default' | 'success' | 'error'; variant: 'filled' | 'outlined' } => {
+    switch (state) {
+        case 'all':
+            return { color: 'success', variant: 'filled' };
+        case 'none':
+            return { color: 'error', variant: 'filled' };
+        default:
+            return { color: 'default', variant: 'outlined' };
+    }
+};
+
+const AllChildrenChip: React.FC<AllChildrenChipProps> = ({ state, onClick, disabled = false }) => {
+    const chipConfig = getChipConfig(state);
+
+    return (
+        <Chip
+            size="small"
+            label="All children"
+            color={chipConfig.color}
+            variant={chipConfig.variant}
+            onClick={onClick}
+            disabled={disabled}
+            className="text-capitalize"
+        />
+    );
+};
+
+export default AllChildrenChip;


### PR DESCRIPTION
## Summary
- derive the All children chip state from the current subtree selection so it mirrors the checked children
- introduce a reusable AllChildrenChip component and replace inline layouts with Bootstrap utility classes for cleaner styling

## Testing
- npm run build *(fails: Module not found: Error: Can't resolve 'react-i18next')*

------
https://chatgpt.com/codex/tasks/task_e_68e2434a84c08332889a5108d739ae7c