### PR TITLE
Add Typesense master ticket APIs and paginate link modal

### DIFF
--- a/api/src/main/java/com/example/api/controller/TicketController.java
+++ b/api/src/main/java/com/example/api/controller/TicketController.java
@@ -2,6 +2,8 @@ package com.example.api.controller;
 
 import com.example.api.dto.PaginationResponse;
 import com.example.api.dto.TicketDto;
+import com.example.api.dto.TypesenseTicketDto;
+import com.example.api.dto.TypesenseTicketPageResponse;
 import com.example.api.models.Ticket;
 import com.example.api.models.TicketComment;
 import com.example.api.models.TicketSla;
@@ -217,6 +219,25 @@ public class TicketController {
         SearchResult result = ticketService.search(query);
         logger.info("Search result returned, status {}", HttpStatus.OK);
         return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/master/typesense")
+    public ResponseEntity<List<TypesenseTicketDto>> getTypesenseMasterTickets() {
+        logger.info("Request to fetch all master tickets from Typesense");
+        List<TypesenseTicketDto> tickets = ticketService.getAllMasterTicketsFromTypesense();
+        logger.info("Returning {} master tickets from Typesense", tickets.size());
+        return ResponseEntity.ok(tickets);
+    }
+
+    @GetMapping("/master/typesense/page")
+    public ResponseEntity<TypesenseTicketPageResponse> getTypesenseMasterTicketsPage(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        logger.info("Request to fetch master tickets from Typesense page={} size={}", page, size);
+        TypesenseTicketPageResponse response = ticketService.getMasterTicketsPageFromTypesense(page, size);
+        logger.info("Returning {} master tickets from Typesense with totalFound={} totalPages={}",
+                response.getTickets().size(), response.getTotalFound(), response.getTotalPages());
+        return ResponseEntity.ok(response);
     }
 
     @PutMapping("/{id}/link/{masterId}")

--- a/api/src/main/java/com/example/api/dto/TypesenseTicketDto.java
+++ b/api/src/main/java/com/example/api/dto/TypesenseTicketDto.java
@@ -1,0 +1,13 @@
+package com.example.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TypesenseTicketDto {
+    private String id;
+    private String subject;
+}

--- a/api/src/main/java/com/example/api/dto/TypesenseTicketPageResponse.java
+++ b/api/src/main/java/com/example/api/dto/TypesenseTicketPageResponse.java
@@ -1,0 +1,18 @@
+package com.example.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TypesenseTicketPageResponse {
+    private List<TypesenseTicketDto> tickets;
+    private int page;
+    private int size;
+    private long totalFound;
+    private int totalPages;
+}

--- a/ui/src/components/RaiseTicket/LinkToMasterTicketModal.tsx
+++ b/ui/src/components/RaiseTicket/LinkToMasterTicketModal.tsx
@@ -1,11 +1,9 @@
-import { Box, Modal, Tooltip } from "@mui/material";
-import React, { useEffect, useState } from "react";
-import GenericButton from "../UI/Button";
-import LinkIcon from '@mui/icons-material/Link';
+import { Box, Modal, Tooltip, Pagination } from "@mui/material";
+import React, { useCallback, useEffect, useState } from "react";
 import CustomIconButton from "../UI/IconButton/CustomIconButton";
 import CustomFieldset from "../CustomFieldset";
 import { useDebounce } from "../../hooks/useDebounce";
-import { searchTickets, getTicket, linkTicketToMaster, makeTicketMaster } from "../../services/TicketService";
+import { searchTickets, getTicket, linkTicketToMaster, makeTicketMaster, getTypesenseMasterTicketsPaginated } from "../../services/TicketService";
 import GenericInput from "../UI/Input/GenericInput";
 
 interface LinkToMasterTicketModalProps {
@@ -19,13 +17,24 @@ interface TicketHit {
     document: {
         subject: string;
         id: string;
-        // add other fields if needed
     };
 }
 
+interface MasterTicket {
+    id: string;
+    subject?: string;
+}
+
+const PAGE_SIZE = 10;
+
 const LinkToMasterTicketModal: React.FC<LinkToMasterTicketModalProps> = ({ open, onClose }) => {
     const [query, setQuery] = useState('');
-    const [results, setResults] = useState<TicketHit[]>([]);
+    const [searchResults, setSearchResults] = useState<MasterTicket[]>([]);
+    const [paginatedTickets, setPaginatedTickets] = useState<MasterTicket[]>([]);
+    const [page, setPage] = useState(0);
+    const [totalPages, setTotalPages] = useState(0);
+    const [isPaginatedLoading, setIsPaginatedLoading] = useState(false);
+    const [paginatedError, setPaginatedError] = useState<string | null>(null);
     const [selected, setSelected] = useState<any | null>(null);
     const [linked, setLinked] = useState(false);
     const [conversionInProgress, setConversionInProgress] = useState(false);
@@ -35,28 +44,68 @@ const LinkToMasterTicketModal: React.FC<LinkToMasterTicketModalProps> = ({ open,
 
     let debouncedQuery = useDebounce(query, 500);
 
+    const fetchPaginatedTickets = useCallback((pageIndex: number) => {
+        setIsPaginatedLoading(true);
+        setPaginatedError(null);
+        getTypesenseMasterTicketsPaginated(pageIndex, PAGE_SIZE)
+            .then((response) => {
+                const rawPayload = response?.data ?? response;
+                const payload = rawPayload?.body?.data ?? rawPayload;
+                const tickets: MasterTicket[] = (payload?.tickets ?? []).map((ticket: any) => ({
+                    id: ticket.id,
+                    subject: ticket.subject,
+                }));
+                setPaginatedTickets(tickets);
+                setTotalPages(payload?.totalPages ?? 0);
+                setPage(payload?.page ?? pageIndex);
+            })
+            .catch(() => {
+                setPaginatedError('Failed to load master tickets');
+                setPaginatedTickets([]);
+                setTotalPages(0);
+            })
+            .finally(() => {
+                setIsPaginatedLoading(false);
+            });
+    }, []);
+
     useEffect(() => {
         if (open) {
             setQuery('');
-            setResults([]);
+            setSearchResults([]);
             setSelected(null);
             setLinked(false);
             setConversionError(null);
             setConversionInProgress(false);
+            setPaginatedTickets([]);
+            setPaginatedError(null);
+            setTotalPages(0);
+            setPage(0);
+            fetchPaginatedTickets(0);
         }
-    }, [open]);
+    }, [open, fetchPaginatedTickets]);
 
     useEffect(() => {
+        if (!open) {
+            return;
+        }
         if (debouncedQuery.length >= 2) {
             searchTickets(debouncedQuery).then((response) => {
                 const rawPayload = response?.data ?? response;
                 const payload = rawPayload?.body?.data ?? rawPayload;
-                setResults(payload?.hits || []);
+                const hits: TicketHit[] = payload?.hits || [];
+                const mappedResults = hits.map((ticket) => ({
+                    id: ticket.document.id,
+                    subject: ticket.document.subject,
+                }));
+                setSearchResults(mappedResults);
+            }).catch(() => {
+                setSearchResults([]);
             });
         } else {
-            setResults([]);
+            setSearchResults([]);
         }
-    }, [debouncedQuery])
+    }, [debouncedQuery, open])
 
 
     const handleSearch = (e: any) => {
@@ -72,7 +121,7 @@ const LinkToMasterTicketModal: React.FC<LinkToMasterTicketModalProps> = ({ open,
             setConversionError(null);
             setConversionInProgress(false);
             setQuery('');
-            setResults([]);
+            setSearchResults([]);
         });
     };
 
@@ -98,14 +147,18 @@ const LinkToMasterTicketModal: React.FC<LinkToMasterTicketModalProps> = ({ open,
         }
     };
 
-    let masterTicketsList = results.map(ticket => ({
-        label: ticket.document.subject,
-        value: ticket.document.id
-    }));
+    const isSearching = debouncedQuery.length >= 2;
+    const ticketsToDisplay = isSearching ? searchResults : paginatedTickets;
+
+    const handlePageChange = (_event: React.ChangeEvent<unknown>, value: number) => {
+        const nextPage = value - 1;
+        setPage(nextPage);
+        fetchPaginatedTickets(nextPage);
+    };
 
     return (
         <Modal open={open} onClose={onClose} >
-            <Box className="modal-box w-75 p-3">
+            <Box className="modal-box w-75 p-3" sx={{ maxHeight: '80vh', overflowY: 'auto' }}>
                 <h4 className="text-center mb-3">Link to Master Ticket</h4>
                 <GenericInput
                     className="w-100 mb-2"
@@ -114,15 +167,40 @@ const LinkToMasterTicketModal: React.FC<LinkToMasterTicketModalProps> = ({ open,
                     value={query}
                     onChange={handleSearch}
                 />
-                {masterTicketsList.map((hit) => (
-                    <div key={hit.value}
-                        className='d-flex border rounded-2 px-2 py-1 my-1'
-                        style={{ cursor: 'pointer' }}
-                        onClick={() => handleSelect(hit.value)}
-                    >
-                        <strong className='mx-1'>{hit.value}</strong> | {hit.label}
-                    </div>
-                ))}
+                <div className='mt-2' style={{ maxHeight: '45vh', overflowY: 'auto' }}>
+                    {isSearching && query.length >= 2 && ticketsToDisplay.length === 0 && (
+                        <p className='text-muted mb-2'>No tickets found for "{query}".</p>
+                    )}
+                    {!isSearching && isPaginatedLoading && (
+                        <p className='text-muted mb-2'>Loading master tickets...</p>
+                    )}
+                    {!isSearching && paginatedError && (
+                        <p className='text-danger mb-2'>{paginatedError}</p>
+                    )}
+                    {!isSearching && !isPaginatedLoading && !paginatedError && ticketsToDisplay.length === 0 && (
+                        <p className='text-muted mb-2'>No master tickets available.</p>
+                    )}
+                    {ticketsToDisplay.map((ticket) => (
+                        <div key={ticket.id}
+                            className='d-flex border rounded-2 px-2 py-1 my-1'
+                            style={{ cursor: 'pointer' }}
+                            onClick={() => handleSelect(ticket.id)}
+                        >
+                            <strong className='mx-1'>{ticket.id}</strong> | {ticket.subject || 'No subject'}
+                        </div>
+                    ))}
+                </div>
+                {!isSearching && totalPages > 1 && (
+                    <Box className='d-flex justify-content-center mt-2'>
+                        <Pagination
+                            count={totalPages}
+                            page={page + 1}
+                            onChange={handlePageChange}
+                            color="primary"
+                            shape="rounded"
+                        />
+                    </Box>
+                )}
                 {selected && (
                     <div className='position-relative mt-3 d-flex justify-content-between'>
                         <CustomFieldset

--- a/ui/src/services/TicketService.ts
+++ b/ui/src/services/TicketService.ts
@@ -32,6 +32,16 @@ export function getTicket(id: string) {
     return axios.get(`${BASE_URL}/tickets/${id}`);
 }
 
+export function getTypesenseMasterTickets() {
+    return axios.get(`${BASE_URL}/tickets/master/typesense`);
+}
+
+export function getTypesenseMasterTicketsPaginated(page: number = 0, size: number = 10) {
+    return axios.get(`${BASE_URL}/tickets/master/typesense/page`, {
+        params: { page, size }
+    });
+}
+
 export function getTicketSla(id: string) {
     return axios.get(`${BASE_URL}/tickets/${id}/sla`);
 }


### PR DESCRIPTION
## Summary
- add DTOs and controller endpoints to expose Typesense master ticket listings with and without pagination
- extend the Typesense client and service layer to support paginated ticket retrieval and document export mapping
- display paginated master ticket results in the link-to-master modal with scroll handling and new API hooks on the frontend

## Testing
- ./gradlew test *(fails: toolchain auto-provisioning not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e268820b3483329c6583fb7b0dd9b4