### PR TITLE
Handle initial Typesense sync without last synced timestamp

### DIFF
--- a/api/src/main/java/com/example/api/typesense/TypesenseClient.java
+++ b/api/src/main/java/com/example/api/typesense/TypesenseClient.java
@@ -95,7 +95,13 @@ public class TypesenseClient {
         System.out.println("Syncing only updated or new Master Tickets....");
 
         LocalDateTime lastSyncedTime = syncMetadataService.getLastSyncedTime();
-        List<Ticket> updatedOrNewMasterTickets = ticketRepository.findByLastModifiedAfter(lastSyncedTime);
+        List<Ticket> updatedOrNewMasterTickets;
+
+        if (lastSyncedTime == null) {
+            updatedOrNewMasterTickets = ticketRepository.findAll();
+        } else {
+            updatedOrNewMasterTickets = ticketRepository.findByLastModifiedAfter(lastSyncedTime);
+        }
         syncTicketsToTypesense(updatedOrNewMasterTickets);
 
         System.out.println("✅ Updated or New Master tickets synced to Typesense.");


### PR DESCRIPTION
## Summary
- retrieve the last synced time for Typesense ticket updates once per run
- perform a full ticket sync when no last synced time is recorded, otherwise sync incrementally

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2731df2848332a409b1842fa72b26