### PR TITLE
Allow ticket searches by id

### DIFF
--- a/api/src/main/java/com/example/api/typesense/TypesenseClient.java
+++ b/api/src/main/java/com/example/api/typesense/TypesenseClient.java
@@ -40,7 +40,7 @@ public class TypesenseClient {
 
         SearchParameters searchParameters = new SearchParameters()
                 .q(query)
-                .queryBy("subject");
+                .queryBy("id,subject");
 
         if (page != null) {
             searchParameters.page(page);


### PR DESCRIPTION
## Summary
- update the Typesense search query to include both ticket id and subject
- verified the collection schema already defines the id field as a searchable string

## Testing
- `./gradlew test` *(fails: Java 17 toolchain is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e27a53b57083329b411f8685763e41