### PR TITLE
Add configurable search engine for ticket search

### DIFF
--- a/api/src/main/java/com/example/api/controller/TicketController.java
+++ b/api/src/main/java/com/example/api/controller/TicketController.java
@@ -8,6 +8,7 @@ import com.example.api.models.Ticket;
 import com.example.api.models.TicketComment;
 import com.example.api.models.TicketSla;
 import com.example.api.service.TicketService;
+import com.example.api.dto.TicketSearchResultDto;
 import com.example.api.service.FileStorageService;
 import com.example.api.service.TicketSlaService;
 import lombok.AllArgsConstructor;
@@ -21,7 +22,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.web.multipart.MultipartFile;
-import org.typesense.model.SearchResult;
 import com.example.api.enums.TicketStatus;
 
 import java.io.IOException;
@@ -214,11 +214,11 @@ public class TicketController {
     }
 
     @PostMapping
-    public ResponseEntity<SearchResult> findTicketsBySearchQuery(@RequestBody String query) throws Exception {
+    public ResponseEntity<List<TicketSearchResultDto>> findTicketsBySearchQuery(@RequestBody String query) throws Exception {
         logger.info("Search tickets by query: {}", query);
-        SearchResult result = ticketService.search(query);
-        logger.info("Search result returned, status {}", HttpStatus.OK);
-        return ResponseEntity.ok(result);
+        List<TicketSearchResultDto> results = ticketService.search(query);
+        logger.info("Search result returned with {} entries, status {}", results.size(), HttpStatus.OK);
+        return ResponseEntity.ok(results);
     }
 
     @GetMapping("/master/typesense")

--- a/api/src/main/java/com/example/api/dto/TicketSearchResultDto.java
+++ b/api/src/main/java/com/example/api/dto/TicketSearchResultDto.java
@@ -1,0 +1,13 @@
+package com.example.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TicketSearchResultDto {
+    private String id;
+    private String subject;
+}

--- a/api/src/main/java/com/example/api/repository/TicketRepository.java
+++ b/api/src/main/java/com/example/api/repository/TicketRepository.java
@@ -27,6 +27,13 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
     Page<Ticket> findByPriority(String priority, Pageable pageable);
 
     @Query("SELECT t FROM Ticket t " +
+            "WHERE t.isMaster = true " +
+            "AND (t.masterId IS NULL OR t.masterId = '') " +
+            "AND (LOWER(t.subject) LIKE LOWER(CONCAT('%', :query, '%')) " +
+            "OR LOWER(t.id) LIKE LOWER(CONCAT('%', :query, '%')))")
+    List<Ticket> searchMasterTicketsBySubjectOrId(@Param("query") String query, Pageable pageable);
+
+    @Query("SELECT t FROM Ticket t " +
             "WHERE t.ticketStatus = :status " +
             "AND t.severity IS NOT NULL " +
             "AND LOWER(t.severity) IN (:severityTokens) " +

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -32,3 +32,4 @@ twilio.authToken=your_auth_token
 twilio.fromNumber=+1234567890
 app.developerMode=false
 file.storage.base-dir=uploads
+app.search.engine=default


### PR DESCRIPTION
## Summary
- add an app.search.engine property to toggle between default and Typesense master ticket searches
- expose a TicketSearchResultDto and update the ticket search endpoint to return id/subject pairs
- query either Typesense or the database for master tickets based on the configured search engine

## Testing
- ./gradlew test *(fails: Java 17 toolchain not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b956e8d88332aa7e29eff8bcf577