### PR TITLE
Fix TicketService constructor injection

### DIFF
--- a/api/src/main/java/com/example/api/service/TicketService.java
+++ b/api/src/main/java/com/example/api/service/TicketService.java
@@ -33,7 +33,7 @@ import com.example.api.typesense.TypesenseClient;
 import com.example.notification.enums.ChannelType;
 import com.example.notification.service.NotificationService;
 import com.example.api.util.DateTimeUtils;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.typesense.model.SearchResult;
@@ -49,7 +49,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 @Service
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class TicketService {
     private static final String TICKET_CREATED_NOTIFICATION_CODE = "TICKET_CREATED";
     private static final String TICKET_ASSIGNED_NOTIFICATION_CODE = "TICKET_ASSIGNED";


### PR DESCRIPTION
## Summary
- replace the all-args constructor on TicketService with RequiredArgsConstructor so only collaborators are injected
- allow the @Value-injected searchEngine property to remain field-injected, avoiding attempts to resolve a String bean

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation on your machine matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c2d0b5f08332b45dfe932418aa08