### PR TITLE
Remove Typesense master ticket API endpoints

### DIFF
--- a/api/src/main/java/com/example/api/controller/TicketController.java
+++ b/api/src/main/java/com/example/api/controller/TicketController.java
@@ -2,8 +2,6 @@ package com.example.api.controller;
 
 import com.example.api.dto.PaginationResponse;
 import com.example.api.dto.TicketDto;
-import com.example.api.dto.TypesenseTicketDto;
-import com.example.api.dto.TypesenseTicketPageResponse;
 import com.example.api.models.Ticket;
 import com.example.api.models.TicketComment;
 import com.example.api.models.TicketSla;
@@ -221,24 +219,6 @@ public class TicketController {
         return ResponseEntity.ok(results);
     }
 
-    @GetMapping("/master/typesense")
-    public ResponseEntity<List<TypesenseTicketDto>> getTypesenseMasterTickets() {
-        logger.info("Request to fetch all master tickets from Typesense");
-        List<TypesenseTicketDto> tickets = ticketService.getAllMasterTicketsFromTypesense();
-        logger.info("Returning {} master tickets from Typesense", tickets.size());
-        return ResponseEntity.ok(tickets);
-    }
-
-    @GetMapping("/master/typesense/page")
-    public ResponseEntity<TypesenseTicketPageResponse> getTypesenseMasterTicketsPage(
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size) {
-        logger.info("Request to fetch master tickets from Typesense page={} size={}", page, size);
-        TypesenseTicketPageResponse response = ticketService.getMasterTicketsPageFromTypesense(page, size);
-        logger.info("Returning {} master tickets from Typesense with totalFound={} totalPages={}",
-                response.getTickets().size(), response.getTotalFound(), response.getTotalPages());
-        return ResponseEntity.ok(response);
-    }
 
     @PutMapping("/{id}/link/{masterId}")
     public ResponseEntity<TicketDto> linkToMaster(@PathVariable String id, @PathVariable String masterId) {


### PR DESCRIPTION
## Summary
- remove the `/master/typesense` and `/master/typesense/page` endpoints from `TicketController`
- eliminate imports of Typesense DTOs from the controller to prevent exposing Typesense access via the API

## Testing
- `./gradlew test` *(fails: missing Java 17 toolchain in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c6eeee78833283daa24e167ff759