### PR TITLE
Enhance master ticket linking UI and master SLA display

### DIFF
--- a/ui/src/pages/RaiseTicket.tsx
+++ b/ui/src/pages/RaiseTicket.tsx
@@ -152,9 +152,16 @@ const RaiseTicket: React.FC<any> = () => {
                 {devMode && <CustomIconButton icon="formatColorFill" onClick={populateDummyTicketDetails} />}
                 <TicketDetails register={register} control={control} errors={errors} createMode attachments={attachments} setAttachments={setAttachments} />
 
-                {showLinkToMasterTicket && <div className="text-start">
-                    <GenericButton textKey="Link to a Master Ticket" variant="contained" onClick={onLinkToMasterTicketModalOpen} disabled={isMaster} />
-                </div>}
+                {showLinkToMasterTicket && (
+                    <div className="text-start d-flex align-items-center gap-2 flex-wrap">
+                        <GenericButton textKey="Link to a Master Ticket" variant="contained" onClick={onLinkToMasterTicketModalOpen} disabled={isMaster} />
+                        {masterId && (
+                            <span className="text-success">
+                                This ticket is linked to master ticket ID {masterId}
+                            </span>
+                        )}
+                    </div>
+                )}
                 {/* Submit Button */}
                 <div className="text-end mt-3">
                     <GenericButton textKey="Submit Ticket" variant="contained" type="submit" />
@@ -162,7 +169,7 @@ const RaiseTicket: React.FC<any> = () => {
             </form>
 
             {/* Link to Master Ticket Modal */}
-            <LinkToMasterTicketModal open={linkToMasterTicketModalOpen} onClose={onLinkToMasterTicketModalClose} setMasterId={setMasterId} subject={subject} />
+            <LinkToMasterTicketModal open={linkToMasterTicketModalOpen} onClose={onLinkToMasterTicketModalClose} setMasterId={setMasterId} subject={subject} masterId={masterId} />
             {/* Successful Modal */}
             <SuccessfulModal ticketId={createdTicketId ?? ''} open={successfullModalOpen} onClose={onClose} />
         </div>

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -48,6 +48,7 @@ export interface Ticket {
     priority: string;
     priorityId?: string;
     isMaster: boolean;
+    masterId?: string;
     userId?: string;
     requestorName?: string;
     requestorEmailId?: string;


### PR DESCRIPTION
## Summary
- convert the master ticket link action into a toggle with explicit Ok/Cancel controls in the modal
- show a message beside the link button when a master ticket is selected during ticket creation
- surface SLA details for a parent master ticket on child ticket views

## Testing
- npm test -- --watchAll=false *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68e2d355cde08332bf0744423a935bc5