### PR TITLE
Implement deterministic ticket ID generation

### DIFF
--- a/api/src/main/java/com/example/api/models/Ticket.java
+++ b/api/src/main/java/com/example/api/models/Ticket.java
@@ -17,7 +17,6 @@ import java.time.LocalDateTime;
 @Data
 public class Ticket {
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name="ticket_id")
     private String id;
     @Column(name="reported_date")

--- a/api/src/main/java/com/example/api/models/TicketSequence.java
+++ b/api/src/main/java/com/example/api/models/TicketSequence.java
@@ -1,0 +1,34 @@
+package com.example.api.models;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "ticket_sequences", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"mode_id", "sequence_date"})
+})
+@Getter
+@Setter
+@NoArgsConstructor
+public class TicketSequence {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "mode_id", nullable = false, length = 50)
+    private String modeId;
+
+    @Column(name = "sequence_date", nullable = false)
+    private LocalDate sequenceDate;
+
+    @Column(name = "last_value", nullable = false)
+    private long lastValue;
+
+    @Version
+    private long version;
+}

--- a/api/src/main/java/com/example/api/repository/TicketSequenceRepository.java
+++ b/api/src/main/java/com/example/api/repository/TicketSequenceRepository.java
@@ -1,0 +1,18 @@
+package com.example.api.repository;
+
+import com.example.api.models.TicketSequence;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.LockModeType;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Repository
+public interface TicketSequenceRepository extends JpaRepository<TicketSequence, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<TicketSequence> findByModeIdAndSequenceDate(String modeId, LocalDate sequenceDate);
+}

--- a/api/src/main/java/com/example/api/service/TicketIdGenerator.java
+++ b/api/src/main/java/com/example/api/service/TicketIdGenerator.java
@@ -1,0 +1,51 @@
+package com.example.api.service;
+
+import com.example.api.enums.Mode;
+import com.example.api.models.TicketSequence;
+import com.example.api.repository.TicketSequenceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Service
+@RequiredArgsConstructor
+public class TicketIdGenerator {
+
+    private static final String ID_PREFIX = "TKT";
+    private static final String UNKNOWN_MODE = "NA";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final TicketSequenceRepository ticketSequenceRepository;
+
+    @Transactional
+    public String generateTicketId(Mode mode) {
+        String modeId = resolveModeId(mode);
+        LocalDate today = LocalDate.now();
+
+        TicketSequence sequence = ticketSequenceRepository
+                .findByModeIdAndSequenceDate(modeId, today)
+                .orElseGet(() -> {
+                    TicketSequence created = new TicketSequence();
+                    created.setModeId(modeId);
+                    created.setSequenceDate(today);
+                    created.setLastValue(0);
+                    return created;
+                });
+
+        long nextValue = sequence.getLastValue() + 1;
+        sequence.setLastValue(nextValue);
+        ticketSequenceRepository.save(sequence);
+
+        return String.format("%s-%s-%s-%d", ID_PREFIX, modeId, DATE_FORMATTER.format(today), nextValue);
+    }
+
+    private String resolveModeId(Mode mode) {
+        if (mode == null) {
+            return UNKNOWN_MODE;
+        }
+        return mode.name().toUpperCase();
+    }
+}

--- a/api/src/main/java/com/example/api/service/TicketService.java
+++ b/api/src/main/java/com/example/api/service/TicketService.java
@@ -74,6 +74,7 @@ public class TicketService {
     private final StakeholderRepository stakeholderRepository;
     private final TicketSlaService ticketSlaService;
     private final RecommendedSeverityFlowRepository recommendedSeverityFlowRepository;
+    private final TicketIdGenerator ticketIdGenerator;
 
     public List<Ticket> getTickets() {
         System.out.println("Getting tickets...");
@@ -185,6 +186,10 @@ public class TicketService {
 
         if(ticket.isMaster()) ticket.setMasterId(null);
         if (ticket.getUpdatedBy() == null) ticket.setUpdatedBy(ticket.getAssignedBy());
+
+        if (ticket.getId() == null || ticket.getId().isBlank()) {
+            ticket.setId(ticketIdGenerator.generateTicketId(ticket.getMode()));
+        }
 
         // If userId exists
         if (ticket.getUserId() != null && !ticket.getUserId().isEmpty()) {

--- a/api/src/test/java/com/example/api/service/TicketIdGeneratorTest.java
+++ b/api/src/test/java/com/example/api/service/TicketIdGeneratorTest.java
@@ -1,0 +1,92 @@
+package com.example.api.service;
+
+import com.example.api.enums.Mode;
+import com.example.api.models.TicketSequence;
+import com.example.api.repository.TicketSequenceRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TicketIdGeneratorTest {
+
+    @Mock
+    private TicketSequenceRepository ticketSequenceRepository;
+
+    @InjectMocks
+    private TicketIdGenerator ticketIdGenerator;
+
+    @BeforeEach
+    void setUp() {
+        when(ticketSequenceRepository.save(any(TicketSequence.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
+
+    @Test
+    void generateTicketId_createsSequenceWhenMissing() {
+        when(ticketSequenceRepository.findByModeIdAndSequenceDate(eq("CALL"), any()))
+                .thenReturn(Optional.empty());
+
+        String id = ticketIdGenerator.generateTicketId(Mode.Call);
+
+        ArgumentCaptor<TicketSequence> sequenceCaptor = ArgumentCaptor.forClass(TicketSequence.class);
+        verify(ticketSequenceRepository).save(sequenceCaptor.capture());
+
+        TicketSequence savedSequence = sequenceCaptor.getValue();
+        String expectedDate = savedSequence.getSequenceDate().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        assertThat(savedSequence.getModeId()).isEqualTo("CALL");
+        assertThat(savedSequence.getLastValue()).isEqualTo(1);
+        assertThat(id).isEqualTo("TKT-CALL-" + expectedDate + "-1");
+    }
+
+    @Test
+    void generateTicketId_incrementsExistingSequence() {
+        TicketSequence existing = new TicketSequence();
+        existing.setModeId("EMAIL");
+        existing.setSequenceDate(java.time.LocalDate.now());
+        existing.setLastValue(5);
+        when(ticketSequenceRepository.findByModeIdAndSequenceDate(eq("EMAIL"), any()))
+                .thenReturn(Optional.of(existing));
+
+        String id = ticketIdGenerator.generateTicketId(Mode.Email);
+
+        ArgumentCaptor<TicketSequence> sequenceCaptor = ArgumentCaptor.forClass(TicketSequence.class);
+        verify(ticketSequenceRepository).save(sequenceCaptor.capture());
+
+        TicketSequence savedSequence = sequenceCaptor.getValue();
+        String expectedDate = savedSequence.getSequenceDate().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        assertThat(savedSequence.getModeId()).isEqualTo("EMAIL");
+        assertThat(savedSequence.getLastValue()).isEqualTo(6);
+        assertThat(id).isEqualTo("TKT-EMAIL-" + expectedDate + "-6");
+    }
+
+    @Test
+    void generateTicketId_usesFallbackWhenModeMissing() {
+        when(ticketSequenceRepository.findByModeIdAndSequenceDate(eq("NA"), any()))
+                .thenReturn(Optional.empty());
+
+        String id = ticketIdGenerator.generateTicketId(null);
+
+        ArgumentCaptor<TicketSequence> sequenceCaptor = ArgumentCaptor.forClass(TicketSequence.class);
+        verify(ticketSequenceRepository).save(sequenceCaptor.capture());
+
+        TicketSequence savedSequence = sequenceCaptor.getValue();
+        String expectedDate = savedSequence.getSequenceDate().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        assertThat(savedSequence.getModeId()).isEqualTo("NA");
+        assertThat(savedSequence.getLastValue()).isEqualTo(1);
+        assertThat(id).isEqualTo("TKT-NA-" + expectedDate + "-1");
+    }
+}

--- a/api/src/test/java/com/example/api/service/TicketServiceTest.java
+++ b/api/src/test/java/com/example/api/service/TicketServiceTest.java
@@ -59,6 +59,8 @@ class TicketServiceTest {
     private TicketSlaService ticketSlaService;
     @Mock
     private RecommendedSeverityFlowRepository recommendedSeverityFlowRepository;
+    @Mock
+    private TicketIdGenerator ticketIdGenerator;
 
     @InjectMocks
     private TicketService ticketService;


### PR DESCRIPTION
## Summary
- add a ticket sequence entity and repository to track per-mode daily counters
- introduce a TicketIdGenerator service and integrate it into TicketService for non-UUID IDs
- cover the generator with unit tests and update existing tests for the new dependency

## Testing
- ./gradlew test --console=plain *(fails: required JDK 17 toolchain is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2df47fa6c833293b1e09e5299a486