### PR TITLE
Filter My Tickets list for requestor users

### DIFF
--- a/ui/src/pages/MyTickets.tsx
+++ b/ui/src/pages/MyTickets.tsx
@@ -9,11 +9,13 @@ const MyTickets: React.FC = () => {
 
     const buildSearchOverrides = useCallback((_: TicketsListFilterState): TicketsListSearchOverrides => {
         const user = getCurrentUserDetails();
+        const roles = (user?.role || []).map(String);
         const username = user?.username || user?.userId || "";
         const userId = user?.userId || "";
+        const isRequestor = roles.includes("5");
 
         return {
-            requestorId: userId || undefined,
+            ...(isRequestor ? { requestorId: userId || undefined } : {}),
             createdBy: username || undefined,
         };
     }, []);


### PR DESCRIPTION
## Summary
- ensure the My Tickets page filters by the logged-in requestor's ID when the Requestor role is detected

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2e3bc901483329b542f86d725a528