### PR TITLE
Add child ticket API and UI linkage handling

### DIFF
--- a/api/src/main/java/com/example/api/controller/TicketController.java
+++ b/api/src/main/java/com/example/api/controller/TicketController.java
@@ -221,11 +221,30 @@ public class TicketController {
 
 
     @PutMapping("/{id}/link/{masterId}")
-    public ResponseEntity<TicketDto> linkToMaster(@PathVariable String id, @PathVariable String masterId) {
-        logger.info("Request to link ticket {} to master {}", id, masterId);
-        TicketDto dto = ticketService.linkToMaster(id, masterId);
-        logger.info("Ticket {} linked to master {}, returning {}", id, masterId, HttpStatus.OK);
+    public ResponseEntity<TicketDto> linkToMaster(@PathVariable String id,
+                                                  @PathVariable String masterId,
+                                                  @RequestParam(required = false) String updatedBy) {
+        logger.info("Request to link ticket {} to master {} by {}", id, masterId, updatedBy);
+        TicketDto dto = ticketService.linkToMaster(id, masterId, updatedBy);
+        logger.info("Ticket {} linked to master {} by {}, returning {}", id, masterId, updatedBy, HttpStatus.OK);
         return ResponseEntity.ok(dto);
+    }
+
+    @PutMapping("/{id}/unlink")
+    public ResponseEntity<TicketDto> unlinkFromMaster(@PathVariable String id,
+                                                      @RequestParam(required = false) String updatedBy) {
+        logger.info("Request to unlink ticket {} from its master by {}", id, updatedBy);
+        TicketDto dto = ticketService.unlinkFromMaster(id, updatedBy);
+        logger.info("Ticket {} unlinked from master by {}, returning {}", id, updatedBy, HttpStatus.OK);
+        return ResponseEntity.ok(dto);
+    }
+
+    @GetMapping("/{id}/children")
+    public ResponseEntity<List<TicketDto>> getChildTickets(@PathVariable String id) {
+        logger.info("Request to fetch child tickets for master {}", id);
+        List<TicketDto> children = ticketService.getChildTickets(id);
+        logger.info("Returning {} child tickets for master {} with status {}", children.size(), id, HttpStatus.OK);
+        return ResponseEntity.ok(children);
     }
 
     @PutMapping("/{id}/master")

--- a/api/src/main/java/com/example/api/repository/TicketRepository.java
+++ b/api/src/main/java/com/example/api/repository/TicketRepository.java
@@ -18,6 +18,8 @@ import java.util.List;
 public interface TicketRepository extends JpaRepository<Ticket, String> {
     public List<Ticket> findByIsMasterTrue();
 
+    List<Ticket> findByMasterId(String masterId);
+
     public List<Ticket> findByLastModifiedAfter(LocalDateTime lastSyncedTime);
 
     List<Ticket> findByTicketStatusAndLastModifiedBefore(TicketStatus ticketStatus, LocalDateTime time);

--- a/ui/src/components/RaiseTicket/LinkToMasterTicketModal.tsx
+++ b/ui/src/components/RaiseTicket/LinkToMasterTicketModal.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import CustomFieldset from "../CustomFieldset";
 import { useDebounce } from "../../hooks/useDebounce";
 import { searchTickets, getTicket, linkTicketToMaster, makeTicketMaster, searchTicketsPaginated } from "../../services/TicketService";
+import { getCurrentUserDetails } from "../../config/config";
 import GenericInput from "../UI/Input/GenericInput";
 
 interface LinkToMasterTicketModalProps {
@@ -41,6 +42,9 @@ const LinkToMasterTicketModal: React.FC<LinkToMasterTicketModalProps> = ({ open,
     const [linked, setLinked] = useState(false);
     const [conversionInProgress, setConversionInProgress] = useState(false);
     const [conversionError, setConversionError] = useState<string | null>(null);
+    const currentUser = getCurrentUserDetails();
+    const currentUsername = currentUser?.username || '';
+
     // TODO: replace with real current ticket details
     const currentTicket = { id: currentTicketId ?? '', subject: subject };
 
@@ -143,7 +147,7 @@ const LinkToMasterTicketModal: React.FC<LinkToMasterTicketModalProps> = ({ open,
         if (shouldLink) {
             if (currentTicketId) {
                 try {
-                    await linkTicketToMaster(currentTicketId, selected.id);
+                    await linkTicketToMaster(currentTicketId, selected.id, currentUsername || undefined);
                     setLinked(true);
                 } catch {
                     setLinked(false);

--- a/ui/src/components/Ticket/ChildTicketsTable.tsx
+++ b/ui/src/components/Ticket/ChildTicketsTable.tsx
@@ -1,0 +1,138 @@
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Box, Tooltip } from '@mui/material';
+import GenericTable from '../UI/GenericTable';
+import CustomIconButton from '../UI/IconButton/CustomIconButton';
+import { TicketRow } from '../AllTickets/TicketsTable';
+import { getStatusNameById, truncateWithEllipsis } from '../../utils/Utils';
+
+interface ChildTicketsTableProps {
+  tickets: TicketRow[];
+  loading: boolean;
+  unlinkingId?: string | null;
+  onView: (id: string) => void;
+  onUnlink: (id: string) => void;
+}
+
+const ChildTicketsTable: React.FC<ChildTicketsTableProps> = ({
+  tickets,
+  loading,
+  unlinkingId,
+  onView,
+  onUnlink,
+}) => {
+  const { t } = useTranslation();
+
+  const columns = useMemo(
+    () => [
+      {
+        title: t('Ticket Id'),
+        dataIndex: 'id',
+        key: 'id',
+        ellipsis: true,
+        render: (_: unknown, record: TicketRow) => (
+          <Tooltip title={record.id} placement="top">
+            <span
+              role="button"
+              tabIndex={0}
+              onClick={() => onView(record.id)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  event.preventDefault();
+                  onView(record.id);
+                }
+              }}
+              style={{ cursor: 'pointer', display: 'inline-flex', alignItems: 'center' }}
+            >
+              {truncateWithEllipsis(record.id, 10)}
+            </span>
+          </Tooltip>
+        ),
+      },
+      {
+        title: t('Subject'),
+        dataIndex: 'subject',
+        key: 'subject',
+        ellipsis: true,
+        render: (value: string) => (
+          <Tooltip title={value} placement="top">
+            <span>{truncateWithEllipsis(value ?? '-', 40)}</span>
+          </Tooltip>
+        ),
+      },
+      {
+        title: t('Category'),
+        dataIndex: 'category',
+        key: 'category',
+        ellipsis: true,
+        render: (_: unknown, record: TicketRow) => (
+          <span>{record.category && record.subCategory ? `${record.category} > ${record.subCategory}` : record.category || '-'}</span>
+        ),
+      },
+      {
+        title: t('Status'),
+        dataIndex: 'statusId',
+        key: 'status',
+        ellipsis: true,
+        render: (_: unknown, record: TicketRow) => {
+          const statusName = record.statusId ? getStatusNameById(record.statusId) : null;
+          return <span>{statusName || record.statusLabel || '-'}</span>;
+        },
+      },
+      {
+        title: t('Assigned To'),
+        dataIndex: 'assignedToName',
+        key: 'assignedTo',
+        ellipsis: true,
+        render: (_: unknown, record: TicketRow) => (
+          <span>{record.assignedToName || record.assignedTo || '-'}</span>
+        ),
+      },
+      {
+        title: t('Actions'),
+        key: 'actions',
+        width: 120,
+        render: (_: unknown, record: TicketRow) => (
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Tooltip title={t('View')}>
+              <span>
+                <CustomIconButton
+                  icon="visibility"
+                  size="small"
+                  onClick={() => onView(record.id)}
+                  aria-label={t('View ticket {{id}}', { id: record.id })}
+                />
+              </span>
+            </Tooltip>
+            <Tooltip title={t('Unlink')}>
+              <span>
+                <CustomIconButton
+                  icon="linkOff"
+                  size="small"
+                  onClick={() => onUnlink(record.id)}
+                  disabled={unlinkingId === record.id}
+                  aria-label={t('Unlink ticket {{id}}', { id: record.id })}
+                />
+              </span>
+            </Tooltip>
+          </Box>
+        ),
+      },
+    ],
+    [onUnlink, onView, t, unlinkingId]
+  );
+
+  return (
+    <GenericTable
+      className="tickets-table"
+      dataSource={tickets}
+      columns={columns as any}
+      rowKey="id"
+      pagination={false}
+      loading={loading}
+      locale={{ emptyText: t('No child tickets linked yet.') }}
+    />
+  );
+};
+
+export default ChildTicketsTable;

--- a/ui/src/components/UI/IconButton/CustomIconButton.tsx
+++ b/ui/src/components/UI/IconButton/CustomIconButton.tsx
@@ -46,6 +46,8 @@ import GradingIcon from '@mui/icons-material/Grading';
 import RateReviewIcon from '@mui/icons-material/RateReview';
 import { PauseCircleOutline, NorthEast, Moving, PersonAddAlt } from '@mui/icons-material';
 import WorkOutlineIcon from '@mui/icons-material/WorkOutline';
+import VisibilityIcon from '@mui/icons-material/Visibility';
+import LinkOffIcon from '@mui/icons-material/LinkOff';
 
 // Define the icon map
 const iconMap = {
@@ -98,6 +100,8 @@ const iconMap = {
     grading: GradingIcon,
     rateReview: RateReviewIcon,
     workOutline: WorkOutlineIcon,
+    visibility: VisibilityIcon,
+    linkOff: LinkOffIcon,
 };
 
 // Valid keys for the icon map

--- a/ui/src/services/TicketService.ts
+++ b/ui/src/services/TicketService.ts
@@ -40,12 +40,28 @@ export function updateTicket(id: string, payload: any) {
     return axios.put(`${BASE_URL}/tickets/${id}`, payload)
 }
 
-export function linkTicketToMaster(id: string, masterId: string) {
-    return axios.put(`${BASE_URL}/tickets/${id}/link/${masterId}`);
+export function linkTicketToMaster(id: string, masterId: string, updatedBy?: string) {
+    return axios.put(
+        `${BASE_URL}/tickets/${id}/link/${masterId}`,
+        null,
+        updatedBy ? { params: { updatedBy } } : undefined
+    );
 }
 
 export function makeTicketMaster(id: string) {
     return axios.put(`${BASE_URL}/tickets/${id}/master`);
+}
+
+export function unlinkTicketFromMaster(id: string, updatedBy?: string) {
+    return axios.put(
+        `${BASE_URL}/tickets/${id}/unlink`,
+        null,
+        updatedBy ? { params: { updatedBy } } : undefined
+    );
+}
+
+export function getChildTickets(masterId: string) {
+    return axios.get(`${BASE_URL}/tickets/${masterId}/children`);
 }
 
 export function addComment(id: string, comment: string) {


### PR DESCRIPTION
## Summary
- add backend endpoints to fetch master ticket children, link with validation, and unlink while recording history
- display child tickets on the ticket view with a master-ticket banner and unlink action
- update client services, icons, and linking modal to pass user context for the new APIs

## Testing
- `./gradlew test` *(fails: Java 17 toolchain not available in container)*
- `npm run build` *(fails: missing `i18next` dependency; installing conflicts with existing peer dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e3529b4e8c8332b191bec5cdf5df47