### PR TITLE
Fix ticket sequence inserts on MySQL by quoting identifiers

### DIFF
--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -16,6 +16,7 @@ spring.flyway.enabled=false
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+spring.jpa.properties.hibernate.globally_quoted_identifiers=true
 
 # Mail configuration
 spring.mail.host=smtp.example.com


### PR DESCRIPTION
## Summary
- enable global identifier quoting in Hibernate so generated SQL escapes reserved column names like `last_value`

## Testing
- ./gradlew test *(fails: local environment lacks the required Java 17 toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68e367af89ec8332a2f2ded32faaa0c3