### PR TITLE
Add backend and frontend test coverage

### DIFF
--- a/api/src/test/java/com/ticketingSystem/api/service/TicketServiceTypesenseTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/TicketServiceTypesenseTest.java
@@ -1,0 +1,163 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.dto.TypesenseTicketDto;
+import com.ticketingSystem.api.dto.TypesenseTicketPageResponse;
+import com.ticketingSystem.api.repository.CategoryRepository;
+import com.ticketingSystem.api.repository.PriorityRepository;
+import com.ticketingSystem.api.repository.RecommendedSeverityFlowRepository;
+import com.ticketingSystem.api.repository.StakeholderRepository;
+import com.ticketingSystem.api.repository.StatusHistoryRepository;
+import com.ticketingSystem.api.repository.StatusMasterRepository;
+import com.ticketingSystem.api.repository.SubCategoryRepository;
+import com.ticketingSystem.api.repository.TicketCommentRepository;
+import com.ticketingSystem.api.repository.TicketRepository;
+import com.ticketingSystem.api.repository.UploadedFileRepository;
+import com.ticketingSystem.api.repository.UserRepository;
+import com.ticketingSystem.api.typesense.TypesenseClient;
+import com.ticketingSystem.notification.service.NotificationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.typesense.model.SearchResult;
+import org.typesense.model.SearchResultHit;
+import org.typesense.model.SearchResultRequestParams;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TicketServiceTypesenseTest {
+
+    @Mock
+    private TypesenseClient typesenseClient;
+    @Mock
+    private TicketRepository ticketRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private TicketCommentRepository commentRepository;
+    @Mock
+    private AssignmentHistoryService assignmentHistoryService;
+    @Mock
+    private StatusHistoryService statusHistoryService;
+    @Mock
+    private StatusHistoryRepository statusHistoryRepository;
+    @Mock
+    private NotificationService notificationService;
+    @Mock
+    private TicketStatusWorkflowService workflowService;
+    @Mock
+    private StatusMasterRepository statusMasterRepository;
+    @Mock
+    private CategoryRepository categoryRepository;
+    @Mock
+    private SubCategoryRepository subCategoryRepository;
+    @Mock
+    private PriorityRepository priorityRepository;
+    @Mock
+    private UploadedFileRepository uploadedFileRepository;
+    @Mock
+    private StakeholderRepository stakeholderRepository;
+    @Mock
+    private TicketSlaService ticketSlaService;
+    @Mock
+    private RecommendedSeverityFlowRepository recommendedSeverityFlowRepository;
+    @Mock
+    private TicketIdGenerator ticketIdGenerator;
+
+    private TicketService ticketService;
+
+    @BeforeEach
+    void setUp() {
+        ticketService = new TicketService(
+                typesenseClient,
+                ticketRepository,
+                userRepository,
+                commentRepository,
+                assignmentHistoryService,
+                statusHistoryService,
+                statusHistoryRepository,
+                notificationService,
+                workflowService,
+                statusMasterRepository,
+                categoryRepository,
+                subCategoryRepository,
+                priorityRepository,
+                uploadedFileRepository,
+                stakeholderRepository,
+                ticketSlaService,
+                recommendedSeverityFlowRepository,
+                ticketIdGenerator
+        );
+    }
+
+    @Test
+    void shouldMapTypesenseDocumentsToDtos() throws Exception {
+        Map<String, Object> first = Map.of("id", "T-1", "subject", "Subject one");
+        Map<String, Object> second = Map.of("id", "T-2");
+        when(typesenseClient.exportTicketDocuments()).thenReturn(List.of(first, second, Map.of()));
+
+        List<TypesenseTicketDto> result = ticketService.getAllMasterTicketsFromTypesense();
+
+        assertThat(result)
+                .extracting(TypesenseTicketDto::getId)
+                .containsExactly("T-1", "T-2");
+        assertThat(result)
+                .filteredOn(dto -> "T-1".equals(dto.getId()))
+                .first()
+                .extracting(TypesenseTicketDto::getSubject)
+                .isEqualTo("Subject one");
+    }
+
+    @Test
+    void shouldWrapExceptionsFromTypesenseExport() throws Exception {
+        when(typesenseClient.exportTicketDocuments()).thenThrow(new RuntimeException("boom"));
+
+        assertThatThrownBy(ticketService::getAllMasterTicketsFromTypesense)
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Failed to fetch tickets from Typesense")
+                .hasCauseInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void shouldReturnPagedResultFromTypesense() throws Exception {
+        SearchResult result = mock(SearchResult.class);
+        SearchResultHit hit = mock(SearchResultHit.class);
+        when(hit.getDocument()).thenReturn(Map.of("id", "ABC", "subject", "Test"));
+        when(result.getHits()).thenReturn(List.of(hit));
+
+        SearchResultRequestParams params = mock(SearchResultRequestParams.class);
+        when(params.getPerPage()).thenReturn(5);
+        when(result.getRequestParams()).thenReturn(params);
+        when(result.getFound()).thenReturn(12L);
+
+        when(typesenseClient.listTickets(1, 10)).thenReturn(result);
+
+        TypesenseTicketPageResponse response = ticketService.getMasterTicketsPageFromTypesense(-3, 0);
+
+        assertThat(response.getPage()).isEqualTo(0);
+        assertThat(response.getSize()).isEqualTo(5);
+        assertThat(response.getTotalFound()).isEqualTo(12);
+        assertThat(response.getTotalPages()).isEqualTo(3);
+        assertThat(response.getTickets())
+                .extracting(TypesenseTicketDto::getId)
+                .containsExactly("ABC");
+    }
+
+    @Test
+    void shouldWrapExceptionsFromTypesensePagination() throws Exception {
+        when(typesenseClient.listTickets(anyInt(), anyInt())).thenThrow(new RuntimeException("down"));
+
+        assertThatThrownBy(() -> ticketService.getMasterTicketsPageFromTypesense(0, 25))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Failed to fetch paginated tickets from Typesense");
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/TicketStatusWorkflowServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/TicketStatusWorkflowServiceTest.java
@@ -1,0 +1,132 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.models.Role;
+import com.ticketingSystem.api.models.Status;
+import com.ticketingSystem.api.models.TicketStatusWorkflow;
+import com.ticketingSystem.api.repository.RoleRepository;
+import com.ticketingSystem.api.repository.StatusMasterRepository;
+import com.ticketingSystem.api.repository.TicketStatusWorkflowRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TicketStatusWorkflowServiceTest {
+
+    @Mock
+    private TicketStatusWorkflowRepository workflowRepository;
+    @Mock
+    private StatusMasterRepository statusMasterRepository;
+    @Mock
+    private RoleRepository roleRepository;
+
+    private TicketStatusWorkflowService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new TicketStatusWorkflowService(workflowRepository, statusMasterRepository, roleRepository);
+    }
+
+    @Test
+    void shouldReturnCurrentAndNextStatuses() {
+        TicketStatusWorkflow current = new TicketStatusWorkflow();
+        current.setId(1);
+        current.setCurrentStatus(1);
+
+        TicketStatusWorkflow next = new TicketStatusWorkflow();
+        next.setId(2);
+        next.setCurrentStatus(1);
+
+        when(workflowRepository.findById(1)).thenReturn(Optional.of(current));
+        when(workflowRepository.findByCurrentStatus(1)).thenReturn(List.of(next));
+
+        List<TicketStatusWorkflow> result = service.getNextStatusesByCurrentStatus("1");
+
+        assertThat(result).containsExactly(current, next);
+    }
+
+    @Test
+    void shouldGroupMappingsByRolePermissions() {
+        Role role = new Role();
+        role.setAllowedStatusActionIds("1| 2 |abc| ");
+        when(roleRepository.findAllById(List.of(7))).thenReturn(List.of(role));
+
+        TicketStatusWorkflow first = new TicketStatusWorkflow();
+        first.setId(1);
+        first.setCurrentStatus(200);
+        TicketStatusWorkflow second = new TicketStatusWorkflow();
+        second.setId(2);
+        second.setCurrentStatus(200);
+
+        when(workflowRepository.findAllById(Set.of(1, 2))).thenReturn(List.of(first, second));
+
+        Map<String, List<TicketStatusWorkflow>> result = service.getMappingsByRoles(List.of(7));
+
+        assertThat(result).containsOnlyKeys("200");
+        assertThat(result.get("200")).containsExactlyInAnyOrder(first, second);
+    }
+
+    @Test
+    void shouldReturnEmptyMappingsWhenRolesMissing() {
+        Map<String, List<TicketStatusWorkflow>> result = service.getMappingsByRoles(null);
+
+        assertThat(result).isEmpty();
+        result = service.getMappingsByRoles(List.of());
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldReturnDistinctStatusIdsForRoles() {
+        Role role = new Role();
+        role.setAllowedStatusActionIds("1|2|2|invalid");
+        when(roleRepository.findAllById(List.of(3))).thenReturn(List.of(role));
+
+        TicketStatusWorkflow workflowWithStatus = new TicketStatusWorkflow();
+        workflowWithStatus.setId(1);
+        workflowWithStatus.setCurrentStatus(900);
+        TicketStatusWorkflow workflowWithoutStatus = new TicketStatusWorkflow();
+        workflowWithoutStatus.setId(2);
+        workflowWithoutStatus.setCurrentStatus(null);
+
+        when(workflowRepository.findAllById(Set.of(1, 2))).thenReturn(List.of(workflowWithStatus, workflowWithoutStatus));
+
+        List<String> result = service.getAllowedStatusIdListByRoles(List.of(3));
+
+        assertThat(result).containsExactly("900");
+    }
+
+    @Test
+    void shouldResolveStatusDetailsFromRepository() {
+        Status status = new Status();
+        status.setStatusId("status-id");
+        status.setStatusCode("CODE");
+        status.setSlaFlag(true);
+
+        when(statusMasterRepository.findByStatusCode("CODE")).thenReturn(status);
+        when(statusMasterRepository.findById("status-id")).thenReturn(Optional.of(status));
+
+        assertThat(service.getStatusIdByCode("CODE")).isEqualTo("status-id");
+        assertThat(service.getSlaFlagByStatusId("status-id")).isTrue();
+        assertThat(service.getStatusCodeById("status-id")).isEqualTo("CODE");
+    }
+
+    @Test
+    void shouldHandleMissingStatusDataGracefully() {
+        when(statusMasterRepository.findByStatusCode("UNKNOWN")).thenReturn(null);
+        when(statusMasterRepository.findById("missing")).thenReturn(Optional.empty());
+
+        assertThat(service.getStatusIdByCode("UNKNOWN")).isNull();
+        assertThat(service.getSlaFlagByStatusId("missing")).isFalse();
+        assertThat(service.getStatusCodeById("missing")).isNull();
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/util/DateTimeUtilsTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/util/DateTimeUtilsTest.java
@@ -1,0 +1,52 @@
+package com.ticketingSystem.api.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DateTimeUtilsTest {
+
+    @Nested
+    @DisplayName("parseToLocalDateTime")
+    class ParseToLocalDateTime {
+
+        @Test
+        void shouldParseIsoOffsetDateTime() {
+            LocalDateTime result = DateTimeUtils.parseToLocalDateTime("2024-01-10T15:45:30+05:00");
+
+            assertThat(result).isEqualTo(LocalDateTime.of(2024, 1, 10, 15, 45, 30));
+        }
+
+        @Test
+        void shouldParseCustomPatternWhenOffsetIsMissing() {
+            LocalDateTime result = DateTimeUtils.parseToLocalDateTime("2024-03-05T08:15:00");
+
+            assertThat(result).isEqualTo(LocalDateTime.of(2024, 3, 5, 8, 15));
+        }
+
+        @Test
+        void shouldParseDateOnlyValuesAsStartOfDay() {
+            LocalDateTime result = DateTimeUtils.parseToLocalDateTime("2024-07-01");
+
+            assertThat(result).isEqualTo(LocalDateTime.of(2024, 7, 1, 0, 0));
+        }
+
+        @Test
+        void shouldReturnNullWhenInputCannotBeParsed() {
+            LocalDateTime result = DateTimeUtils.parseToLocalDateTime("not-a-date");
+
+            assertThat(result).isNull();
+        }
+
+        @Test
+        void shouldReturnNullWhenInputIsBlank() {
+            LocalDateTime result = DateTimeUtils.parseToLocalDateTime("   ");
+
+            assertThat(result).isNull();
+        }
+    }
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -46,6 +46,7 @@
       "devDependencies": {
         "@types/react-router-dom": "^5.3.3",
         "@types/sockjs-client": "^1.5.4",
+        "msw": "^2.11.3",
         "typescript": "^5.8.3"
       }
     },
@@ -2211,6 +2212,36 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "license": "MIT"
     },
+    "node_modules/@bundled-es-modules/cookie": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cookie": "^0.7.2"
+      }
+    },
+    "node_modules/@bundled-es-modules/cookie/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "statuses": "^2.0.1"
+      }
+    },
     "node_modules/@csstools/normalize.css": {
       "version": "12.1.1",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.1.1.tgz",
@@ -2797,6 +2828,122 @@
       "deprecated": "Use @eslint/object-schema instead",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.0.tgz",
+      "integrity": "sha512-JWaTfCxI1eTmJ1BIv86vUfjVatOdxwD0DAVKYevY8SazeUUZtW+tNbsdejVO1GYE0GXJW1N1ahmiC3TFd+7wZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.18",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.18.tgz",
+      "integrity": "sha512-MilmWOzHa3Ks11tzvuAmFoAd/wRuaP3SwlT1IZhyMke31FKLxPiuDWcGXhU+PKveNOpAc4axzAgrgxuIJJRmLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.2",
+        "@inquirer/type": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.2.2.tgz",
+      "integrity": "sha512-yXq/4QUnk4sHMtmbd7irwiepjB8jXU0kkFRL4nr/aDBA2mDz13cMakEWdDwX3eSCTkk03kwcndD1zfRAIlELxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.0",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
+      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -3293,6 +3440,24 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.39.7",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.39.7.tgz",
+      "integrity": "sha512-sURvQbbKsq5f8INV54YJgJEdk8oxBanqkTiXXd33rKmofFCwZLhLRszPduMZ9TA9b8/1CHc/IJmOlBHJk2Q5AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.1.1.tgz",
@@ -3647,6 +3812,31 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.1",
@@ -4728,6 +4918,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "8.56.12",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
@@ -5060,6 +5257,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
@@ -6906,6 +7110,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/cliui": {
@@ -10150,6 +10364,16 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "license": "MIT"
     },
+    "node_modules/graphql": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
+      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/gzip-size": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
@@ -10272,6 +10496,13 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -11032,6 +11263,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
       "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "license": "MIT"
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-number": {
@@ -13015,6 +13253,129 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.11.3.tgz",
+      "integrity": "sha512-878imp8jxIpfzuzxYfX0qqTq1IFQz/1/RBHs/PyirSjzi+xKM/RRfIpIqHSCWjH0GxidrjhgiiXC+DWXNDvT9w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bundled-es-modules/cookie": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.39.1",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@types/cookie": "^0.6.0",
+        "@types/statuses": "^2.0.4",
+        "graphql": "^16.8.1",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.7.0",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.0",
+        "type-fest": "^4.26.1",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/msw/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/msw/node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/msw/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/msw/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
@@ -13026,6 +13387,16 @@
       },
       "bin": {
         "multicast-dns": "cli.js"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/mz": {
@@ -13427,6 +13798,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
@@ -16681,6 +17059,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/rettime": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.7.0.tgz",
+      "integrity": "sha512-LPRKoHnLKd/r3dVxcwO7vhCW+orkOGj9ViueosEBK6ie89CijnfRlhaDhHq/3Hxu4CkWQtxwlBG0mzTQY6uQjw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -17706,6 +18091,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -18531,6 +18923,26 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "license": "MIT"
     },
+    "node_modules/tldts": {
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.16.tgz",
+      "integrity": "sha512-5bdPHSwbKTeHmXrgecID4Ljff8rQjv7g8zKQPkCozRo2HWWni+p310FSn5ImI+9kWw9kK4lzOB5q/a6iv0IJsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.16"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.16.tgz",
+      "integrity": "sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -18936,6 +19348,16 @@
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
       "integrity": "sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg==",
       "license": "MIT"
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
     },
     "node_modules/upath": {
       "version": "1.2.0",
@@ -20012,6 +20434,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/ui/package.json
+++ b/ui/package.json
@@ -65,6 +65,7 @@
   "devDependencies": {
     "@types/react-router-dom": "^5.3.3",
     "@types/sockjs-client": "^1.5.4",
+    "msw": "^2.11.3",
     "typescript": "^5.8.3"
   }
 }

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -2,8 +2,44 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+jest.mock('react-router-dom', () => ({
+  Routes: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Route: ({ element }: { element: React.ReactNode }) => <>{element}</>,
+  Navigate: ({ to }: { to: string }) => <div data-testid="navigate" data-to={to} />,
+}), { virtual: true });
+
+jest.mock('./utils/Utils', () => ({
+  getUserDetails: jest.fn(() => null),
+  getUserPermissions: jest.fn(() => null),
+}));
+
+jest.mock('./context/NotificationContext', () => ({
+  NotificationProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('./pages/RaiseTicket', () => () => <div>RaiseTicket</div>);
+jest.mock('./pages/AllTickets', () => () => <div>AllTickets</div>);
+jest.mock('./pages/KnowledgeBase', () => () => <div>KnowledgeBase</div>);
+jest.mock('./pages/TicketDetails', () => () => <div>TicketDetails</div>);
+jest.mock('./pages/CustomerSatisfactionForm', () => () => <div>CustomerSatisfactionForm</div>);
+jest.mock('./pages/CategoriesMaster', () => () => <div>CategoriesMaster</div>);
+jest.mock('./pages/EscalationMaster', () => () => <div>EscalationMaster</div>);
+jest.mock('./pages/RoleMaster', () => () => <div>RoleMaster</div>);
+jest.mock('./pages/RoleDetails', () => () => <div>RoleDetails</div>);
+jest.mock('./pages/Login', () => () => <h2>Helpdesk Login</h2>);
+jest.mock('./pages/DevLogin', () => () => <div>DevLogin</div>);
+jest.mock('./pages/MyTickets', () => () => <div>MyTickets</div>);
+jest.mock('./pages/MyWorkload', () => () => <div>MyWorkload</div>);
+jest.mock('./pages/Faq', () => () => <div>Faq</div>);
+jest.mock('./pages/FaqForm', () => () => <div>FaqForm</div>);
+jest.mock('./pages/RootCauseAnalysis', () => () => <div>RootCauseAnalysis</div>);
+jest.mock('./components/Layout/SidebarLayout', () => ({ children }: { children: React.ReactNode }) => <div>{children}</div>);
+
+
+describe('App routing', () => {
+  it('renders the login route for unauthenticated users', () => {
+    render(<App />);
+
+    expect(screen.getByRole('heading', { name: /login/i })).toBeInTheDocument();
+  });
 });

--- a/ui/src/__tests__/DateRangeFilter.test.tsx
+++ b/ui/src/__tests__/DateRangeFilter.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DateRangeFilter from '../components/Filters/DateRangeFilter';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('../i18n', () => ({}));
+
+jest.mock('../utils/Utils', () => ({
+  getUserDetails: jest.fn(() => null),
+  getUserPermissions: jest.fn(() => null),
+  formatDateWithSuffix: jest.fn((date: Date) => date.toISOString()),
+}));
+
+jest.mock('../components/UI/IconButton/CustomIconButton', () => ({ onClick }: { onClick: () => void }) => (
+  <button type="button" aria-label="apply" onClick={onClick}>
+    apply
+  </button>
+));
+
+jest.mock('../utils/dateUtils', () => {
+  const actual = jest.requireActual('../utils/dateUtils');
+  return {
+    ...actual,
+    getPresetDateRange: jest.fn((preset: string) => {
+      if (preset === 'LAST_1_WEEK') {
+        return { fromDate: '2024-01-01', toDate: '2024-01-07' };
+      }
+      return undefined;
+    }),
+  };
+});
+
+const dateUtils = require('../utils/dateUtils');
+
+describe('DateRangeFilter', () => {
+  it('allows selecting a preset and notifies parent', async () => {
+    const onChange = jest.fn();
+
+    render(<DateRangeFilter value={{ preset: 'ALL' }} onChange={onChange} />);
+
+    const dropdown = screen.getByRole('combobox');
+    await userEvent.click(dropdown);
+
+    const lastWeekOption = await screen.findByRole('option', { name: 'Last 1 Week' });
+    await userEvent.click(lastWeekOption);
+
+    expect(dateUtils.getPresetDateRange).toHaveBeenCalledWith('LAST_1_WEEK');
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ preset: 'LAST_1_WEEK' }));
+  });
+
+  it('applies custom date range when submitted', async () => {
+    const onChange = jest.fn();
+
+    render(
+      <DateRangeFilter
+        value={{ preset: 'CUSTOM', fromDate: '2024-01-02', toDate: '2024-01-05' }}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('From'), { target: { value: '2024-02-01' } });
+    fireEvent.change(screen.getByLabelText('To'), { target: { value: '2024-02-06' } });
+
+    await userEvent.click(screen.getByRole('button', { name: 'apply' }));
+
+    expect(onChange).toHaveBeenCalledWith({ preset: 'CUSTOM', fromDate: '2024-02-01', toDate: '2024-02-06' });
+  });
+});

--- a/ui/src/__tests__/dateUtils.test.ts
+++ b/ui/src/__tests__/dateUtils.test.ts
@@ -1,0 +1,29 @@
+import { buildApiDateParams, ensureCustomPreset, getPresetDateRange } from '../utils/dateUtils';
+
+describe('dateUtils', () => {
+  it('derives preset ranges relative to provided date', () => {
+    const now = new Date(Date.UTC(2024, 4, 20, 12));
+
+    expect(getPresetDateRange('LAST_1_WEEK', now)).toEqual({ fromDate: '2024-05-13', toDate: '2024-05-20' });
+    expect(getPresetDateRange('LAST_1_MONTH', now)).toEqual({ fromDate: '2024-04-20', toDate: '2024-05-20' });
+    expect(getPresetDateRange('ALL', now)).toBeUndefined();
+  });
+
+  it('builds API params with day boundaries', () => {
+    expect(buildApiDateParams(undefined)).toEqual({});
+    expect(buildApiDateParams({ preset: 'ALL' })).toEqual({});
+    expect(
+      buildApiDateParams({ preset: 'CUSTOM', fromDate: '2024-05-01', toDate: '2024-05-10' })
+    ).toEqual({ fromDate: '2024-05-01T00:00:00', toDate: '2024-05-10T23:59:59' });
+  });
+
+  it('merges updates into a custom preset', () => {
+    const state = { preset: 'CUSTOM', fromDate: '2024-05-01', toDate: '2024-05-10' } as const;
+
+    expect(ensureCustomPreset(state, { toDate: '2024-05-15' })).toEqual({
+      preset: 'CUSTOM',
+      fromDate: '2024-05-01',
+      toDate: '2024-05-15',
+    });
+  });
+});

--- a/ui/src/setupTests.ts
+++ b/ui/src/setupTests.ts
@@ -1,5 +1,1 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+import './test/setupTests';

--- a/ui/src/test/msw/handlers.ts
+++ b/ui/src/test/msw/handlers.ts
@@ -1,0 +1,14 @@
+import { http, HttpResponse } from 'msw';
+
+const API_URL = process.env.REACT_APP_API_URL ?? 'http://localhost:8082';
+
+export const handlers = [
+  http.get(`${API_URL}/tickets`, () => {
+    return HttpResponse.json({ data: [] });
+  }),
+  http.post(`${API_URL}/tickets/add`, async ({ request }) => {
+    const body = request instanceof Request ? await request.formData() : null;
+    const subject = body?.get('subject') ?? 'New ticket';
+    return HttpResponse.json({ id: 'TICK-100', subject });
+  }),
+];

--- a/ui/src/test/setupTests.ts
+++ b/ui/src/test/setupTests.ts
@@ -1,0 +1,58 @@
+import '@testing-library/jest-dom';
+import { TextDecoder, TextEncoder } from 'util';
+
+if (typeof global.TextEncoder === 'undefined') {
+  // @ts-ignore
+  global.TextEncoder = TextEncoder;
+}
+if (typeof global.TextDecoder === 'undefined') {
+  // @ts-ignore
+  global.TextDecoder = TextDecoder as typeof global.TextDecoder;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { TransformStream, ReadableStream, WritableStream } = require('stream/web');
+if (typeof global.TransformStream === 'undefined') {
+  // @ts-ignore
+  global.TransformStream = TransformStream;
+}
+if (typeof global.ReadableStream === 'undefined') {
+  // @ts-ignore
+  global.ReadableStream = ReadableStream;
+}
+if (typeof global.WritableStream === 'undefined') {
+  // @ts-ignore
+  global.WritableStream = WritableStream;
+}
+
+jest.mock('msw', () => ({
+  http: {
+    get: (...args: unknown[]) => ({ method: 'GET', args }),
+    post: (...args: unknown[]) => ({ method: 'POST', args }),
+  },
+  HttpResponse: {
+    json: (body: unknown) => body,
+  },
+}));
+
+jest.mock('msw/node', () => {
+  const listeners = {
+    listen: jest.fn(),
+    resetHandlers: jest.fn(),
+    close: jest.fn(),
+  };
+  return {
+    setupServer: () => listeners,
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { setupServer } = require('msw/node');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { handlers } = require('./msw/handlers');
+
+export const server = setupServer(...handlers);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());


### PR DESCRIPTION
## Summary
- add JUnit tests for the ticket workflow and typesense integrations alongside DateTimeUtils coverage
- expand React testing with focused suites for date utilities, DateRangeFilter, and App routing while stubbing external concerns
- configure Jest setup with MSW handler scaffolding and required polyfills/mocks for browser APIs

## Testing
- npm test -- --watchAll=false
- ./gradlew test --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e3e2ebc2f88332b4fac562452bdb45