### PR TITLE
test: add comprehensive UI component coverage

### DIFF
--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -35,6 +35,10 @@ jest.mock('./pages/FaqForm', () => () => <div>FaqForm</div>);
 jest.mock('./pages/RootCauseAnalysis', () => () => <div>RootCauseAnalysis</div>);
 jest.mock('./components/Layout/SidebarLayout', () => ({ children }: { children: React.ReactNode }) => <div>{children}</div>);
 
+jest.mock('jwt-decode', () => ({
+  jwtDecode: () => ({}),
+}), { virtual: true });
+
 
 describe('App routing', () => {
   it('renders the login route for unauthenticated users', () => {

--- a/ui/src/__tests__/DateRangeFilter.test.tsx
+++ b/ui/src/__tests__/DateRangeFilter.test.tsx
@@ -6,7 +6,7 @@ jest.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => key,
   }),
-}));
+}), { virtual: true });
 
 jest.mock('../i18n', () => ({}));
 

--- a/ui/src/components/UI/__tests__/Button.test.tsx
+++ b/ui/src/components/UI/__tests__/Button.test.tsx
@@ -1,0 +1,31 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GenericButton from '../Button';
+import { renderWithTheme } from '../../../test/testUtils';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => `translated:${key}`,
+  }),
+}), { virtual: true });
+
+describe('GenericButton', () => {
+  it('renders translated text when textKey is provided', () => {
+    renderWithTheme(<GenericButton textKey="actions.save" />);
+
+    expect(screen.getByRole('button', { name: 'translated:actions.save' })).toBeInTheDocument();
+  });
+
+  it('renders children when no textKey is provided', async () => {
+    const onClick = jest.fn();
+    renderWithTheme(
+      <GenericButton onClick={onClick}>
+        Click Me
+      </GenericButton>,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Click Me' }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/components/UI/__tests__/CustomTabsComponent.test.tsx
+++ b/ui/src/components/UI/__tests__/CustomTabsComponent.test.tsx
@@ -1,0 +1,42 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CustomTabsComponent from '../CustomTabsComponent';
+import { renderWithTheme } from '../../../test/testUtils';
+
+describe('CustomTabsComponent', () => {
+  const tabs = [
+    { key: 'first', tabTitle: 'First', tabComponent: <div>First content</div> },
+    { key: 'second', tabTitle: 'Second', tabComponent: <div>Second content</div> },
+  ];
+
+  it('renders the first tab content by default', () => {
+    renderWithTheme(<CustomTabsComponent tabs={tabs} />);
+
+    expect(screen.getByText('First content')).toBeInTheDocument();
+    expect(screen.queryByText('Second content')).not.toBeInTheDocument();
+  });
+
+  it('changes tab when a new tab is selected', async () => {
+    const onTabChange = jest.fn();
+    renderWithTheme(<CustomTabsComponent tabs={tabs} onTabChange={onTabChange} />);
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Second' }));
+
+    expect(onTabChange).toHaveBeenCalledWith('second');
+    expect(screen.getByText('Second content')).toBeInTheDocument();
+  });
+
+  it('respects the controlled currentTab prop', () => {
+    const { rerender } = renderWithTheme(
+      <CustomTabsComponent tabs={tabs} currentTab="second" />,
+    );
+
+    expect(screen.getByText('Second content')).toBeInTheDocument();
+
+    rerender(
+      <CustomTabsComponent tabs={tabs} currentTab="first" />,
+    );
+
+    expect(screen.getByText('First content')).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/UI/__tests__/Dropdown.test.tsx
+++ b/ui/src/components/UI/__tests__/Dropdown.test.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useForm } from 'react-hook-form';
+import GenericDropdown from '../Dropdown/GenericDropdown';
+import DropdownController from '../Dropdown/DropdownController';
+import GenericDropdownController from '../Dropdown/GenericDropdownController';
+import { renderWithTheme } from '../../../test/testUtils';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}), { virtual: true });
+
+describe('GenericDropdown', () => {
+  const options = [
+    { label: 'Option One', value: 'one' },
+    { label: 'Option Two', value: 'two' },
+  ];
+
+  const openMenu = async () => {
+    const trigger = screen.getByRole('combobox');
+    fireEvent.mouseDown(trigger);
+  };
+
+  it('renders translated label and options', async () => {
+    renderWithTheme(
+      <GenericDropdown label="dropdown.label" value="one" onChange={jest.fn()} options={options} />,
+    );
+
+    expect(screen.getAllByText('dropdown.label')[0]).toBeInTheDocument();
+
+    await openMenu();
+
+    expect(await screen.findByRole('option', { name: 'Option One' })).toBeInTheDocument();
+  });
+
+  it('shows a fallback menu item when no options are provided', async () => {
+    renderWithTheme(
+      <GenericDropdown label="dropdown.empty" value="" onChange={jest.fn()} options={[]} />, 
+    );
+
+    await openMenu();
+
+    expect(await screen.findByText('No options available')).toBeInTheDocument();
+  });
+});
+
+describe('DropdownController', () => {
+  const options = [
+    { label: 'First', value: 'first' },
+    { label: 'Second', value: 'second' },
+  ];
+
+  it('maps the selected option back to the provided callback', async () => {
+    const handleChange = jest.fn();
+    renderWithTheme(
+      <DropdownController value="first" onChange={handleChange} options={options} label="controller" />,
+    );
+
+    fireEvent.mouseDown(screen.getByRole('combobox'));
+    await userEvent.click(await screen.findByRole('option', { name: 'Second' }));
+
+    expect(handleChange).toHaveBeenCalledWith('second');
+  });
+});
+
+describe('GenericDropdownController', () => {
+  const options = [
+    { label: 'Alpha', value: 'alpha' },
+    { label: 'Beta', value: 'beta' },
+  ];
+
+  const FormWrapper = ({ onExternalChange }: { onExternalChange?: () => void }) => {
+    const { control, trigger } = useForm({
+      defaultValues: { status: '' },
+      mode: 'onBlur',
+    });
+
+    return (
+      <div>
+        <GenericDropdownController
+          name="status"
+          control={control}
+          rules={{ required: 'Status is required' }}
+          onChange={onExternalChange}
+          label="status"
+          options={options}
+        />
+        <button type="button" onClick={() => trigger('status')}>
+          validate
+        </button>
+      </div>
+    );
+  };
+
+  it('propagates selections to react-hook-form and external handlers', async () => {
+    const onExternalChange = jest.fn();
+    renderWithTheme(<FormWrapper onExternalChange={onExternalChange} />);
+
+    fireEvent.mouseDown(screen.getByRole('combobox'));
+    await userEvent.click(await screen.findByRole('option', { name: 'Beta' }));
+
+    expect(onExternalChange).toHaveBeenCalled();
+  });
+
+  it('displays validation messages returned by react-hook-form', async () => {
+    renderWithTheme(<FormWrapper />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'validate' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Status is required')).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/components/UI/__tests__/Fieldset.test.tsx
+++ b/ui/src/components/UI/__tests__/Fieldset.test.tsx
@@ -1,0 +1,28 @@
+import { screen } from '@testing-library/react';
+import Fieldset from '../Fieldset';
+import { renderWithTheme } from '../../../test/testUtils';
+
+describe('Fieldset', () => {
+  it('renders title and children', () => {
+    renderWithTheme(
+      <Fieldset title="Section title">
+        <div>Child content</div>
+      </Fieldset>,
+    );
+
+    expect(screen.getByText('Section title')).toBeInTheDocument();
+    expect(screen.getByText('Child content')).toBeInTheDocument();
+  });
+
+  it('applies collapsed spacing when collapsed is true', () => {
+    const { container } = renderWithTheme(
+      <Fieldset title="Collapsed" collapsed>
+        <div>Inner</div>
+      </Fieldset>,
+    );
+
+    const fieldset = container.querySelector('fieldset');
+    expect(fieldset?.className).toContain('p-4');
+    expect(fieldset?.className).not.toContain('pt-5');
+  });
+});

--- a/ui/src/components/UI/__tests__/FileUpload.test.tsx
+++ b/ui/src/components/UI/__tests__/FileUpload.test.tsx
@@ -1,0 +1,83 @@
+import { act, fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FileUpload from '../FileUpload';
+import { renderWithTheme } from '../../../test/testUtils';
+
+describe('FileUpload', () => {
+  const originalCreateObjectURL = global.URL?.createObjectURL;
+  const originalRevokeObjectURL = global.URL?.revokeObjectURL;
+
+  beforeAll(() => {
+    // @ts-expect-error jsdom type
+    global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+    // @ts-expect-error jsdom type
+    global.URL.revokeObjectURL = jest.fn();
+  });
+
+  afterAll(() => {
+    if (originalCreateObjectURL) {
+      // @ts-expect-error jsdom type
+      global.URL.createObjectURL = originalCreateObjectURL;
+    } else {
+      // @ts-expect-error jsdom type
+      delete global.URL.createObjectURL;
+    }
+
+    if (originalRevokeObjectURL) {
+      // @ts-expect-error jsdom type
+      global.URL.revokeObjectURL = originalRevokeObjectURL;
+    } else {
+      // @ts-expect-error jsdom type
+      delete global.URL.revokeObjectURL;
+    }
+  });
+
+  it('accepts files within the size limit and notifies parent', async () => {
+    const onFilesChange = jest.fn();
+    const file = new File(['hello'], 'hello.png', { type: 'image/png' });
+
+    const { container } = renderWithTheme(
+      <FileUpload maxSizeMB={5} onFilesChange={onFilesChange} attachments={[]} />,
+    );
+
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    await act(async () => {
+      await userEvent.upload(input, file);
+    });
+
+    expect(onFilesChange).toHaveBeenCalledWith([file]);
+  });
+
+  it('shows an error when a file exceeds the size limit', async () => {
+    const largeBuffer = new Uint8Array(6 * 1024 * 1024);
+    const largeFile = new File([largeBuffer], 'large.pdf', { type: 'application/pdf' });
+
+    const { container } = renderWithTheme(
+      <FileUpload maxSizeMB={2} attachments={[]} />,
+    );
+
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    await act(async () => {
+      await userEvent.upload(input, largeFile);
+    });
+
+    expect(screen.getByText(/Max upload size exceeded/)).toBeInTheDocument();
+  });
+
+  it('allows removing previously selected files', async () => {
+    const onFilesChange = jest.fn();
+    const file = new File(['bye'], 'bye.png', { type: 'image/png' });
+
+    const { container } = renderWithTheme(
+      <FileUpload maxSizeMB={5} onFilesChange={onFilesChange} attachments={[file]} />,
+    );
+
+    const removeButton = container.querySelector('.remove-icon') as HTMLElement;
+    removeButton.style.display = 'block';
+    fireEvent.click(removeButton);
+
+    expect(onFilesChange).toHaveBeenCalledWith([]);
+  });
+});

--- a/ui/src/components/UI/__tests__/GenericTable.test.tsx
+++ b/ui/src/components/UI/__tests__/GenericTable.test.tsx
@@ -1,0 +1,41 @@
+import { screen } from '@testing-library/react';
+import GenericTable from '../GenericTable';
+import { createTestTheme, renderWithTheme } from '../../../test/testUtils';
+
+const dataSource = [
+  { key: '1', name: 'Alice', age: 30 },
+];
+
+const columns = [
+  { title: 'Name', dataIndex: 'name', key: 'name' },
+  { title: 'Age', dataIndex: 'age', key: 'age' },
+];
+
+describe('GenericTable', () => {
+  it('applies theme aware styling in light mode', () => {
+    const { container } = renderWithTheme(
+      <GenericTable dataSource={dataSource} columns={columns} pagination={false} />,
+    );
+
+    const styledElement = container.querySelector('[style*="--table-header-bg"]');
+    expect(styledElement).toBeInTheDocument();
+  });
+
+  it('uses the dark theme modifier class when palette mode is dark', () => {
+    const darkTheme = createTestTheme({ palette: { mode: 'dark', success: { main: '#4caf50', dark: '#357a38' } } });
+    const { container } = renderWithTheme(
+      <GenericTable dataSource={dataSource} columns={columns} pagination={false} className="custom" />,
+      { theme: darkTheme },
+    );
+
+    expect(container.querySelector('.table-dark-theme')).toBeInTheDocument();
+  });
+
+  it('renders provided data rows', () => {
+    renderWithTheme(
+      <GenericTable dataSource={dataSource} columns={columns} pagination={false} />,
+    );
+
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/UI/__tests__/IconButton.test.tsx
+++ b/ui/src/components/UI/__tests__/IconButton.test.tsx
@@ -1,0 +1,22 @@
+import { screen } from '@testing-library/react';
+import CustomIconButton, { IconComponent } from '../IconButton/CustomIconButton';
+import { renderWithTheme } from '../../../test/testUtils';
+
+describe('CustomIconButton and IconComponent', () => {
+  it('renders the mapped material icon when a known key is provided', () => {
+    const { container } = renderWithTheme(
+      <CustomIconButton icon="delete" aria-label="delete" />,
+    );
+
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('falls back to rendering the icon name when unknown', () => {
+    const { container } = renderWithTheme(
+      <IconComponent icon="unknown" className="fallback" />,
+    );
+
+    expect(container.querySelector('.fallback')?.textContent).toBe('unknown');
+  });
+
+});

--- a/ui/src/components/UI/__tests__/Icons.test.tsx
+++ b/ui/src/components/UI/__tests__/Icons.test.tsx
@@ -1,0 +1,34 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import InfoIcon from '../Icons/InfoIcon';
+import MasterIcon from '../Icons/MasterIcon';
+import PriorityIcon from '../Icons/PriorityIcon';
+import { renderWithTheme } from '../../../test/testUtils';
+
+describe('UI icons', () => {
+  it('displays popover content on hover', async () => {
+    const { container } = renderWithTheme(
+      <InfoIcon title="More info" text="Details" />, 
+    );
+
+    const trigger = container.querySelector('.m-2') as HTMLElement;
+    fireEvent.mouseEnter(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByText('More info')).toBeInTheDocument();
+      expect(screen.getByText('Details')).toBeInTheDocument();
+    });
+  });
+
+  it('renders master icon with the initial letter', () => {
+    renderWithTheme(<MasterIcon />);
+
+    expect(screen.getByText('M')).toBeInTheDocument();
+  });
+
+  it('renders the expected number of priority indicators', () => {
+    renderWithTheme(<PriorityIcon level={3} priorityText="High" />);
+
+    const indicators = screen.getAllByTestId('KeyboardArrowUpIcon');
+    expect(indicators).toHaveLength(2);
+  });
+});

--- a/ui/src/components/UI/__tests__/Input.test.tsx
+++ b/ui/src/components/UI/__tests__/Input.test.tsx
@@ -1,0 +1,81 @@
+import { screen } from '@testing-library/react';
+import GenericInput from '../Input/GenericInput';
+import CustomFormInput from '../Input/CustomFormInput';
+import { renderWithTheme } from '../../../test/testUtils';
+
+jest.mock('../../i18n', () => ({}), { virtual: true });
+jest.mock('i18next', () => {
+  const fake = {
+    use: () => fake,
+    init: () => undefined,
+  };
+  return fake;
+}, { virtual: true });
+jest.mock('jwt-decode', () => ({
+  jwtDecode: () => ({}),
+}), { virtual: true });
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => `t:${key}`,
+  }),
+}), { virtual: true });
+
+describe('GenericInput', () => {
+  it('translates labels using i18next', () => {
+    renderWithTheme(
+      <GenericInput label="input.label" fullWidth />,
+    );
+
+    expect(screen.getByLabelText('t:input.label')).toBeInTheDocument();
+  });
+});
+
+describe('CustomFormInput', () => {
+  const register = jest.fn(() => ({
+    name: 'name',
+    onBlur: jest.fn(),
+    onChange: jest.fn(),
+    ref: jest.fn(),
+  }));
+
+  afterEach(() => {
+    register.mockClear();
+  });
+
+  it('registers the field with computed validation rules', () => {
+    const errors = { name: { message: 'Name is required' } } as any;
+
+    renderWithTheme(
+      <CustomFormInput
+        register={register as any}
+        errors={errors}
+        control={undefined as any}
+        name="name"
+        label="Name"
+        required
+        showLabel
+      />,
+    );
+
+    expect(register).toHaveBeenCalledWith('name', expect.objectContaining({ required: 'Please fill the Name' }));
+    expect(screen.getAllByText('t:Name')[0]).toBeInTheDocument();
+    expect(screen.getByText('Name is required')).toBeInTheDocument();
+  });
+
+  it('omits the required validation when the field is disabled', () => {
+    renderWithTheme(
+      <CustomFormInput
+        register={register as any}
+        errors={{}}
+        control={undefined as any}
+        name="description"
+        label="Description"
+        required
+        disabled
+      />,
+    );
+
+    expect(register).toHaveBeenCalledWith('description', {});
+  });
+});

--- a/ui/src/components/UI/__tests__/Modals.test.tsx
+++ b/ui/src/components/UI/__tests__/Modals.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FailureModal from '../FailureModal';
+import SuccessModal from '../SuccessModal';
+import { renderWithTheme } from '../../../test/testUtils';
+
+describe('Status modals', () => {
+  it('renders failure modal content when open', async () => {
+    const onClose = jest.fn();
+    renderWithTheme(
+      <FailureModal
+        open
+        title="Failure"
+        subtext="Something went wrong"
+        actions={<button type="button">Retry</button>}
+        onClose={onClose}
+      />,
+    );
+
+    expect(screen.getByText('Failure')).toBeInTheDocument();
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Retry'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('invokes onClose when the modal backdrop is clicked', async () => {
+    const onClose = jest.fn();
+    renderWithTheme(
+      <FailureModal open title="Failure" onClose={onClose} />,
+    );
+
+    const backdrop = document.querySelector('.MuiBackdrop-root') as HTMLElement;
+    fireEvent.mouseDown(backdrop);
+    fireEvent.mouseUp(backdrop);
+    fireEvent.click(backdrop);
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('renders success modal with optional actions', () => {
+    const onClose = jest.fn();
+    renderWithTheme(
+      <SuccessModal
+        open
+        title="Success"
+        subtext="All good"
+        actions={<button type="button">Close</button>}
+        onClose={onClose}
+      />,
+    );
+
+    expect(screen.getByText('Success')).toBeInTheDocument();
+    expect(screen.getByText('All good')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/UI/__tests__/MultiValueProgressBar.test.tsx
+++ b/ui/src/components/UI/__tests__/MultiValueProgressBar.test.tsx
@@ -1,0 +1,40 @@
+import { render } from '@testing-library/react';
+import MultiValueProgressBar, { MultiValueProgressSegment } from '../MultiValueProgressBar';
+
+describe('MultiValueProgressBar', () => {
+  const segments: MultiValueProgressSegment[] = [
+    { value: 60, color: '#4caf50', startLabel: 'A', endLabel: 'B', marker: { left: true } },
+    { value: 40, color: '#2196f3', startLabel: 'C', endLabel: 'D', marker: { right: true, size: 4, color: '#000' } },
+  ];
+
+  it('renders a segment for each value with computed widths', () => {
+    const { container } = render(
+      <MultiValueProgressBar segments={segments} totalValue={100} />,
+    );
+
+    const renderedSegments = container.querySelectorAll('.multi-progress__segment');
+    expect(renderedSegments).toHaveLength(2);
+    expect(renderedSegments[0]).toHaveStyle({ width: '60%' });
+    expect(renderedSegments[1]).toHaveStyle({ width: '40%' });
+  });
+
+  it('renders labels and markers when provided', () => {
+    const { container, getByText } = render(
+      <MultiValueProgressBar segments={segments} totalValue={100} />,
+    );
+
+    expect(getByText('A')).toBeInTheDocument();
+    expect(getByText('D')).toBeInTheDocument();
+
+    const markers = container.querySelectorAll('.multi-progress__marker');
+    expect(markers).toHaveLength(2);
+  });
+
+  it('handles empty segment lists gracefully', () => {
+    const { container } = render(
+      <MultiValueProgressBar segments={[]} totalValue={100} />,
+    );
+
+    expect(container.querySelectorAll('.multi-progress__segment')).toHaveLength(0);
+  });
+});

--- a/ui/src/components/UI/__tests__/RemarkComponent.test.tsx
+++ b/ui/src/components/UI/__tests__/RemarkComponent.test.tsx
@@ -1,0 +1,67 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RemarkComponent from '../Remark/RemarkComponent';
+import { renderWithTheme } from '../../../test/testUtils';
+
+describe('RemarkComponent', () => {
+  it('generates confirmation message based on action name', () => {
+    const onSubmit = jest.fn();
+    const onCancel = jest.fn();
+
+    renderWithTheme(
+      <RemarkComponent actionName="Resolve" onSubmit={onSubmit} onCancel={onCancel} />,
+    );
+
+    expect(
+      screen.getByText('If you are sure you want to Resolve the ticket, please add a remark and submit'),
+    ).toBeInTheDocument();
+  });
+
+  it('submits and resets remark in inline mode', async () => {
+    const onSubmit = jest.fn();
+    const onCancel = jest.fn();
+    renderWithTheme(
+      <RemarkComponent actionName="Close" onSubmit={onSubmit} onCancel={onCancel} />,
+    );
+
+    const input = screen.getByRole('textbox');
+    await userEvent.type(input, 'All done');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(onSubmit).toHaveBeenCalledWith('All done');
+    expect((input as HTMLInputElement).value).toBe('');
+  });
+
+  it('resets remark and notifies cancel handler', async () => {
+    const onSubmit = jest.fn();
+    const onCancel = jest.fn();
+    renderWithTheme(
+      <RemarkComponent defaultRemark="Existing" onSubmit={onSubmit} onCancel={onCancel} />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalled();
+    expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('Existing');
+  });
+
+  it('renders as a modal dialog when requested', () => {
+    const onSubmit = jest.fn();
+    const onCancel = jest.fn();
+
+    renderWithTheme(
+      <RemarkComponent
+        isModal
+        open
+        title="Add Remark"
+        actionName="Reopen"
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+      />,
+    );
+
+    expect(screen.getByText('Add Remark')).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/UI/__tests__/ToggleComponents.test.tsx
+++ b/ui/src/components/UI/__tests__/ToggleComponents.test.tsx
@@ -1,0 +1,45 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RadioToggleGroup from '../RadioToggleGroup';
+import ViewToggle from '../ViewToggle';
+import { renderWithTheme } from '../../../test/testUtils';
+
+describe('Toggle components', () => {
+  const options = [
+    { value: 'grid', label: 'Grid', icon: 'grid' },
+    { value: 'list', label: 'List', icon: 'table' },
+  ];
+
+  it('renders radio options with icons and triggers onChange', async () => {
+    const onChange = jest.fn();
+    renderWithTheme(
+      <RadioToggleGroup value="grid" onChange={onChange} options={options} />,
+    );
+
+    const listOption = screen.getByRole('radio', { name: 'List' });
+    await userEvent.click(listOption);
+
+    expect(onChange).toHaveBeenCalledWith('list');
+  });
+
+  it('renders as a ToggleButtonGroup when radio prop is false', async () => {
+    const onChange = jest.fn();
+    renderWithTheme(
+      <ViewToggle value="grid" onChange={onChange} options={options} />, 
+    );
+
+    const listButton = screen.getByRole('button', { name: 'List' });
+    await userEvent.click(listButton);
+
+    expect(onChange).toHaveBeenCalledWith('list');
+  });
+
+  it('delegates to RadioToggleGroup when radio is true', () => {
+    const onChange = jest.fn();
+    renderWithTheme(
+      <ViewToggle value="grid" onChange={onChange} options={options} radio />,
+    );
+
+    expect(screen.getAllByRole('radio')).toHaveLength(2);
+  });
+});

--- a/ui/src/components/UI/__tests__/UserAvatar.test.tsx
+++ b/ui/src/components/UI/__tests__/UserAvatar.test.tsx
@@ -1,0 +1,26 @@
+import { fireEvent, screen } from '@testing-library/react';
+import UserAvatar from '../UserAvatar/UserAvatar';
+import { renderWithTheme } from '../../../test/testUtils';
+
+describe('UserAvatar', () => {
+  it('renders initials from the provided name', () => {
+    renderWithTheme(<UserAvatar name="Jane Doe" />);
+
+    expect(screen.getByText('JD')).toBeInTheDocument();
+  });
+
+  it('does not render initials when name is not provided', () => {
+    renderWithTheme(<UserAvatar />);
+
+    expect(screen.queryByText('JD')).not.toBeInTheDocument();
+  });
+
+  it('invokes onClick when provided', () => {
+    const onClick = jest.fn();
+    renderWithTheme(<UserAvatar name="John Smith" onClick={onClick} />);
+
+    fireEvent.click(screen.getByText('JS'));
+
+    expect(onClick).toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/UI/__tests__/VerifyIconButton.test.tsx
+++ b/ui/src/components/UI/__tests__/VerifyIconButton.test.tsx
@@ -1,0 +1,36 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import VerifyIconButton from '../IconButton/VerifyIconButton';
+import { renderWithTheme } from '../../../test/testUtils';
+
+jest.mock('../IconButton/CustomIconButton', () => ({
+  __esModule: true,
+  default: ({ onClick }: { onClick?: () => void }) => (
+    <div role="button" data-testid="custom-icon-button" onClick={onClick} tabIndex={0}>
+      send
+    </div>
+  ),
+}));
+
+describe('VerifyIconButton', () => {
+  it('renders a progress indicator when pending', () => {
+    renderWithTheme(<VerifyIconButton pending />);
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  it('renders a success icon when verified', () => {
+    renderWithTheme(<VerifyIconButton verified />);
+
+    expect(screen.getByTestId('CheckCircleIcon')).toBeInTheDocument();
+  });
+
+  it('delegates clicks to the provided handler in the default state', async () => {
+    const onClick = jest.fn();
+    renderWithTheme(<VerifyIconButton onClick={onClick} />);
+
+    await userEvent.click(screen.getByTestId('custom-icon-button'));
+
+    expect(onClick).toHaveBeenCalled();
+  });
+});

--- a/ui/src/test/setupTests.ts
+++ b/ui/src/test/setupTests.ts
@@ -33,7 +33,7 @@ jest.mock('msw', () => ({
   HttpResponse: {
     json: (body: unknown) => body,
   },
-}));
+}), { virtual: true });
 
 jest.mock('msw/node', () => {
   const listeners = {
@@ -44,7 +44,7 @@ jest.mock('msw/node', () => {
   return {
     setupServer: () => listeners,
   };
-});
+}, { virtual: true });
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { setupServer } = require('msw/node');

--- a/ui/src/test/testUtils.tsx
+++ b/ui/src/test/testUtils.tsx
@@ -1,0 +1,43 @@
+import { ReactElement, ReactNode } from 'react';
+import { render, RenderOptions } from '@testing-library/react';
+import { ThemeProvider, Theme, ThemeOptions, createTheme } from '@mui/material/styles';
+
+export const createTestTheme = (options?: ThemeOptions): Theme =>
+  createTheme({
+    palette: {
+      mode: 'light',
+      primary: { main: '#1976d2' },
+      success: { main: '#2e7d32', dark: '#1b5e20' },
+    },
+    ...options,
+  });
+
+interface ProvidersOptions extends Omit<RenderOptions, 'wrapper'> {
+  theme?: Theme;
+}
+
+const renderWithTheme = (ui: ReactElement, { theme = createTestTheme(), ...renderOptions }: ProvidersOptions = {}) => {
+  if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+
+  function Wrapper({ children }: { children?: ReactNode }) {
+    return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+  }
+
+  return render(ui, { wrapper: Wrapper, ...renderOptions });
+};
+
+export { renderWithTheme };


### PR DESCRIPTION
## Summary
- add a reusable themed render helper for component tests
- create detailed test suites covering every UI primitive including buttons, dropdowns, inputs, modals, tables, file upload, and toggle controls
- stub external dependencies so the new tests run in isolation

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68e495fdcdec833296348e94b40a5708