### PR TITLE
Add comprehensive tests for AllTickets components

### DIFF
--- a/ui/src/components/AllTickets/__tests__/AssigneeDropdown.test.tsx
+++ b/ui/src/components/AllTickets/__tests__/AssigneeDropdown.test.tsx
@@ -1,0 +1,218 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import AssigneeDropdown from '../AssigneeDropdown';
+
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockUseApi = jest.fn();
+jest.mock('../../../hooks/useApi', () => ({
+    useApi: (...args: any[]) => mockUseApi(...args),
+}));
+
+const mockGetAllLevels = jest.fn();
+const mockGetAllUsers = jest.fn();
+const mockGetAllUsersByLevel = jest.fn();
+const mockGetAllRoles = jest.fn();
+const mockGetUsersByRoles = jest.fn();
+const mockUpdateTicket = jest.fn();
+
+jest.mock('../../../services/LevelService', () => ({
+    getAllLevels: (...args: any[]) => mockGetAllLevels(...args),
+    getAllUsersByLevel: (...args: any[]) => mockGetAllUsersByLevel(...args),
+}));
+
+jest.mock('../../../services/UserService', () => ({
+    getAllUsers: (...args: any[]) => mockGetAllUsers(...args),
+    getUsersByRoles: (...args: any[]) => mockGetUsersByRoles(...args),
+}));
+
+jest.mock('../../../services/RoleService', () => ({
+    getAllRoles: (...args: any[]) => mockGetAllRoles(...args),
+}));
+
+jest.mock('../../../services/TicketService', () => ({
+    updateTicket: (...args: any[]) => mockUpdateTicket(...args),
+}));
+
+const mockGetCurrentUserDetails = jest.fn();
+jest.mock('../../../config/config', () => ({
+    getCurrentUserDetails: (...args: any[]) => mockGetCurrentUserDetails(...args),
+}));
+
+const mockRemarkComponent = jest.fn(({ onSubmit, onCancel }: any) => (
+    <div data-testid="remark-component">
+        <button onClick={() => onSubmit('Reassigning ticket')}>submit-remark</button>
+        <button onClick={onCancel}>cancel-remark</button>
+    </div>
+));
+jest.mock('../../UI/Remark/RemarkComponent', () => ({
+    __esModule: true,
+    default: (props: any) => mockRemarkComponent(props),
+}));
+
+const mockAdvancedDialog = jest.fn(({ open }: any) => (open ? <div data-testid="advanced-dialog" /> : null));
+jest.mock('../AdvancedAssignmentOptionsDialog', () => ({
+    __esModule: true,
+    default: (props: any) => mockAdvancedDialog(props),
+}));
+
+jest.mock('@mui/material', () => {
+    const actual = jest.requireActual('@mui/material');
+    return {
+        ...actual,
+        Menu: ({ open, children }: any) => (open ? <div data-testid="assignee-menu">{children}</div> : null),
+        Tooltip: ({ children }: any) => <>{children}</>,
+        IconButton: ({ onClick, children }: any) => (
+            <button data-testid="assignee-trigger" onClick={onClick}>
+                {children}
+            </button>
+        ),
+        Button: ({ onClick, children }: any) => (
+            <button onClick={onClick}>{children}</button>
+        ),
+        Chip: ({ label, onClick }: any) => (
+            <button data-testid={`chip-${label}`} onClick={onClick}>
+                {label}
+            </button>
+        ),
+        ListItemButton: ({ children, onClick }: any) => (
+            <div data-testid="assignee-option" onClick={onClick}>
+                {children}
+            </div>
+        ),
+    };
+});
+
+const mockUserAvatar = jest.fn(({ name, onClick }: any) => (
+    <button data-testid="assignee-trigger" onClick={onClick}>
+        {name || 'assign'}
+    </button>
+));
+jest.mock('../../UI/UserAvatar/UserAvatar', () => ({
+    __esModule: true,
+    default: (props: any) => mockUserAvatar(props),
+}));
+
+jest.mock('@mui/icons-material/PersonAddAlt', () => () => <span data-testid="add-icon" />);
+
+describe('AssigneeDropdown', () => {
+    const mockLevels = [
+        { levelId: 'L1', levelName: 'Level 1' },
+        { levelId: 'L2', levelName: 'Level 2' },
+    ];
+
+    const mockUsers = [
+        { userId: '1', username: 'agent.one', name: 'Agent One', roles: '3|8', levels: ['L1', 'L2'] },
+        { userId: '2', username: 'agent.two', name: 'Agent Two', roles: '9', levels: ['L1'] },
+    ];
+
+    const mockRoles = [
+        { roleId: '16', role: 'Regional Nodal Officer' },
+    ];
+
+    const mockRnoUsers = [
+        { userId: 'r1', username: 'rno.user', name: 'RNO User', roles: '16', levels: ['L1'] },
+    ];
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseApi.mockReset();
+
+        const levelsHandler = jest.fn(async (fn) => fn());
+        const usersByLevelHandler = jest.fn(async (fn) => fn());
+        const allUsersHandler = jest.fn(async (fn) => fn());
+        const rolesHandler = jest.fn(async (fn) => fn());
+        const rnoHandler = jest.fn(async (fn) => fn());
+        const updateHandler = jest.fn(async (fn) => fn());
+
+        const responses = [
+            { data: mockLevels, apiHandler: levelsHandler },
+            { data: [], apiHandler: usersByLevelHandler },
+            { data: mockUsers, apiHandler: allUsersHandler },
+            { data: mockRoles, apiHandler: rolesHandler },
+            { data: mockRnoUsers, apiHandler: rnoHandler },
+            { apiHandler: updateHandler },
+        ];
+        let callCount = 0;
+        mockUseApi.mockImplementation(() => {
+            const response = responses[callCount % responses.length];
+            callCount += 1;
+            return response;
+        });
+
+        mockGetAllLevels.mockResolvedValue(mockLevels);
+        mockGetAllUsers.mockResolvedValue(mockUsers);
+        mockGetAllUsersByLevel.mockResolvedValue(mockUsers);
+        mockGetAllRoles.mockResolvedValue(mockRoles);
+        mockGetUsersByRoles.mockResolvedValue(mockRnoUsers);
+        mockUpdateTicket.mockResolvedValue({});
+
+        mockGetCurrentUserDetails.mockReturnValue({
+            username: 'current.user',
+            allowedStatusActionIds: ['4', '16'],
+        });
+    });
+
+    it('loads initial data and displays available users when opened', async () => {
+        render(<AssigneeDropdown ticketId="INC-100" />);
+
+        await waitFor(() => expect(mockGetAllLevels).toHaveBeenCalled());
+        expect(mockGetAllUsers).toHaveBeenCalled();
+        expect(mockGetAllRoles).toHaveBeenCalled();
+
+        const triggerButtons = screen.getAllByTestId('assignee-trigger');
+        fireEvent.click(triggerButtons[0]);
+
+        const menu = await screen.findByTestId('assignee-menu');
+        expect(menu).toBeInTheDocument();
+        expect(screen.getAllByText('Agent One').length).toBeGreaterThan(0);
+    });
+
+    it('submits an assignment with remark and notifies callbacks', async () => {
+        const onAssigned = jest.fn();
+        const searchCurrentTicketsPaginatedApi = jest.fn();
+
+        render(
+            <AssigneeDropdown
+                ticketId="INC-101"
+                onAssigned={onAssigned}
+                searchCurrentTicketsPaginatedApi={searchCurrentTicketsPaginatedApi}
+            />,
+        );
+
+        const triggerButtons = screen.getAllByTestId('assignee-trigger');
+        fireEvent.click(triggerButtons[0]);
+
+        const options = await screen.findAllByTestId('assignee-option');
+        fireEvent.click(options[0]);
+        await waitFor(() => expect(mockRemarkComponent).toHaveBeenCalled());
+        const remarkProps = mockRemarkComponent.mock.calls[0][0];
+        remarkProps.onSubmit('Reassigning ticket');
+
+        await waitFor(() => expect(mockUpdateTicket).toHaveBeenCalledWith('INC-101', expect.any(Object)));
+
+        const payload = mockUpdateTicket.mock.calls[0][1];
+        expect(payload).toMatchObject({
+            assignedTo: 'agent.one',
+            assignedToLevel: 'L1',
+            levelId: 'L1',
+        });
+
+        expect(searchCurrentTicketsPaginatedApi).toHaveBeenCalledWith('INC-101');
+        expect(onAssigned).toHaveBeenCalledWith('Agent One');
+    });
+
+    it('opens advanced options dialog and fetches RNO users', async () => {
+        render(<AssigneeDropdown ticketId="INC-200" />);
+
+        const triggerButtons = screen.getAllByTestId('assignee-trigger');
+        fireEvent.click(triggerButtons[0]);
+
+        fireEvent.click(screen.getByText('Advanced Options'));
+
+        await waitFor(() => expect(mockAdvancedDialog).toHaveBeenLastCalledWith(expect.objectContaining({ open: true })));
+        expect(mockGetUsersByRoles).toHaveBeenCalledWith(['16']);
+    });
+});

--- a/ui/src/components/AllTickets/__tests__/TicketsList.test.tsx
+++ b/ui/src/components/AllTickets/__tests__/TicketsList.test.tsx
@@ -1,0 +1,283 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import TicketsList from '../TicketsList';
+import type { TicketRow } from '../TicketsTable';
+
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockUseApi = jest.fn();
+jest.mock('../../../hooks/useApi', () => ({
+    useApi: (...args: any[]) => mockUseApi(...args),
+}));
+
+const mockUseDebounce = jest.fn((value) => value);
+jest.mock('../../../hooks/useDebounce', () => ({
+    useDebounce: (...args: any[]) => mockUseDebounce(...args),
+}));
+
+const mockUseCategoryFilters = jest.fn();
+jest.mock('../../../hooks/useCategoryFilters', () => ({
+    useCategoryFilters: (...args: any[]) => mockUseCategoryFilters(...args),
+}));
+
+const mockSearchTicketsPaginated = jest.fn();
+jest.mock('../../../services/TicketService', () => ({
+    searchTicketsPaginated: (...args: any[]) => mockSearchTicketsPaginated(...args),
+}));
+
+const mockGetStatuses = jest.fn();
+const mockSetStatusListInSession = jest.fn();
+jest.mock('../../../utils/Utils', () => ({
+    getStatuses: (...args: any[]) => mockGetStatuses(...args),
+    setStatusList: (...args: any[]) => mockSetStatusListInSession(...args),
+}));
+
+const mockCheckMyTicketsAccess = jest.fn(() => true);
+jest.mock('../../../utils/permissions', () => ({
+    checkMyTicketsAccess: (...args: any[]) => mockCheckMyTicketsAccess(...args),
+}));
+
+const mockGetStatusWorkflowMappings = jest.fn();
+const mockGetAllowedStatusListByRoles = jest.fn();
+jest.mock('../../../services/StatusService', () => ({
+    getStatusWorkflowMappings: (...args: any[]) => mockGetStatusWorkflowMappings(...args),
+    getAllowedStatusListByRoles: (...args: any[]) => mockGetAllowedStatusListByRoles(...args),
+}));
+
+const mockGetCurrentUserDetails = jest.fn();
+jest.mock('../../../config/config', () => ({
+    getCurrentUserDetails: (...args: any[]) => mockGetCurrentUserDetails(...args),
+}));
+
+jest.mock('../../Title', () => ({ textKey }: { textKey: string }) => <h1>{textKey}</h1>);
+
+const mockTicketsTable = jest.fn(() => <div data-testid="tickets-table" />);
+jest.mock('../TicketsTable', () => ({
+    __esModule: true,
+    default: (props: any) => mockTicketsTable(props),
+}));
+
+const mockTicketCard = jest.fn(({ ticket }: { ticket: TicketRow }) => (
+    <div data-testid="ticket-card">{ticket.subject}</div>
+));
+jest.mock('../TicketCard', () => ({
+    __esModule: true,
+    default: (props: any) => mockTicketCard(props),
+}));
+
+const mockViewTicket = jest.fn(() => <div data-testid="view-ticket" />);
+jest.mock('../ViewTicket', () => ({
+    __esModule: true,
+    default: (props: any) => mockViewTicket(props),
+}));
+
+jest.mock('../../UI/ViewToggle', () => ({ value, onChange }: { value: string; onChange: (val: string) => void }) => (
+    <div>
+        <button data-testid="toggle-grid" onClick={() => onChange('grid')}>
+            grid
+        </button>
+        <span data-testid="current-view">{value}</span>
+    </div>
+));
+
+jest.mock('../../UI/Dropdown/DropdownController', () => ({ label, value, onChange, options }: any) => (
+    <label>
+        {label}
+        <select data-testid={`dropdown-${label}`} value={value} onChange={(e) => onChange(e.target.value)}>
+            {options.map((opt: any) => (
+                <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                </option>
+            ))}
+        </select>
+    </label>
+));
+
+jest.mock('../../PaginationControls', () => ({ page, onChange, pageSize, onPageSizeChange }: any) => (
+    <div data-testid="pagination-controls">
+        <button onClick={() => onChange({}, page + 1)}>Next</button>
+        <button onClick={() => onPageSizeChange(pageSize + 5)}>Size</button>
+    </div>
+));
+
+jest.mock('../../UI/Input/GenericInput', () => ({ value, onChange }: any) => (
+    <input data-testid="tickets-search" value={value} onChange={onChange} />
+));
+
+const mockGetDateRangeApiParams = jest.fn(() => ({ fromDate: undefined, toDate: undefined }));
+jest.mock('../../Filters/DateRangeFilter', () => ({
+    __esModule: true,
+    default: ({ onChange }: any) => (
+        <button data-testid="date-range" onClick={() => onChange({ preset: 'TODAY' })}>
+            date
+        </button>
+    ),
+    getDateRangeApiParams: (...args: any[]) => mockGetDateRangeApiParams(...args),
+}));
+
+describe('TicketsList', () => {
+    const mockTickets: TicketRow[] = [
+        {
+            id: 'INC-1',
+            subject: 'Printer not working',
+            category: 'IT',
+            subCategory: 'Hardware',
+            priority: 'High',
+            priorityId: 'P1',
+            isMaster: false,
+        },
+        {
+            id: 'INC-2',
+            subject: 'Login issue',
+            category: 'IT',
+            subCategory: 'Access',
+            priority: 'Medium',
+            priorityId: 'P2',
+            isMaster: true,
+        },
+    ];
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseApi.mockReset();
+        mockGetDateRangeApiParams.mockReturnValue({ fromDate: undefined, toDate: undefined });
+        mockCheckMyTicketsAccess.mockReturnValue(true);
+
+        mockUseCategoryFilters.mockReturnValue({
+            categoryOptions: [
+                { label: 'All', value: 'All' },
+                { label: 'IT', value: 'IT' },
+            ],
+            subCategoryOptions: [
+                { label: 'All', value: 'All' },
+                { label: 'Hardware', value: 'Hardware' },
+            ],
+            loadSubCategories: jest.fn(),
+        });
+
+        mockGetCurrentUserDetails.mockReturnValue({
+            levels: ['L1'],
+            role: ['Agent'],
+        });
+
+        mockGetStatuses.mockResolvedValue([
+            { statusId: 'OPEN', statusName: 'Open' },
+            { statusId: 'CLOSED', statusName: 'Closed' },
+        ]);
+        mockSetStatusListInSession.mockResolvedValue(undefined);
+
+        mockGetStatusWorkflowMappings.mockResolvedValue({
+            OPEN: [],
+        });
+
+        mockGetAllowedStatusListByRoles.mockResolvedValue(['OPEN', 'CLOSED']);
+
+        mockSearchTicketsPaginated.mockResolvedValue({ items: mockTickets, totalPages: 2 });
+
+        mockUseDebounce.mockImplementation((value) => value);
+    });
+
+    const arrangeUseApiMocks = (overrides?: { data?: any; workflowData?: any; allowedData?: any }) => {
+        const searchHandler = jest.fn(async (fn) => fn());
+        const workflowHandler = jest.fn(async (fn) => fn());
+        const allowedHandler = jest.fn(async (fn) => fn());
+
+        const searchResponse = {
+            data: overrides?.data ?? { items: mockTickets, totalPages: 2 },
+            pending: false,
+            apiHandler: searchHandler,
+        };
+        const workflowResponse = {
+            data: overrides?.workflowData ?? { OPEN: [] },
+            pending: false,
+            apiHandler: workflowHandler,
+        };
+        const allowedResponse = {
+            data: overrides?.allowedData ?? ['OPEN', 'CLOSED'],
+            pending: false,
+            apiHandler: allowedHandler,
+        };
+
+        const responses = [searchResponse, workflowResponse, allowedResponse];
+        let callCount = 0;
+        mockUseApi.mockImplementation(() => {
+            const response = responses[callCount % responses.length];
+            callCount += 1;
+            return response;
+        });
+
+        return { searchHandler, workflowHandler, allowedHandler };
+    };
+
+    it('renders table view with fetched tickets and triggers initial search', async () => {
+        const { searchHandler } = arrangeUseApiMocks();
+
+        render(<TicketsList titleKey="tickets.title" />);
+
+        await waitFor(() => expect(searchHandler).toHaveBeenCalled());
+        await waitFor(() => expect(mockTicketsTable).toHaveBeenCalled());
+
+        expect(screen.getByRole('heading', { name: 'tickets.title' })).toBeInTheDocument();
+
+        const tableProps = mockTicketsTable.mock.calls[mockTicketsTable.mock.calls.length - 1][0];
+        expect(tableProps.tickets).toEqual(mockTickets);
+        expect(tableProps.permissionPathPrefix).toBe('myTickets');
+
+        expect(mockSearchTicketsPaginated).toHaveBeenCalledWith(
+            '',
+            undefined,
+            undefined,
+            0,
+            5,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            'reportedDate',
+            'desc',
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+        );
+    });
+
+    it('switches to grid view when view toggle is used', async () => {
+        const { searchHandler } = arrangeUseApiMocks();
+
+        render(<TicketsList titleKey="tickets.title" />);
+
+        await waitFor(() => expect(searchHandler).toHaveBeenCalled());
+        await waitFor(() => expect(mockTicketsTable).toHaveBeenCalled());
+
+        fireEvent.click(screen.getByTestId('toggle-grid'));
+
+        await waitFor(() => expect(mockTicketCard).toHaveBeenCalledTimes(mockTickets.length));
+        expect(mockTicketCard).toHaveBeenCalledWith(
+            expect.objectContaining({ ticket: expect.objectContaining({ id: 'INC-1' }) }),
+        );
+    });
+
+    it('triggers a new search when the query changes', async () => {
+        const { searchHandler } = arrangeUseApiMocks();
+
+        render(<TicketsList titleKey="tickets.title" />);
+
+        await waitFor(() => expect(searchHandler).toHaveBeenCalled());
+
+        const searchInput = screen.getByTestId('tickets-search');
+        fireEvent.change(searchInput, { target: { value: 'INC' } });
+
+        await waitFor(() => {
+            expect(mockSearchTicketsPaginated).toHaveBeenCalled();
+            const lastCall = mockSearchTicketsPaginated.mock.calls[mockSearchTicketsPaginated.mock.calls.length - 1];
+            expect(lastCall[0]).toBe('INC');
+            expect(lastCall[3]).toBe(0);
+            expect(lastCall[4]).toBe(5);
+        });
+    });
+});

--- a/ui/src/components/AllTickets/__tests__/TicketsTable.test.tsx
+++ b/ui/src/components/AllTickets/__tests__/TicketsTable.test.tsx
@@ -1,0 +1,217 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import TicketsTable, { TicketRow } from '../TicketsTable';
+
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+    useNavigate: () => mockNavigate,
+}), { virtual: true });
+
+const mockUseApi = jest.fn();
+jest.mock('../../../hooks/useApi', () => ({
+    useApi: (...args: any[]) => mockUseApi(...args),
+}));
+
+const mockCheckAccessMaster = jest.fn(() => true);
+const mockCheckMyTicketsColumnAccess = jest.fn(() => true);
+jest.mock('../../../utils/permissions', () => ({
+    checkAccessMaster: (...args: any[]) => mockCheckAccessMaster(...args),
+    checkMyTicketsColumnAccess: (...args: any[]) => mockCheckMyTicketsColumnAccess(...args),
+}));
+
+const mockGetStatusNameById = jest.fn(() => 'Open');
+const mockTruncateWithEllipsis = jest.fn((value: string) => value);
+jest.mock('../../../utils/Utils', () => ({
+    getStatusNameById: (...args: any[]) => mockGetStatusNameById(...args),
+    truncateWithEllipsis: (...args: any[]) => mockTruncateWithEllipsis(...args),
+}));
+
+const mockAssigneeDropdown = jest.fn(() => <div data-testid="assignee-dropdown" />);
+jest.mock('../AssigneeDropdown', () => ({
+    __esModule: true,
+    default: (props: any) => mockAssigneeDropdown(props),
+}));
+
+const mockRemarkComponent = jest.fn(() => <div data-testid="remark-component" />);
+jest.mock('../../UI/Remark/RemarkComponent', () => ({
+    __esModule: true,
+    default: (props: any) => mockRemarkComponent(props),
+}));
+
+const mockUserAvatar = jest.fn(({ name }: { name: string }) => <div data-testid="user-avatar">{name}</div>);
+jest.mock('../../UI/UserAvatar/UserAvatar', () => ({
+    __esModule: true,
+    default: (props: any) => mockUserAvatar(props),
+}));
+
+const mockRequestorDetails = jest.fn(() => <div data-testid="requestor-details" />);
+jest.mock('../RequestorDetails', () => ({
+    __esModule: true,
+    default: (props: any) => mockRequestorDetails(props),
+}));
+
+const mockPriorityIcon = jest.fn(({ priorityText }: { priorityText: string }) => (
+    <div data-testid="priority-icon">{priorityText}</div>
+));
+jest.mock('../../UI/Icons/PriorityIcon', () => ({
+    __esModule: true,
+    default: (props: any) => mockPriorityIcon(props),
+}));
+
+const mockCustomIconButton = jest.fn(({ icon, onClick, className }: any) => (
+    <button data-testid={`custom-icon-${icon}`} onClick={onClick} className={className || ''} />
+));
+jest.mock('../../UI/IconButton/CustomIconButton', () => {
+    const MockIconComponent = ({ icon, className }: any) => (
+        <span data-testid={`icon-component-${icon}`} className={className} />
+    );
+    return {
+        __esModule: true,
+        default: (props: any) => mockCustomIconButton(props),
+        IconComponent: MockIconComponent,
+    };
+});
+
+const mockGenericTable = jest.fn((props: any) => <div data-testid="generic-table" />);
+jest.mock('../../UI/GenericTable', () => ({
+    __esModule: true,
+    default: (props: any) => mockGenericTable(props),
+}));
+
+jest.mock('@mui/material', () => {
+    const actual = jest.requireActual('@mui/material');
+    return {
+        ...actual,
+        Tooltip: ({ children }: any) => <>{children}</>,
+    };
+});
+
+const mockUpdateTicket = jest.fn();
+jest.mock('../../../services/TicketService', () => ({
+    updateTicket: (...args: any[]) => mockUpdateTicket(...args),
+}));
+
+const mockGetCurrentUserDetails = jest.fn(() => ({ username: 'agent.user' }));
+jest.mock('../../../config/config', () => ({
+    getCurrentUserDetails: (...args: any[]) => mockGetCurrentUserDetails(...args),
+}));
+
+const tickets: TicketRow[] = [
+    {
+        id: 'INC-001',
+        subject: 'Network outage',
+        category: 'Infrastructure',
+        subCategory: 'Network',
+        priority: 'Critical',
+        priorityId: 'P1',
+        isMaster: true,
+        requestorName: 'Jane Smith',
+        requestorEmailId: 'jane@example.com',
+        requestorMobileNo: '1234567890',
+        statusId: 'OPEN',
+        assignedTo: 'agent1',
+        assignedToName: 'Agent One',
+        feedbackStatus: 'PENDING',
+        severity: 'High',
+        severityId: 'S1',
+        severityLabel: 'High',
+    },
+];
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseApi.mockReset();
+    mockUseApi.mockImplementation(() => ({ apiHandler: jest.fn(async (fn) => fn()) }));
+    mockNavigate.mockReset();
+    mockCheckAccessMaster.mockImplementation(() => true);
+    mockCheckMyTicketsColumnAccess.mockImplementation(() => true);
+});
+
+describe('TicketsTable', () => {
+    it('passes rows to GenericTable and highlights refreshing ticket', async () => {
+        render(
+            <TicketsTable
+                tickets={tickets}
+                onIdClick={jest.fn()}
+                onRowClick={jest.fn()}
+                searchCurrentTicketsPaginatedApi={jest.fn()}
+                refreshingTicketId="INC-001"
+                statusWorkflows={{ OPEN: [] }}
+            />,
+        );
+
+        await waitFor(() => expect(mockGenericTable).toHaveBeenCalled());
+        const tableProps = mockGenericTable.mock.calls[0][0];
+        expect(tableProps.dataSource).toEqual(tickets);
+        expect(tableProps.rowClassName(tickets[0])).toBe('refreshing-row');
+    });
+
+    it('renders assignee dropdown when assignment is allowed', async () => {
+        render(
+            <TicketsTable
+                tickets={tickets}
+                onIdClick={jest.fn()}
+                onRowClick={jest.fn()}
+                searchCurrentTicketsPaginatedApi={jest.fn()}
+                statusWorkflows={{ OPEN: [{ id: '1', action: 'Resolve', nextStatus: 'RESOLVED' }] as any }}
+            />,
+        );
+
+        await waitFor(() => expect(mockGenericTable).toHaveBeenCalled());
+        const tableProps = mockGenericTable.mock.calls[0][0];
+        const assigneeColumn = tableProps.columns.find((col: any) => col.key === 'assignee');
+        expect(assigneeColumn).toBeDefined();
+        const renderedAssignee = assigneeColumn.render(null, tickets[0]);
+        expect(React.isValidElement(renderedAssignee)).toBe(true);
+        render(<>{renderedAssignee}</>);
+        expect(mockAssigneeDropdown).toHaveBeenCalledWith(
+            expect.objectContaining({ ticketId: 'INC-001', assigneeName: 'Agent One' }),
+        );
+    });
+
+    it('includes severity column when enabled', async () => {
+        render(
+            <TicketsTable
+                tickets={tickets}
+                onIdClick={jest.fn()}
+                onRowClick={jest.fn()}
+                searchCurrentTicketsPaginatedApi={jest.fn()}
+                statusWorkflows={{ OPEN: [] }}
+                showSeverityColumn
+            />,
+        );
+
+        await waitFor(() => expect(mockGenericTable).toHaveBeenCalled());
+        const tableProps = mockGenericTable.mock.calls[0][0];
+        const severityColumn = tableProps.columns.find((col: any) => col.key === 'severity');
+        expect(severityColumn).toBeDefined();
+
+        const rendered = render(<>{severityColumn.render(null, tickets[0])}</>);
+        expect(rendered.getByText('High')).toBeInTheDocument();
+    });
+
+    it('renders RCA action button when rcaStatus is provided', async () => {
+        const rcaTickets: TicketRow[] = [{ ...tickets[0], rcaStatus: 'PENDING' }];
+
+        render(
+            <TicketsTable
+                tickets={rcaTickets}
+                onIdClick={jest.fn()}
+                onRowClick={jest.fn()}
+                searchCurrentTicketsPaginatedApi={jest.fn()}
+                statusWorkflows={{ OPEN: [] }}
+            />,
+        );
+
+        await waitFor(() => expect(mockGenericTable).toHaveBeenCalled());
+        const tableProps = mockGenericTable.mock.calls[0][0];
+        const actionsColumn = tableProps.columns.find((col: any) => col.key === 'action');
+        expect(actionsColumn).toBeDefined();
+        const rendered = render(<>{actionsColumn.render(null, rcaTickets[0])}</>);
+        expect(rendered.getByRole('button')).toHaveTextContent('Submit RCA');
+    });
+});


### PR DESCRIPTION
## Summary
- add Jest tests for TicketsList to exercise data fetching, grid toggle, and search updates
- add Jest tests for TicketsTable to verify column rendering, severity display, and RCA actions
- cover AssigneeDropdown flows including data loading, assignment submission, and advanced options dialog

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e4b43c84f48332b5bb792ca02634a2