### PR TITLE
Add MIS reports dashboard and backend endpoints

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/controller/ReportsController.java
+++ b/api/src/main/java/com/ticketingSystem/api/controller/ReportsController.java
@@ -1,0 +1,41 @@
+package com.ticketingSystem.api.controller;
+
+import com.ticketingSystem.api.dto.reports.CustomerSatisfactionReportDto;
+import com.ticketingSystem.api.dto.reports.ProblemManagementReportDto;
+import com.ticketingSystem.api.dto.reports.TicketResolutionTimeReportDto;
+import com.ticketingSystem.api.dto.reports.TicketSummaryReportDto;
+import com.ticketingSystem.api.service.ReportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/reports")
+@CrossOrigin(origins = "http://localhost:3000")
+@RequiredArgsConstructor
+public class ReportsController {
+    private final ReportService reportService;
+
+    @GetMapping("/ticket-summary")
+    public ResponseEntity<TicketSummaryReportDto> getTicketSummaryReport() {
+        return ResponseEntity.ok(reportService.getTicketSummaryReport());
+    }
+
+    @GetMapping("/resolution-time")
+    public ResponseEntity<TicketResolutionTimeReportDto> getTicketResolutionTimeReport() {
+        return ResponseEntity.ok(reportService.getTicketResolutionTimeReport());
+    }
+
+    @GetMapping("/customer-satisfaction")
+    public ResponseEntity<CustomerSatisfactionReportDto> getCustomerSatisfactionReport() {
+        return ResponseEntity.ok(reportService.getCustomerSatisfactionReport());
+    }
+
+    @GetMapping("/problem-management")
+    public ResponseEntity<ProblemManagementReportDto> getProblemManagementReport() {
+        return ResponseEntity.ok(reportService.getProblemManagementReport());
+    }
+}

--- a/api/src/main/java/com/ticketingSystem/api/dto/reports/CustomerSatisfactionReportDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/reports/CustomerSatisfactionReportDto.java
@@ -1,0 +1,19 @@
+package com.ticketingSystem.api.dto.reports;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomerSatisfactionReportDto {
+    private long totalResponses;
+    private double overallSatisfactionAverage;
+    private double resolutionEffectivenessAverage;
+    private double communicationSupportAverage;
+    private double timelinessAverage;
+    private double compositeScore;
+}

--- a/api/src/main/java/com/ticketingSystem/api/dto/reports/ProblemCategoryStatDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/reports/ProblemCategoryStatDto.java
@@ -1,0 +1,15 @@
+package com.ticketingSystem.api.dto.reports;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProblemCategoryStatDto {
+    private String category;
+    private long ticketCount;
+}

--- a/api/src/main/java/com/ticketingSystem/api/dto/reports/ProblemManagementReportDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/reports/ProblemManagementReportDto.java
@@ -1,0 +1,16 @@
+package com.ticketingSystem.api.dto.reports;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProblemManagementReportDto {
+    private List<ProblemCategoryStatDto> categoryStats;
+}

--- a/api/src/main/java/com/ticketingSystem/api/dto/reports/TicketResolutionTimeReportDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/reports/TicketResolutionTimeReportDto.java
@@ -1,0 +1,18 @@
+package com.ticketingSystem.api.dto.reports;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TicketResolutionTimeReportDto {
+    private double averageResolutionHours;
+    private long resolvedTicketCount;
+    private Map<String, Double> averageResolutionHoursByStatus;
+}

--- a/api/src/main/java/com/ticketingSystem/api/dto/reports/TicketSummaryReportDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/reports/TicketSummaryReportDto.java
@@ -1,0 +1,20 @@
+package com.ticketingSystem.api.dto.reports;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TicketSummaryReportDto {
+    private long totalTickets;
+    private long openTickets;
+    private long closedTickets;
+    private Map<String, Long> statusCounts;
+    private Map<String, Long> modeCounts;
+}

--- a/api/src/main/java/com/ticketingSystem/api/repository/TicketRepository.java
+++ b/api/src/main/java/com/ticketingSystem/api/repository/TicketRepository.java
@@ -1,5 +1,6 @@
 package com.ticketingSystem.api.repository;
 
+import com.ticketingSystem.api.enums.Mode;
 import com.ticketingSystem.api.models.Ticket;
 import com.ticketingSystem.api.enums.TicketStatus;
 import org.springframework.data.domain.Page;
@@ -21,6 +22,20 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
     List<Ticket> findByMasterId(String masterId);
 
     public List<Ticket> findByLastModifiedAfter(LocalDateTime lastSyncedTime);
+
+    long countByTicketStatus(TicketStatus ticketStatus);
+
+    @Query("SELECT t.ticketStatus AS status, COUNT(t) AS count FROM Ticket t GROUP BY t.ticketStatus")
+    List<StatusCountProjection> countTicketsByStatus();
+
+    @Query("SELECT t.mode AS mode, COUNT(t) AS count FROM Ticket t GROUP BY t.mode")
+    List<ModeCountProjection> countTicketsByMode();
+
+    @Query("SELECT t.category AS category, COUNT(t) AS count FROM Ticket t WHERE t.category IS NOT NULL GROUP BY t.category")
+    List<CategoryCountProjection> countTicketsByCategory();
+
+    @Query("SELECT t FROM Ticket t WHERE t.reportedDate IS NOT NULL AND t.resolvedAt IS NOT NULL")
+    List<Ticket> findResolvedTickets();
 
     List<Ticket> findByTicketStatusAndLastModifiedBefore(TicketStatus ticketStatus, LocalDateTime time);
 
@@ -82,4 +97,22 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
                                @Param("fromDate") LocalDateTime fromDate,
                                @Param("toDate") LocalDateTime toDate,
                                Pageable pageable);
+
+    interface StatusCountProjection {
+        TicketStatus getStatus();
+
+        Long getCount();
+    }
+
+    interface ModeCountProjection {
+        Mode getMode();
+
+        Long getCount();
+    }
+
+    interface CategoryCountProjection {
+        String getCategory();
+
+        Long getCount();
+    }
 }

--- a/api/src/main/java/com/ticketingSystem/api/service/ReportService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/ReportService.java
@@ -1,0 +1,169 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.dto.reports.CustomerSatisfactionReportDto;
+import com.ticketingSystem.api.dto.reports.ProblemCategoryStatDto;
+import com.ticketingSystem.api.dto.reports.ProblemManagementReportDto;
+import com.ticketingSystem.api.dto.reports.TicketResolutionTimeReportDto;
+import com.ticketingSystem.api.dto.reports.TicketSummaryReportDto;
+import com.ticketingSystem.api.enums.TicketStatus;
+import com.ticketingSystem.api.models.Ticket;
+import com.ticketingSystem.api.models.TicketFeedback;
+import com.ticketingSystem.api.repository.TicketFeedbackRepository;
+import com.ticketingSystem.api.repository.TicketRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.DoubleSummaryStatistics;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+    private final TicketRepository ticketRepository;
+    private final TicketFeedbackRepository ticketFeedbackRepository;
+
+    public TicketSummaryReportDto getTicketSummaryReport() {
+        long totalTickets = ticketRepository.count();
+        long openTickets = ticketRepository.countByTicketStatus(TicketStatus.OPEN);
+        long closedTickets = ticketRepository.countByTicketStatus(TicketStatus.CLOSED);
+
+        Map<String, Long> statusCounts = ticketRepository.countTicketsByStatus().stream()
+                .collect(Collectors.toMap(
+                        projection -> projection.getStatus() != null
+                                ? projection.getStatus().name()
+                                : "UNKNOWN",
+                        projection -> Optional.ofNullable(projection.getCount()).orElse(0L),
+                        Long::sum,
+                        LinkedHashMap::new
+                ));
+
+        Map<String, Long> modeCounts = ticketRepository.countTicketsByMode().stream()
+                .collect(Collectors.toMap(
+                        projection -> projection.getMode() != null
+                                ? projection.getMode().name().toUpperCase(Locale.ROOT)
+                                : "UNSPECIFIED",
+                        projection -> Optional.ofNullable(projection.getCount()).orElse(0L),
+                        Long::sum,
+                        LinkedHashMap::new
+                ));
+
+        return TicketSummaryReportDto.builder()
+                .totalTickets(totalTickets)
+                .openTickets(openTickets)
+                .closedTickets(closedTickets)
+                .statusCounts(statusCounts)
+                .modeCounts(modeCounts)
+                .build();
+    }
+
+    public TicketResolutionTimeReportDto getTicketResolutionTimeReport() {
+        List<Ticket> resolvedTickets = ticketRepository.findResolvedTickets();
+
+        Map<String, DoubleSummaryStatistics> statsByStatus = resolvedTickets.stream()
+                .filter(ticket -> ticket.getReportedDate() != null && ticket.getResolvedAt() != null)
+                .collect(Collectors.groupingBy(
+                        ticket -> ticket.getTicketStatus() != null ? ticket.getTicketStatus().name() : "RESOLVED",
+                        Collectors.summarizingDouble(ticket -> getResolutionDurationInHours(ticket.getReportedDate(), ticket.getResolvedAt()))
+                ));
+
+        Map<String, Double> averageByStatus = statsByStatus.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> entry.getValue().getCount() == 0 ? 0.0 : round(entry.getValue().getAverage()),
+                        (a, b) -> b,
+                        LinkedHashMap::new
+                ));
+
+        double overallAverage = resolvedTickets.stream()
+                .filter(ticket -> ticket.getReportedDate() != null && ticket.getResolvedAt() != null)
+                .mapToDouble(ticket -> getResolutionDurationInHours(ticket.getReportedDate(), ticket.getResolvedAt()))
+                .average()
+                .orElse(0.0);
+
+        return TicketResolutionTimeReportDto.builder()
+                .resolvedTicketCount(resolvedTickets.size())
+                .averageResolutionHours(round(overallAverage))
+                .averageResolutionHoursByStatus(averageByStatus)
+                .build();
+    }
+
+    public CustomerSatisfactionReportDto getCustomerSatisfactionReport() {
+        List<TicketFeedback> feedbackList = ticketFeedbackRepository.findAll();
+
+        if (feedbackList.isEmpty()) {
+            return CustomerSatisfactionReportDto.builder()
+                    .totalResponses(0)
+                    .overallSatisfactionAverage(0.0)
+                    .resolutionEffectivenessAverage(0.0)
+                    .communicationSupportAverage(0.0)
+                    .timelinessAverage(0.0)
+                    .compositeScore(0.0)
+                    .build();
+        }
+
+        OptionalDouble overallSatisfaction = feedbackList.stream()
+                .mapToInt(TicketFeedback::getOverallSatisfaction)
+                .average();
+        OptionalDouble resolutionEffectiveness = feedbackList.stream()
+                .mapToInt(TicketFeedback::getResolutionEffectiveness)
+                .average();
+        OptionalDouble communicationSupport = feedbackList.stream()
+                .mapToInt(TicketFeedback::getCommunicationSupport)
+                .average();
+        OptionalDouble timeliness = feedbackList.stream()
+                .mapToInt(TicketFeedback::getTimeliness)
+                .average();
+
+        double compositeScore = feedbackList.stream()
+                .mapToDouble(feedback -> (
+                        feedback.getOverallSatisfaction()
+                                + feedback.getResolutionEffectiveness()
+                                + feedback.getCommunicationSupport()
+                                + feedback.getTimeliness()
+                ) / 4.0)
+                .average()
+                .orElse(0.0);
+
+        return CustomerSatisfactionReportDto.builder()
+                .totalResponses(feedbackList.size())
+                .overallSatisfactionAverage(round(overallSatisfaction.orElse(0.0)))
+                .resolutionEffectivenessAverage(round(resolutionEffectiveness.orElse(0.0)))
+                .communicationSupportAverage(round(communicationSupport.orElse(0.0)))
+                .timelinessAverage(round(timeliness.orElse(0.0)))
+                .compositeScore(round(compositeScore))
+                .build();
+    }
+
+    public ProblemManagementReportDto getProblemManagementReport() {
+        List<ProblemCategoryStatDto> categoryStats = ticketRepository.countTicketsByCategory().stream()
+                .sorted(Comparator.comparingLong(TicketRepository.CategoryCountProjection::getCount).reversed())
+                .map(projection -> ProblemCategoryStatDto.builder()
+                        .category(projection.getCategory())
+                        .ticketCount(Optional.ofNullable(projection.getCount()).orElse(0L))
+                        .build())
+                .collect(Collectors.toList());
+
+        return ProblemManagementReportDto.builder()
+                .categoryStats(categoryStats)
+                .build();
+    }
+
+    private double getResolutionDurationInHours(LocalDateTime reportedAt, LocalDateTime resolvedAt) {
+        Duration duration = Duration.between(reportedAt, resolvedAt);
+        return duration.toMinutes() / 60.0;
+    }
+
+    private double round(double value) {
+        return Math.round(value * 100.0) / 100.0;
+    }
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -18,6 +18,7 @@ import MyWorkload from './pages/MyWorkload';
 import Faq from './pages/Faq';
 import FaqForm from './pages/FaqForm';
 import RootCauseAnalysis from './pages/RootCauseAnalysis';
+import MISReports from './pages/MISReports';
 import { getUserDetails, getUserPermissions } from './utils/Utils';
 import { NotificationProvider } from './context/NotificationContext';
 import { DevModeContext } from './context/DevModeContext';
@@ -62,6 +63,7 @@ function App() {
         <Route path="root-cause-analysis/:ticketId" element={<TicketDetails />} />
         <Route path="tickets/:ticketId/feedback" element={<CustomerSatisfactionForm />} />
         <Route path="knowledge-base" element={<KnowledgeBase />} />
+        <Route path="mis-reports" element={<MISReports />} />
         <Route path="categories-master" element={<CategoriesMaster />} />
         <Route path="escalation-master" element={<EscalationMaster />} />
         <Route path="role-master" element={<RoleMaster />} />

--- a/ui/src/components/Layout/Sidebar.tsx
+++ b/ui/src/components/Layout/Sidebar.tsx
@@ -54,6 +54,12 @@ const menuItems = [
     icon: "libraryBooks",
   },
   {
+    key: "misReports",
+    label: "MIS Reports",
+    to: "/mis-reports",
+    icon: "timeline",
+  },
+  {
     key: "categoriesMaster",
     label: "Categories Master",
     to: "/categories-master",

--- a/ui/src/components/MISReports/CustomerSatisfactionReport.tsx
+++ b/ui/src/components/MISReports/CustomerSatisfactionReport.tsx
@@ -1,0 +1,94 @@
+import React, { useEffect, useMemo } from "react";
+import { Box, Typography } from "@mui/material";
+import ReactECharts from "echarts-for-react";
+import CustomFieldset from "../CustomFieldset";
+import { useApi } from "../../hooks/useApi";
+import { fetchCustomerSatisfactionReport } from "../../services/ReportService";
+import { CustomerSatisfactionReport } from "../../types/reports";
+
+const CustomerSatisfactionReport: React.FC = () => {
+    const { data, pending, apiHandler } = useApi<CustomerSatisfactionReport>();
+
+    useEffect(() => {
+        apiHandler(() => fetchCustomerSatisfactionReport());
+    }, [apiHandler]);
+
+    const chartOptions = useMemo(() => {
+        if (!data) {
+            return {};
+        }
+
+        const metrics = [
+            { name: "Overall", value: data.overallSatisfactionAverage },
+            { name: "Resolution", value: data.resolutionEffectivenessAverage },
+            { name: "Communication", value: data.communicationSupportAverage },
+            { name: "Timeliness", value: data.timelinessAverage },
+        ];
+
+        return {
+            tooltip: {
+                trigger: "axis",
+            },
+            xAxis: {
+                type: "category",
+                data: metrics.map(metric => metric.name),
+            },
+            yAxis: {
+                type: "value",
+                min: 0,
+                max: 5,
+            },
+            series: [
+                {
+                    type: "bar",
+                    data: metrics.map(metric => Number(metric.value.toFixed(2))),
+                    itemStyle: {
+                        color: "#f57c00",
+                    },
+                },
+            ],
+        };
+    }, [data]);
+
+    return (
+        <CustomFieldset title="Customer Satisfaction" variant="bordered">
+            {pending && (
+                <Typography variant="body2" fontStyle="italic">
+                    Gathering feedback trends...
+                </Typography>
+            )}
+
+            {!pending && data && (
+                <Box display="flex" flexDirection="column" gap={2}>
+                    <Box display="flex" flexWrap="wrap" gap={4}>
+                        <Box>
+                            <Typography variant="subtitle2" color="text.secondary">
+                                Total Feedback Responses
+                            </Typography>
+                            <Typography variant="h5" fontWeight={700}>
+                                {data.totalResponses}
+                            </Typography>
+                        </Box>
+                        <Box>
+                            <Typography variant="subtitle2" color="text.secondary">
+                                Composite Satisfaction Score
+                            </Typography>
+                            <Typography variant="h5" fontWeight={700}>
+                                {data.compositeScore.toFixed(2)} / 5
+                            </Typography>
+                        </Box>
+                    </Box>
+
+                    <Box>
+                        <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                            Average Ratings by Dimension
+                        </Typography>
+                        <ReactECharts option={chartOptions} style={{ height: 280 }} />
+                    </Box>
+                </Box>
+            )}
+        </CustomFieldset>
+    );
+};
+
+export default CustomerSatisfactionReport;

--- a/ui/src/components/MISReports/ProblemManagementReport.tsx
+++ b/ui/src/components/MISReports/ProblemManagementReport.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useMemo } from "react";
+import { Box, Typography } from "@mui/material";
+import ReactECharts from "echarts-for-react";
+import CustomFieldset from "../CustomFieldset";
+import { useApi } from "../../hooks/useApi";
+import { fetchProblemManagementReport } from "../../services/ReportService";
+import { ProblemManagementReport } from "../../types/reports";
+
+const ProblemManagementReport: React.FC = () => {
+    const { data, pending, apiHandler } = useApi<ProblemManagementReport>();
+
+    useEffect(() => {
+        apiHandler(() => fetchProblemManagementReport());
+    }, [apiHandler]);
+
+    const chartOptions = useMemo(() => {
+        const stats = data?.categoryStats ?? [];
+        return {
+            tooltip: {
+                trigger: "axis",
+            },
+            grid: {
+                left: "3%",
+                right: "4%",
+                bottom: "3%",
+                containLabel: true,
+            },
+            xAxis: {
+                type: "value",
+            },
+            yAxis: {
+                type: "category",
+                data: stats.map(stat => stat.category),
+                axisLabel: {
+                    formatter: (value: string) => value?.length > 18 ? `${value.slice(0, 18)}…` : value,
+                },
+            },
+            series: [
+                {
+                    type: "bar",
+                    data: stats.map(stat => stat.ticketCount),
+                    itemStyle: {
+                        color: "#0288d1",
+                    },
+                },
+            ],
+        };
+    }, [data]);
+
+    const topCategory = useMemo(() => {
+        if (!data?.categoryStats?.length) {
+            return null;
+        }
+
+        return data.categoryStats.reduce((prev, current) =>
+            current.ticketCount > prev.ticketCount ? current : prev
+        );
+    }, [data]);
+
+    return (
+        <CustomFieldset title="Problem Management" variant="bordered">
+            {pending && (
+                <Typography variant="body2" fontStyle="italic">
+                    Analysing recurring issues...
+                </Typography>
+            )}
+
+            {!pending && data && (
+                <Box display="flex" flexDirection="column" gap={2}>
+                    {topCategory && (
+                        <Box>
+                            <Typography variant="subtitle2" color="text.secondary">
+                                Most Reported Category
+                            </Typography>
+                            <Typography variant="h6" fontWeight={700}>
+                                {topCategory.category} ({topCategory.ticketCount} tickets)
+                            </Typography>
+                        </Box>
+                    )}
+
+                    <Box>
+                        <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                            Category-wise Ticket Volume
+                        </Typography>
+                        <ReactECharts option={chartOptions} style={{ height: 320 }} />
+                    </Box>
+                </Box>
+            )}
+        </CustomFieldset>
+    );
+};
+
+export default ProblemManagementReport;

--- a/ui/src/components/MISReports/TicketResolutionTimeReport.tsx
+++ b/ui/src/components/MISReports/TicketResolutionTimeReport.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useMemo } from "react";
+import { Box, Typography } from "@mui/material";
+import ReactECharts from "echarts-for-react";
+import CustomFieldset from "../CustomFieldset";
+import { useApi } from "../../hooks/useApi";
+import { fetchTicketResolutionTimeReport } from "../../services/ReportService";
+import { TicketResolutionTimeReport } from "../../types/reports";
+
+const TicketResolutionTimeReport: React.FC = () => {
+    const { data, pending, apiHandler } = useApi<TicketResolutionTimeReport>();
+
+    useEffect(() => {
+        apiHandler(() => fetchTicketResolutionTimeReport());
+    }, [apiHandler]);
+
+    const chartOptions = useMemo(() => {
+        const entries = Object.entries(data?.averageResolutionHoursByStatus ?? {});
+        return {
+            tooltip: {
+                trigger: "axis",
+            },
+            xAxis: {
+                type: "category",
+                data: entries.map(([status]) => status),
+            },
+            yAxis: {
+                type: "value",
+                name: "Hours",
+            },
+            series: [
+                {
+                    name: "Average Resolution Time",
+                    type: "line",
+                    smooth: true,
+                    areaStyle: {},
+                    data: entries.map(([, value]) => value),
+                    itemStyle: {
+                        color: "#2e7d32",
+                    },
+                },
+            ],
+        };
+    }, [data]);
+
+    return (
+        <CustomFieldset title="Ticket Resolution Time" variant="bordered">
+            {pending && (
+                <Typography variant="body2" fontStyle="italic">
+                    Calculating resolution insights...
+                </Typography>
+            )}
+
+            {!pending && data && (
+                <Box display="flex" flexDirection="column" gap={2}>
+                    <Box display="flex" flexWrap="wrap" gap={4}>
+                        <Box>
+                            <Typography variant="subtitle2" color="text.secondary">
+                                Average Resolution Time
+                            </Typography>
+                            <Typography variant="h5" fontWeight={700}>
+                                {data.averageResolutionHours.toFixed(2)} hrs
+                            </Typography>
+                        </Box>
+                        <Box>
+                            <Typography variant="subtitle2" color="text.secondary">
+                                Resolved Tickets Considered
+                            </Typography>
+                            <Typography variant="h5" fontWeight={700}>
+                                {data.resolvedTicketCount}
+                            </Typography>
+                        </Box>
+                    </Box>
+
+                    <Box>
+                        <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                            Average Resolution Hours by Status
+                        </Typography>
+                        <ReactECharts option={chartOptions} style={{ height: 280 }} />
+                    </Box>
+                </Box>
+            )}
+        </CustomFieldset>
+    );
+};
+
+export default TicketResolutionTimeReport;

--- a/ui/src/components/MISReports/TicketSummaryReport.tsx
+++ b/ui/src/components/MISReports/TicketSummaryReport.tsx
@@ -1,0 +1,142 @@
+import React, { useEffect, useMemo } from "react";
+import { Box, Typography } from "@mui/material";
+import ReactECharts from "echarts-for-react";
+import CustomFieldset from "../CustomFieldset";
+import { useApi } from "../../hooks/useApi";
+import { fetchTicketSummaryReport } from "../../services/ReportService";
+import { TicketSummaryReport } from "../../types/reports";
+
+const TicketSummaryReport: React.FC = () => {
+    const { data, pending, apiHandler } = useApi<TicketSummaryReport>();
+
+    useEffect(() => {
+        apiHandler(() => fetchTicketSummaryReport());
+    }, [apiHandler]);
+
+    const statusChartOptions = useMemo(() => {
+        const entries = Object.entries(data?.statusCounts ?? {});
+        return {
+            tooltip: {
+                trigger: "item",
+            },
+            legend: {
+                top: "bottom",
+            },
+            series: [
+                {
+                    name: "Status",
+                    type: "pie",
+                    radius: ["40%", "70%"],
+                    avoidLabelOverlap: false,
+                    itemStyle: {
+                        borderRadius: 6,
+                        borderColor: "#fff",
+                        borderWidth: 2,
+                    },
+                    label: {
+                        show: false,
+                        position: "center",
+                    },
+                    emphasis: {
+                        label: {
+                            show: true,
+                            fontSize: 16,
+                            fontWeight: "bold",
+                        },
+                    },
+                    labelLine: {
+                        show: false,
+                    },
+                    data: entries.map(([name, value]) => ({ name, value })),
+                },
+            ],
+        };
+    }, [data]);
+
+    const modeChartOptions = useMemo(() => {
+        const entries = Object.entries(data?.modeCounts ?? {});
+        return {
+            tooltip: {
+                trigger: "axis",
+                axisPointer: {
+                    type: "shadow",
+                },
+            },
+            xAxis: {
+                type: "category",
+                data: entries.map(([name]) => name),
+            },
+            yAxis: {
+                type: "value",
+            },
+            series: [
+                {
+                    name: "Tickets",
+                    type: "bar",
+                    data: entries.map(([, value]) => value),
+                    itemStyle: {
+                        color: "#1976d2",
+                    },
+                },
+            ],
+        };
+    }, [data]);
+
+    return (
+        <CustomFieldset title="Ticket Summary Report" variant="bordered">
+            {pending && (
+                <Typography variant="body2" fontStyle="italic">
+                    Loading ticket summary...
+                </Typography>
+            )}
+
+            {!pending && data && (
+                <Box display="flex" flexDirection="column" gap={2}>
+                    <Box display="flex" flexWrap="wrap" gap={4}>
+                        <Box>
+                            <Typography variant="subtitle2" color="text.secondary">
+                                Total Tickets
+                            </Typography>
+                            <Typography variant="h5" fontWeight={700}>
+                                {data.totalTickets}
+                            </Typography>
+                        </Box>
+                        <Box>
+                            <Typography variant="subtitle2" color="text.secondary">
+                                Open Tickets
+                            </Typography>
+                            <Typography variant="h5" fontWeight={700}>
+                                {data.openTickets}
+                            </Typography>
+                        </Box>
+                        <Box>
+                            <Typography variant="subtitle2" color="text.secondary">
+                                Closed Tickets
+                            </Typography>
+                            <Typography variant="h5" fontWeight={700}>
+                                {data.closedTickets}
+                            </Typography>
+                        </Box>
+                    </Box>
+
+                    <Box display="flex" flexWrap="wrap" gap={4}>
+                        <Box flex={1} minWidth={280}>
+                            <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                                Ticket Status Distribution
+                            </Typography>
+                            <ReactECharts option={statusChartOptions} style={{ height: 280 }} />
+                        </Box>
+                        <Box flex={1} minWidth={280}>
+                            <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                                Mode of Receipt
+                            </Typography>
+                            <ReactECharts option={modeChartOptions} style={{ height: 280 }} />
+                        </Box>
+                    </Box>
+                </Box>
+            )}
+        </CustomFieldset>
+    );
+};
+
+export default TicketSummaryReport;

--- a/ui/src/pages/MISReports.tsx
+++ b/ui/src/pages/MISReports.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Box, Typography } from "@mui/material";
+import TicketSummaryReport from "../components/MISReports/TicketSummaryReport";
+import TicketResolutionTimeReport from "../components/MISReports/TicketResolutionTimeReport";
+import CustomerSatisfactionReport from "../components/MISReports/CustomerSatisfactionReport";
+import ProblemManagementReport from "../components/MISReports/ProblemManagementReport";
+
+const MISReports: React.FC = () => {
+    return (
+        <Box display="flex" flexDirection="column" gap={3} p={2}>
+            <Typography variant="h4" fontWeight={700} gutterBottom>
+                Management Information System Reports
+            </Typography>
+
+            <TicketSummaryReport />
+            <TicketResolutionTimeReport />
+            <CustomerSatisfactionReport />
+            <ProblemManagementReport />
+        </Box>
+    );
+};
+
+export default MISReports;

--- a/ui/src/services/ReportService.ts
+++ b/ui/src/services/ReportService.ts
@@ -1,0 +1,18 @@
+import axios from "./apiClient";
+import { BASE_URL } from "./api";
+
+export function fetchTicketSummaryReport() {
+    return axios.get(`${BASE_URL}/reports/ticket-summary`);
+}
+
+export function fetchTicketResolutionTimeReport() {
+    return axios.get(`${BASE_URL}/reports/resolution-time`);
+}
+
+export function fetchCustomerSatisfactionReport() {
+    return axios.get(`${BASE_URL}/reports/customer-satisfaction`);
+}
+
+export function fetchProblemManagementReport() {
+    return axios.get(`${BASE_URL}/reports/problem-management`);
+}

--- a/ui/src/types/reports.ts
+++ b/ui/src/types/reports.ts
@@ -1,0 +1,31 @@
+export interface TicketSummaryReport {
+    totalTickets: number;
+    openTickets: number;
+    closedTickets: number;
+    statusCounts: Record<string, number>;
+    modeCounts: Record<string, number>;
+}
+
+export interface TicketResolutionTimeReport {
+    averageResolutionHours: number;
+    resolvedTicketCount: number;
+    averageResolutionHoursByStatus: Record<string, number>;
+}
+
+export interface CustomerSatisfactionReport {
+    totalResponses: number;
+    overallSatisfactionAverage: number;
+    resolutionEffectivenessAverage: number;
+    communicationSupportAverage: number;
+    timelinessAverage: number;
+    compositeScore: number;
+}
+
+export interface ProblemCategoryStat {
+    category: string;
+    ticketCount: number;
+}
+
+export interface ProblemManagementReport {
+    categoryStats: ProblemCategoryStat[];
+}


### PR DESCRIPTION
## Summary
- add backend report DTOs, service logic, and controller endpoints to expose MIS report data
- extend the ticket repository with aggregation helpers used by new reporting service methods
- build a MIS Reports React page with individual chart components, shared report types, and navigation updates

## Testing
- ./gradlew test *(fails: Gradle toolchain could not download JDK 17 in this environment)*
- npm run build *(fails: workspace is missing the i18next dependency prior to install)*

------
https://chatgpt.com/codex/tasks/task_e_68e4bb91aaa48332893fd8c5e3f903b4