### PR TITLE
Add unit tests for core UI hooks

### DIFF
--- a/ui/src/__mocks__/react-router-dom.ts
+++ b/ui/src/__mocks__/react-router-dom.ts
@@ -1,0 +1,24 @@
+const escapeRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const defaultMatchPath = (
+  options: { path: string; end?: boolean },
+  pathname: string
+): Record<string, unknown> | null => {
+  const { path, end = true } = options;
+  const pattern = path
+    .split('/')
+    .map(segment => (segment.startsWith(':') ? '[^/]+' : escapeRegex(segment)))
+    .join('/');
+  const regex = new RegExp(`^${pattern}${end ? '$' : ''}`);
+  return regex.test(pathname) ? { params: {} } : null;
+};
+
+export const useNavigate = jest.fn();
+export const useLocation = jest.fn();
+export const matchPath = jest.fn(defaultMatchPath);
+
+export default {
+  useNavigate,
+  useLocation,
+  matchPath,
+};

--- a/ui/src/hooks/__tests__/useApi.test.ts
+++ b/ui/src/hooks/__tests__/useApi.test.ts
@@ -1,0 +1,66 @@
+jest.mock('../../context/SnackbarContext', () => ({
+  useSnackbar: jest.fn(),
+}));
+
+import { act, renderHook } from '@testing-library/react';
+
+import { useApi } from '../useApi';
+import { useSnackbar } from '../../context/SnackbarContext';
+
+describe('useApi', () => {
+  const showMessage = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+    (useSnackbar as jest.Mock).mockReturnValue({ showMessage });
+  });
+
+  it('handles successful responses with nested payloads', async () => {
+    const { result } = renderHook(() => useApi<{ value: number }>());
+
+    let resolved: { value: number } | null = null;
+    await act(async () => {
+      resolved = await result.current.apiHandler(() =>
+        Promise.resolve({ data: { body: { data: { value: 42 } } } })
+      );
+    });
+
+    expect(resolved).toEqual({ value: 42 });
+    expect(result.current.data).toEqual({ value: 42 });
+    expect(result.current.error).toBeNull();
+    expect(result.current.success).toBe(true);
+    expect(result.current.pending).toBe(false);
+    expect(showMessage).not.toHaveBeenCalled();
+  });
+
+  it('reports errors returned from successful API calls', async () => {
+    const { result } = renderHook(() => useApi<unknown>());
+
+    await act(async () => {
+      void result.current.apiHandler(() =>
+        Promise.resolve({ data: { body: { success: false, error: { message: 'Oops' } } } })
+      );
+      await Promise.resolve();
+    });
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBe('Oops');
+    expect(result.current.success).toBe(false);
+    expect(showMessage).toHaveBeenCalledWith('Oops', 'error');
+  });
+
+  it('handles rejected API calls by surfacing the error message', async () => {
+    const { result } = renderHook(() => useApi<unknown>());
+
+    await act(async () => {
+      void result.current.apiHandler(() => Promise.reject(new Error('Network down')));
+      await Promise.resolve();
+    });
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBe('Network down');
+    expect(result.current.success).toBe(false);
+    expect(showMessage).toHaveBeenCalledWith('Network down', 'error');
+  });
+});

--- a/ui/src/hooks/__tests__/useAuthGuard.test.ts
+++ b/ui/src/hooks/__tests__/useAuthGuard.test.ts
@@ -1,0 +1,62 @@
+jest.mock('../../utils/Utils', () => ({
+  getUserDetails: jest.fn(),
+  getUserPermissions: jest.fn(),
+}));
+
+jest.mock('react-router-dom');
+
+import { act, renderHook } from '@testing-library/react';
+
+import { useAuthGuard } from '../useAuthGuard';
+import { getUserDetails, getUserPermissions } from '../../utils/Utils';
+import { useNavigate } from 'react-router-dom';
+
+describe('useAuthGuard', () => {
+  const navigate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    (useNavigate as jest.Mock).mockReturnValue(navigate);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does not redirect when user and permissions exist', () => {
+    (getUserDetails as jest.Mock).mockReturnValue({ userId: '1' });
+    (getUserPermissions as jest.Mock).mockReturnValue(['READ']);
+
+    const addListenerSpy = jest.spyOn(window, 'addEventListener');
+    const removeListenerSpy = jest.spyOn(window, 'removeEventListener');
+    const clearIntervalSpy = jest.spyOn(global, 'clearInterval');
+
+    const { unmount } = renderHook(() => useAuthGuard());
+
+    expect(navigate).not.toHaveBeenCalled();
+    expect(addListenerSpy).toHaveBeenCalledWith('storage', expect.any(Function));
+
+    unmount();
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    expect(removeListenerSpy).toHaveBeenCalledWith('storage', expect.any(Function));
+
+    addListenerSpy.mockRestore();
+    removeListenerSpy.mockRestore();
+    clearIntervalSpy.mockRestore();
+  });
+
+  it('redirects to the login page when user data is missing', () => {
+    (getUserDetails as jest.Mock).mockReturnValue({});
+    (getUserPermissions as jest.Mock).mockReturnValue(null);
+
+    renderHook(() => useAuthGuard());
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(navigate).toHaveBeenCalledWith('/login');
+  });
+});

--- a/ui/src/hooks/__tests__/useCategoryFilters.test.ts
+++ b/ui/src/hooks/__tests__/useCategoryFilters.test.ts
@@ -1,0 +1,90 @@
+jest.mock('../../services/CategoryService', () => ({
+  getCategories: jest.fn(),
+  getSubCategories: jest.fn(),
+}));
+
+jest.mock('../../utils/Utils', () => ({
+  getDropdownOptions: jest.fn(),
+}));
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { useCategoryFilters } from '../useCategoryFilters';
+import { getCategories, getSubCategories } from '../../services/CategoryService';
+import { getDropdownOptions } from '../../utils/Utils';
+
+describe('useCategoryFilters', () => {
+  const defaultOption = { label: 'All', value: 'All' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getCategories as jest.Mock).mockResolvedValue({ data: { body: { data: [] } } });
+    (getDropdownOptions as jest.Mock).mockReturnValue([]);
+  });
+
+  it('loads category options on mount', async () => {
+    (getCategories as jest.Mock).mockResolvedValue({ data: { body: { data: [{ category: 'A' }] } } });
+    (getDropdownOptions as jest.Mock).mockReturnValue([{ label: 'Category A', value: '1' }]);
+
+    const { result } = renderHook(() => useCategoryFilters());
+
+    await waitFor(() => expect(result.current.categoryOptions).toHaveLength(2));
+
+    expect(getCategories).toHaveBeenCalled();
+    expect(getDropdownOptions).toHaveBeenCalledWith([{ category: 'A' }], 'category', 'categoryId');
+    expect(result.current.categoryOptions).toEqual([defaultOption, { label: 'Category A', value: '1' }]);
+  });
+
+  it('falls back to the default category option when the request fails', async () => {
+    (getCategories as jest.Mock).mockRejectedValue(new Error('fail'));
+
+    const { result } = renderHook(() => useCategoryFilters());
+
+    await waitFor(() => expect(result.current.categoryOptions).toEqual([defaultOption]));
+  });
+
+  it('resets subcategories when no category is provided', async () => {
+    const { result } = renderHook(() => useCategoryFilters());
+
+    await act(async () => {
+      await result.current.loadSubCategories();
+    });
+
+    expect(result.current.subCategoryOptions).toEqual([defaultOption]);
+    expect(getSubCategories).not.toHaveBeenCalled();
+  });
+
+  it('loads subcategories for a given category', async () => {
+    (getSubCategories as jest.Mock).mockResolvedValue({ data: { body: { data: [{ subCategory: 'B' }] } } });
+    (getDropdownOptions as jest.Mock)
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([{ label: 'Sub', value: '2' }]);
+
+    const { result } = renderHook(() => useCategoryFilters());
+
+    await waitFor(() => expect(getCategories).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.loadSubCategories('cat-1');
+    });
+
+    expect(getSubCategories).toHaveBeenCalledWith('cat-1');
+    expect(getDropdownOptions).toHaveBeenLastCalledWith([{ subCategory: 'B' }], 'subCategory', 'subCategoryId');
+    expect(result.current.subCategoryOptions).toEqual([defaultOption, { label: 'Sub', value: '2' }]);
+  });
+
+  it('resets subcategories when fetching fails', async () => {
+    (getSubCategories as jest.Mock).mockRejectedValue(new Error('nope'));
+    (getDropdownOptions as jest.Mock).mockReturnValueOnce([]);
+
+    const { result } = renderHook(() => useCategoryFilters());
+
+    await waitFor(() => expect(getCategories).toHaveBeenCalled());
+
+    await act(async () => {
+      await result.current.loadSubCategories('cat-2');
+    });
+
+    expect(result.current.subCategoryOptions).toEqual([defaultOption]);
+  });
+});

--- a/ui/src/hooks/__tests__/useDebounce.test.ts
+++ b/ui/src/hooks/__tests__/useDebounce.test.ts
@@ -1,0 +1,58 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useDebounce } from '../useDebounce';
+
+describe('useDebounce', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('delays updating the value until the timeout expires', () => {
+    const { result, rerender } = renderHook(({ value, delay }) => useDebounce(value, delay), {
+      initialProps: { value: 'initial', delay: 200 },
+    });
+
+    expect(result.current).toBe('initial');
+
+    act(() => {
+      rerender({ value: 'updated', delay: 200 });
+    });
+
+    expect(result.current).toBe('initial');
+
+    act(() => {
+      jest.advanceTimersByTime(199);
+    });
+
+    expect(result.current).toBe('initial');
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    expect(result.current).toBe('updated');
+  });
+
+  it('clears pending timers on unmount', () => {
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+
+    const { rerender, unmount } = renderHook(({ value }) => useDebounce(value, 300), {
+      initialProps: { value: 'first' },
+    });
+
+    act(() => {
+      rerender({ value: 'second' });
+    });
+
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+
+    clearTimeoutSpy.mockRestore();
+  });
+});

--- a/ui/src/hooks/__tests__/useNotifications.test.ts
+++ b/ui/src/hooks/__tests__/useNotifications.test.ts
@@ -1,0 +1,169 @@
+jest.mock('../../services/api', () => ({
+  BASE_URL: 'http://test.local',
+}));
+
+jest.mock('../../config/config', () => ({
+  getCurrentUserDetails: jest.fn(),
+}));
+
+jest.mock('../../services/NotificationService', () => ({
+  fetchNotifications: jest.fn(),
+  markNotificationsAsRead: jest.fn(),
+}));
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { useNotifications } from '../useNotifications';
+import { getCurrentUserDetails } from '../../config/config';
+import { fetchNotifications, markNotificationsAsRead } from '../../services/NotificationService';
+
+describe('useNotifications', () => {
+  class MockEventSource {
+    static instances: MockEventSource[] = [];
+
+    public url: string;
+    public withCredentials?: boolean;
+    public onmessage: ((event: MessageEvent) => void) | null = null;
+    public onerror: (() => void) | null = null;
+    private listeners = new Map<string, Set<EventListener>>();
+    public closed = false;
+
+    constructor(url: string, config?: EventSourceInit) {
+      this.url = url;
+      this.withCredentials = config?.withCredentials;
+      MockEventSource.instances.push(this);
+    }
+
+    addEventListener(type: string, listener: EventListener) {
+      if (!this.listeners.has(type)) {
+        this.listeners.set(type, new Set());
+      }
+      this.listeners.get(type)!.add(listener);
+    }
+
+    dispatch(type: string, event: MessageEvent) {
+      const listeners = this.listeners.get(type);
+      if (listeners) {
+        listeners.forEach(listener => listener(event));
+      }
+    }
+
+    close() {
+      this.closed = true;
+    }
+  }
+
+  const originalEventSource = global.EventSource;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    (getCurrentUserDetails as jest.Mock).mockReturnValue({
+      userId: 'user-1',
+      email: 'user@example.com',
+      username: 'tester',
+    });
+    (fetchNotifications as jest.Mock).mockImplementation(async (page: number) => ({
+      data: {
+        data: {
+          items: [
+            {
+              id: `notif-${page + 1}`,
+              title: `Notification ${page + 1}`,
+              message: 'Hello',
+              read: page > 0,
+              createdAt: `2023-01-0${page + 1}T00:00:00.000Z`,
+            },
+          ],
+          hasMore: page === 0,
+          page,
+          size: 7,
+          total: 2,
+        },
+      },
+    }));
+    (markNotificationsAsRead as jest.Mock).mockResolvedValue(undefined);
+    // @ts-expect-error assigning mock
+    global.EventSource = MockEventSource;
+    MockEventSource.instances = [];
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    if (originalEventSource) {
+      global.EventSource = originalEventSource;
+    } else {
+      // @ts-expect-error clearing mock
+      delete global.EventSource;
+    }
+  });
+
+  it('loads notifications on mount and computes the unread count', async () => {
+    const { result } = renderHook(() => useNotifications());
+
+    await waitFor(() => expect(fetchNotifications).toHaveBeenCalledWith(0, 7));
+    await waitFor(() => expect(result.current.notifications).toHaveLength(1));
+
+    expect(result.current.unreadCount).toBe(1);
+    expect(result.current.hasMore).toBe(true);
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0].withCredentials).toBe(true);
+  });
+
+  it('loads additional pages when loadMore is called', async () => {
+    const { result } = renderHook(() => useNotifications());
+
+    await waitFor(() => expect(result.current.notifications).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.loadMore();
+    });
+
+    await waitFor(() => expect(fetchNotifications).toHaveBeenCalledWith(1, 7));
+    expect(result.current.notifications).toHaveLength(2);
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it('marks notifications as read via the API', async () => {
+    const { result } = renderHook(() => useNotifications());
+
+    await waitFor(() => expect(result.current.notifications).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.markAllAsRead();
+    });
+
+    expect(markNotificationsAsRead).toHaveBeenCalled();
+    expect(result.current.unreadCount).toBe(0);
+    expect(result.current.notifications.every(notification => notification.read)).toBe(true);
+  });
+
+  it('handles realtime notifications and acknowledgement', async () => {
+    const { result } = renderHook(() => useNotifications());
+
+    await waitFor(() => expect(MockEventSource.instances).toHaveLength(1));
+
+    const eventSource = MockEventSource.instances[0];
+    const payload = { code: 'NEW', title: 'New notification', message: 'Realtime' };
+
+    act(() => {
+      eventSource.onmessage?.({ data: JSON.stringify(payload) } as MessageEvent);
+    });
+
+    await waitFor(() => expect(result.current.notifications.length).toBe(2));
+    expect(result.current.notifications[0].code).toBe('NEW');
+    expect(result.current.latestNotification?.code).toBe('NEW');
+
+    act(() => {
+      result.current.markAsRead(result.current.notifications[0].id);
+    });
+
+    expect(result.current.notifications[0].read).toBe(true);
+
+    act(() => {
+      result.current.acknowledgeLatestNotification();
+    });
+
+    expect(result.current.latestNotification).toBeNull();
+  });
+});

--- a/ui/src/hooks/__tests__/usePageTitle.test.ts
+++ b/ui/src/hooks/__tests__/usePageTitle.test.ts
@@ -1,0 +1,61 @@
+jest.mock('react-router-dom');
+
+jest.mock('../../context/NotificationContext', () => ({
+  useNotificationContext: jest.fn(),
+}));
+
+import { renderHook } from '@testing-library/react';
+
+import { usePageTitle } from '../usePageTitle';
+import { useLocation, matchPath } from 'react-router-dom';
+import { useNotificationContext } from '../../context/NotificationContext';
+
+describe('usePageTitle', () => {
+  const applyMatchImplementation = () => {
+    (matchPath as jest.Mock).mockImplementation(
+      (options: { path: string; end?: boolean }, pathname: string) => {
+        const { path, end = true } = options;
+        const pattern = path
+          .split('/')
+          .map(segment => (segment.startsWith(':') ? '[^/]+' : segment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+          .join('/');
+        const regex = new RegExp(`^${pattern}${end ? '$' : ''}`);
+        return regex.test(pathname) ? { params: {} } : null;
+      }
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    applyMatchImplementation();
+    document.title = 'Initial Title';
+  });
+
+  it('sets the page title based on the current route', () => {
+    (useLocation as jest.Mock).mockReturnValue({ pathname: '/tickets/123' });
+    (useNotificationContext as jest.Mock).mockReturnValue({ unreadCount: 0 } as any);
+
+    renderHook(() => usePageTitle());
+
+    expect(document.title).toBe('Ticket Details');
+    expect(matchPath).toHaveBeenCalled();
+  });
+
+  it('prefixes the title with the unread count when present', () => {
+    (useLocation as jest.Mock).mockReturnValue({ pathname: '/faq' });
+    (useNotificationContext as jest.Mock).mockReturnValue({ unreadCount: 3 } as any);
+
+    renderHook(() => usePageTitle());
+
+    expect(document.title).toBe('(3) FAQ');
+  });
+
+  it('falls back to the default title when no route matches', () => {
+    (useLocation as jest.Mock).mockReturnValue({ pathname: '/not-a-route' });
+    (useNotificationContext as jest.Mock).mockReturnValue({ unreadCount: 0 } as any);
+
+    renderHook(() => usePageTitle());
+
+    expect(document.title).toBe('Ticketing System');
+  });
+});


### PR DESCRIPTION
## Summary
- add focused unit tests for the major UI hooks including API, auth guard, category filters, debounce, notifications, and page title behaviors
- introduce a lightweight react-router-dom mock to support hook testing scenarios

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68e4bbf29d74833283c65ec60ac9d2d5