### PR TITLE
Add manual UI test scenarios for additional ticketing pages

### DIFF
--- a/docs/manual-tests/page-wise-manual-tests.md
+++ b/docs/manual-tests/page-wise-manual-tests.md
@@ -117,3 +117,141 @@ The following manual test scenarios are organized by primary application pages t
 98. **Session timeout handling** – Simulate session expiry and ensure the user is returned to login with a relevant message.
 99. **Unauthorized action handling** – Attempt an action beyond the user’s permissions and ensure an error banner or toast appears.
 
+
+## Detailed UI Test Cases for Specific Pages
+
+### AllTickets.tsx
+| # | Scenario | Preconditions | Steps | Expected Result |
+|---|----------|---------------|-------|-----------------|
+| 100 | Highlight recommended severity row from list action | User has access to the All Tickets list and at least one ticket with an available "Recommend Severity" action. | 1. From the list, trigger the "Recommend Severity" control on any ticket.<br>2. Observe the table row state after the action fires. | The targeted row gains the focus highlight and remains scrolled into view until the detail view acknowledges the recommendation. |
+| 101 | Clear recommendation focus once handled in ticket view | Scenario 100 completed and the ticket view opened in a separate tab or pane. | 1. Open the ticket that was highlighted.<br>2. Complete or dismiss the recommendation workflow inside the ticket view.<br>3. Return to the list. | The highlight is removed and the list reflects the cleared focus state without additional user interaction. |
+| 102 | Reset focus when selection changes to a different ticket | A recommended severity highlight is active. | 1. Select a different ticket via the checkbox or row click.<br>2. Deselect to return to no active selection. | The focus highlight for the original ticket disappears, ensuring the state is cleared when another ticket becomes active. |
+| 103 | Navigate to ticket details via row click | User can open ticket details from the list. | 1. Click any row (not the ticket ID hyperlink). | The router navigates to `/tickets/{id}` for the clicked ticket. |
+
+### CategoriesMaster.tsx
+| # | Scenario | Preconditions | Steps | Expected Result |
+|---|----------|---------------|-------|-----------------|
+| 104 | Filter category list as the user types | Existing categories already loaded. | 1. Type a partial string in the Category filter input.<br>2. Observe the primary category list. | Only categories matching the filter remain, while non-matching categories move to the "Other Categories" list. |
+| 105 | Show add-category CTA only for unique values | Same as Scenario 104. | 1. Enter a category name that does not currently exist.<br>2. Observe the inline button. | The "Add Category" button appears; selecting it persists the new category and clears the input. |
+| 106 | Prevent subcategory creation without selecting a category | At least one category is available. | 1. Ensure no category is selected.<br>2. Enter text in the Sub-Category input and attempt to add. | The add button stays disabled and no API call is issued because a parent category is required. |
+| 107 | Delete subcategory after confirmation | A category with at least one subcategory is selected. | 1. Click the delete icon for a subcategory.<br>2. Accept the confirmation prompt. | The subcategory is removed from the list and the latest data is fetched from the service. |
+
+### CreateRole.tsx
+| # | Scenario | Preconditions | Steps | Expected Result |
+|---|----------|---------------|-------|-----------------|
+| 108 | Enforce unique role name requirement | Create Role panel is open. | 1. Leave the Role Name field empty.<br>2. Attempt to submit. | Validation message appears and submission is blocked until a non-empty value is provided. |
+| 109 | Trigger custom permissions modal | Permissions list contains the "Custom" option. | 1. Open the Permissions autocomplete.<br>2. Choose the "Custom" chip. | The Permissions modal opens, allowing the user to craft a custom permission JSON. |
+| 110 | Persist custom permission selection | Scenario 109 completed. | 1. Submit a JSON payload in the custom permissions modal.<br>2. Close the modal. | The permissions field shows "Custom" as the sole selected value and the JSON payload is staged for submission. |
+| 111 | Select multiple status actions for the role | Status actions fetched successfully. | 1. Open the Status Actions autocomplete.<br>2. Select multiple actions.<br>3. Submit the form. | The payload sends the selected action IDs joined by pipe (`|`) in `allowedStatusActionIds`. |
+
+### CustomerSatisfactionForm.tsx
+| # | Scenario | Preconditions | Steps | Expected Result |
+|---|----------|---------------|-------|-----------------|
+| 112 | Record star rating interaction | Feedback form opened for a ticket awaiting feedback. | 1. Click a star value for "Overall Satisfaction".<br>2. Repeat for other rating sections. | The selected rating values persist and render filled stars matching the chosen score. |
+| 113 | Prevent submission without ticket context | Feedback route accessed without a valid `ticketId`. | 1. Attempt to submit feedback. | Submission is blocked; no API call is fired because the route enforces a valid ticket identifier. |
+| 114 | Submit feedback and receive toast confirmation | Valid `ticketId` with all required ratings provided. | 1. Fill all ratings and add an optional comment.<br>2. Click Submit. | The form disables while submitting, displays a success toast, and navigates back to the previous page. |
+| 115 | Respect view-only mode | Feedback is already provided (view mode). | 1. Open an already-submitted feedback form.<br>2. Inspect rating widgets and comment field. | All inputs render in read-only mode and submit/cancel buttons are replaced with a close button. |
+
+### EscalationMaster.tsx
+| # | Scenario | Preconditions | Steps | Expected Result |
+|---|----------|---------------|-------|-----------------|
+| 116 | Validate escalation user form | Page loaded with empty form fields. | 1. Leave Name, Email, or Phone blank.<br>2. Click Submit. | No API call is made and visual feedback instructs the user to complete required fields. |
+| 117 | Create escalation contact and reset form | All required fields populated with valid data. | 1. Enter Name, Email, and Phone.<br>2. Click Submit. | Contact is created, success toast appears, and the form clears all inputs. |
+| 118 | Search contacts using debounce field | Existing contacts present. | 1. Type a partial term into the Search box.<br>2. Pause typing. | After the debounce interval, the table filters to contacts matching the name, email, or phone substring. |
+| 119 | Delete contact via action column | Table populated with at least one contact. | 1. Click the delete icon on a contact row.<br>2. Confirm the prompt. | The contact is removed and the list refreshes to exclude the deleted record. |
+
+### Faq.tsx
+| # | Scenario | Preconditions | Steps | Expected Result |
+|---|----------|---------------|-------|-----------------|
+| 120 | Load FAQs in preferred language | FAQs exist with English and Hindi content. | 1. Set the app language to English.<br>2. Open the FAQ page.<br>3. Switch language to Hindi. | Questions and answers display in the selected language, falling back to the other language when a translation is missing. |
+| 121 | Hide create button without permission | Current user lacks `faq.addQnAButton` access. | 1. Navigate to the FAQ page. | The "Add Q & A" button is hidden entirely. |
+| 122 | Navigate to FAQ creation when permitted | Current user has `faq.addQnAButton` access. | 1. Click the "Add Q & A" button. | Router navigates to `/faq/new` for question creation. |
+| 123 | Render keyword metadata for search indexing | FAQs contain keyword metadata. | 1. Inspect a rendered FAQ entry. | `data-keywords` attributes on question and answer nodes reflect the stored keyword string for client-side filtering. |
+
+### FaqForm.tsx
+| # | Scenario | Preconditions | Steps | Expected Result |
+|---|----------|---------------|-------|-----------------|
+| 124 | Require at least one question and answer | Creation form opened. | 1. Leave both English and Hindi question fields empty.<br>2. Click Submit. | Alert prompts the user to provide at least one question and one answer; submission stops. |
+| 125 | Prompt before submitting single-language content | Only English question/answer provided. | 1. Fill in English fields and leave Hindi blank.<br>2. Submit the form.<br>3. Respond to confirmation dialog. | A confirmation prompt appears warning about missing translations; declining aborts submission. |
+| 126 | Display success modal after creation | All validation satisfied. | 1. Submit the form with required content.<br>2. Wait for API success. | Success modal opens showing follow-up actions; closing it resets the form. |
+| 127 | Handle API failure gracefully | Backend returns an error response. | 1. Submit form while forcing an API failure.<br>2. Observe modal response. | Failure modal opens, informing the user that creation failed; form values remain for correction. |
+
+### Histories.tsx
+| # | Scenario | Preconditions | Steps | Expected Result |
+|---|----------|---------------|-------|-----------------|
+| 128 | Default tab selection | Component rendered without `currentTab` prop. | 1. Mount the Histories component with a ticket ID only. | The Status History tab renders first by default. |
+| 129 | Switch to Assignment History tab | Same as Scenario 128. | 1. Click the Assignment History tab header. | Assignment history content replaces the status history view. |
+| 130 | Honor controlled tab state | Component receives `currentTab="assignment"`. | 1. Render Histories with `currentTab` prop set.<br>2. Observe initial view. | Assignment History tab is active on mount, reflecting the controlled prop. |
+| 131 | Emit tab change callback | Parent supplies `onTabChange`. | 1. Click a non-active tab.<br>2. Inspect callback invocation. | `onTabChange` fires with the newly selected tab key. |
+
+### KnowledgeBase.tsx
+| # | Scenario | Preconditions | Steps | Expected Result |
+|---|----------|---------------|-------|-----------------|
+| 132 | Initialize Filegator session successfully | Filegator service responds with success. | 1. Navigate to Knowledge Base page. | Iframe `src` updates to `http://localhost:8080` once the session promise resolves. |
+| 133 | Fallback to default URL on session failure | Filegator session request fails. | 1. Force the service to reject.<br>2. Load the page. | Component still assigns `http://localhost:8080` as iframe source despite failure. |
+| 134 | Maintain iframe sizing | Any session outcome. | 1. Resize the viewport.<br>2. Observe iframe container. | Iframe retains full width and 88vh height to maximize available viewport space. |
+| 135 | Restrict content to embed only | Any session outcome. | 1. Inspect DOM structure. | Only the iframe renders (Title component intentionally commented out), ensuring no additional navigation is presented. |
+
+### Login.tsx
+| # | Scenario | Preconditions | Steps | Expected Result |
+|---|----------|---------------|-------|-----------------|
+| 136 | Cycle through login themes | Portal selected and login screen visible. | 1. Use the theme toggle control (if exposed) or trigger theme change event. | The layout cycles between three predefined themes, each updating heading styles and form layout. |
+| 137 | Enforce portal selection before login | Portal chooser visible. | 1. Attempt to submit credentials before selecting a portal. | Submission is prevented and the user is prompted to pick either Requestor or Helpdesk. |
+| 138 | Handle JWT bypass toggle in dev mode | Dev mode enabled via context. | 1. Toggle the JWT bypass switch.<br>2. Perform a login. | Token storage is skipped when bypass is active; decoded auth details fall back to response payload. |
+| 139 | Populate user profile after login | Valid credentials provided. | 1. Log in successfully.<br>2. Inspect local storage/session storage utilities. | `setUserDetails` stores normalized user info including role IDs, contact details, and allowed status actions. |
+
+### MyTickets.tsx
+| # | Scenario | Preconditions | Steps | Expected Result |
+|---|----------|---------------|-------|-----------------|
+| 140 | Apply requestor override for requestor role | Logged-in user has role ID `5`. | 1. Navigate to My Tickets list.<br>2. Inspect network request payload. | API request includes `requestorId` equal to the current user ID, limiting results to tickets created by the user. |
+| 141 | Use username fallback when userId missing | User profile lacks `userId` but has `username`. | 1. Trigger the My Tickets search. | `createdBy` parameter uses the username fallback to scope results. |
+| 142 | Filter out non-applicable statuses for level 4 | User role list includes `4`. | 1. Load My Tickets list.<br>2. Compare returned statuses. | Tickets with statuses other than `1` or `2` are removed client-side for role 4 users. |
+| 143 | Show full list for non-restricted roles | User roles exclude `4` and `9`. | 1. Load My Tickets. | No additional client-side filtering is applied; tickets remain as returned by the API. |
+
+### MyWorkload.tsx
+| # | Scenario | Preconditions | Steps | Expected Result |
+|---|----------|---------------|-------|-----------------|
+| 144 | Scope workload to assigned username | Logged-in user has a username. | 1. Navigate to My Workload.<br>2. Inspect outgoing API query. | `assignedTo` parameter equals the current username, limiting results to tickets assigned to the user. |
+| 145 | Apply team-lead status filter | User roles include `4` or `TEAM_LEAD`. | 1. View My Workload results.<br>2. Inspect statuses returned. | Only tickets in `OPEN`/`ASSIGNED` (status IDs `1` or `2`) remain after client-side filtering. |
+| 146 | Apply escalation role filter | User roles include `9`. | 1. View My Workload results. | Tickets are filtered to statuses `6`/`ESCALATED` only. |
+| 147 | Preserve navigation to ticket details | Any role. | 1. Click a row in My Workload. | Router navigates to `/tickets/{id}` matching the clicked ticket. |
+
+### RaiseTicket.tsx
+| # | Scenario | Preconditions | Steps | Expected Result |
+|---|----------|---------------|-------|-----------------|
+| 148 | Toggle dev-mode autofill controls | Dev mode enabled. | 1. Click the formatColorFill icon in Ticket Details section. | Category, subcategory, priority, subject, and description fields populate with sample values for quick testing. |
+| 149 | Prevent linking when ticket marked as master | Checkbox `isMaster` selected. | 1. Check the "Mark as master" control.<br>2. Attempt to open the Link to Master modal. | The link button becomes disabled and the informational banner indicates the ticket cannot be linked. |
+| 150 | Upload attachments after ticket creation | Form filled with required fields and attachments added. | 1. Submit the ticket.<br>2. Wait for ticket ID generation.<br>3. Observe network calls. | Ticket is created first; attachments upload in a subsequent call tied to the generated ticket ID. |
+| 151 | Reset form after closing success modal | Ticket submitted successfully. | 1. Close the success modal using the default button.<br>2. Inspect form fields. | All form controls reset to initial values and attachment state clears. |
+
+### RoleDetails.tsx
+| # | Scenario | Preconditions | Steps | Expected Result |
+|---|----------|---------------|-------|-----------------|
+| 152 | Rename role inline | Role details loaded; user has edit permission. | 1. Click the edit icon beside the role title.<br>2. Enter a new name and confirm. | `renameRole` endpoint is called, success toast displays, and navigation updates to the new role route. |
+| 153 | Modify permissions using tree component | Role permissions loaded. | 1. Adjust permission nodes within the tree.<br>2. Click Save. | `updateRolePermission` and `updateRole` execute, then permission tree refreshes with persisted values. |
+| 154 | Cancel permission edits before save | Permissions modified but not yet saved. | 1. Click Cancel under the permission tree. | Pending modifications are discarded and the tree reverts to last saved state. |
+| 155 | Edit JSON structure in master role | Dev mode active and role name "Master". | 1. Click the JSON chip.<br>2. Submit changes via JSON modal. | Permission structure updates immediately and Save button persists the edited JSON. |
+
+### RoleMaster.tsx
+| # | Scenario | Preconditions | Steps | Expected Result |
+|---|----------|---------------|-------|-----------------|
+| 156 | Switch between table and grid layouts | Roles data loaded. | 1. Use the ViewToggle control to switch views. | Layout switches between table and grid; the last selection persists while navigating within the page. |
+| 157 | Create role workflow | Permissions metadata fetched. | 1. Click "Create Role".<br>2. Fill required fields in the embedded CreateRole form.<br>3. Submit. | Role is created, permissions cache reloads, and the roles table refreshes with the new entry. |
+| 158 | Delete single role from table | Table view active. | 1. Click the delete icon in a role row.<br>2. Confirm prompt. | Role is removed and table refreshes to reflect deletion. |
+| 159 | Bulk delete selected roles | Multiple roles selected in table view. | 1. Check the selection boxes for several roles.<br>2. Click "Delete Selected" and confirm. | `deleteRoles` service removes the selected roles and selection state resets. |
+
+### RootCauseAnalysis.tsx
+| # | Scenario | Preconditions | Steps | Expected Result |
+|---|----------|---------------|-------|-----------------|
+| 160 | Normalize severity labels | RCA tickets returned with varying severity formats. | 1. Load the Root Cause Analysis list. | Severity column displays normalized labels (`Critical`, `High`, `Medium`, etc.) regardless of raw value casing. |
+| 161 | Filter tickets by category and subcategory | Categories and subcategories available. | 1. Choose a Category from the dropdown.<br>2. Select a Sub Category.<br>3. Observe list refresh. | Tickets update to only those matching the selected filters; subcategory control resets when category changes. |
+| 162 | Refresh single ticket from table | List loaded with at least one ticket. | 1. Use the per-row refresh action. | Refresh icon triggers data reload for the targeted ticket; the `refreshingTicketId` indicator activates during the call. |
+| 163 | Submit RCA update via modal | Ticket row exposes RCA action. | 1. Click the RCA button.<br>2. Fill modal inputs and submit.<br>3. Close modal. | Modal closes and the table refreshes, reflecting the new RCA status. |
+
+### TicketDetails.tsx
+| # | Scenario | Preconditions | Steps | Expected Result |
+|---|----------|---------------|-------|-----------------|
+| 164 | Toggle history sidebar visibility | Ticket details loaded with history panel closed. | 1. Click the control to open the history sidebar.<br>2. Inspect layout. | History sidebar slides into view at fixed width and main ticket view resizes accordingly. |
+| 165 | Persist ticket view when sidebar open | Scenario 164 completed. | 1. Navigate within the ticket view (e.g., change sub-tab). | Ticket view remains visible and responsive while sidebar is open. |
+| 166 | Handle missing ticketId gracefully | Route accessed without `ticketId` parameter. | 1. Navigate to `/tickets/` (no ID). | Component returns `null`, resulting in no render and preventing downstream errors. |
+| 167 | Render ticket view for provided ID | Valid ticket ID present in URL. | 1. Visit `/tickets/{id}`.<br>2. Observe loaded components. | `TicketView` receives the ID prop and history sidebar binds to the same ID, ensuring synchronized content. |


### PR DESCRIPTION
## Summary
- add structured manual UI test cases for AllTickets, MyTickets, MyWorkload, and other key pages
- cover flows for FAQ management, role administration, RCA, and ticket detail interactions with numbered scenarios

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68e4bc8221b8833296762cfce55a91ff