### PR TITLE
Add comprehensive TicketView unit tests

### DIFF
--- a/ui/src/components/TicketView/__tests__/ChildTicketsList.test.tsx
+++ b/ui/src/components/TicketView/__tests__/ChildTicketsList.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ChildTicketsList from '../ChildTicketsList';
+import { useApi } from '../../../hooks/useApi';
+import { getChildTickets, unlinkTicketFromMaster } from '../../../services/TicketService';
+import { getCurrentUserDetails } from '../../../config/config';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../../../hooks/useApi', () => ({
+  useApi: jest.fn(),
+}));
+
+jest.mock('../../../config/config', () => ({
+  getCurrentUserDetails: jest.fn(() => ({ username: 'test-user', userId: 'user-1' })),
+}));
+
+jest.mock('../../../services/TicketService', () => ({
+  getChildTickets: jest.fn(),
+  unlinkTicketFromMaster: jest.fn(),
+}));
+
+jest.mock('../../Ticket/ChildTicketsTable', () => ({
+  tickets,
+  loading,
+  unlinkingId,
+  onView,
+  onUnlink,
+}: any) => (
+  <div>
+    <div data-testid="loading-state">{loading ? 'loading' : 'loaded'}</div>
+    <div data-testid="unlinking-id">{unlinkingId || 'none'}</div>
+    <button type="button" onClick={() => onView?.('child-1')}>view</button>
+    <button type="button" onClick={() => onUnlink?.('child-1')}>unlink</button>
+    <span data-testid="tickets-count">{Array.isArray(tickets) ? tickets.length : 0}</span>
+  </div>
+));
+
+const useApiMock = useApi as jest.MockedFunction<typeof useApi>;
+const getChildTicketsMock = getChildTickets as jest.Mock;
+const unlinkTicketFromMasterMock = unlinkTicketFromMaster as jest.Mock;
+const getCurrentUserDetailsMock = getCurrentUserDetails as jest.Mock;
+
+let consoleLogSpy: jest.SpyInstance;
+
+describe('ChildTicketsList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useApiMock.mockReset();
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    (window as any).confirm = jest.fn(() => true);
+
+    const fetchHandler = jest.fn((callback: () => Promise<any>) => Promise.resolve(callback()));
+    const unlinkHandler = jest.fn((callback: () => Promise<any>) => Promise.resolve(callback()));
+
+    useApiMock.mockImplementation(() => ({ data: null, pending: false, success: false, error: null, apiHandler: (cb: () => Promise<any>) => Promise.resolve(cb()) } as any));
+
+    useApiMock.mockImplementationOnce(() => ({
+      data: [{ id: 'child-1' }],
+      pending: false,
+      success: true,
+      error: null,
+      apiHandler: fetchHandler,
+    }) as any);
+
+    useApiMock.mockImplementationOnce(() => ({
+      data: null,
+      pending: false,
+      success: false,
+      error: null,
+      apiHandler: unlinkHandler,
+    }) as any);
+
+    getCurrentUserDetailsMock.mockReturnValue({ username: 'test-user', userId: 'user-1' });
+    getChildTicketsMock.mockResolvedValue([{ id: 'child-1' }]);
+    unlinkTicketFromMasterMock.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  it('fetches child tickets on mount and renders table', async () => {
+    render(<ChildTicketsList parentId="parent-123" />);
+
+    await waitFor(() => expect(getChildTicketsMock).toHaveBeenCalledWith('parent-123'));
+
+    expect(screen.getByTestId('tickets-count')).toHaveTextContent('1');
+    expect(screen.getByTestId('loading-state')).toHaveTextContent('loaded');
+  });
+
+  it('navigates when view is triggered', async () => {
+    render(<ChildTicketsList parentId="parent-456" />);
+
+    fireEvent.click(screen.getByText('view'));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/tickets/child-1');
+    });
+  });
+
+  it('calls unlink API when unlink is confirmed', async () => {
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+    render(<ChildTicketsList parentId="parent-789" />);
+
+    fireEvent.click(screen.getByText('unlink'));
+
+    await waitFor(() => {
+      expect(unlinkTicketFromMasterMock).toHaveBeenCalledWith('child-1', 'test-user');
+    });
+    expect(screen.getByTestId('unlinking-id')).toHaveTextContent('child-1');
+    confirmSpy.mockRestore();
+  });
+});

--- a/ui/src/components/TicketView/__tests__/HistorySidebar.test.tsx
+++ b/ui/src/components/TicketView/__tests__/HistorySidebar.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import HistorySidebar from '../HistorySidebar';
+import Histories from '../../../pages/Histories';
+
+type HistoriesProps = React.ComponentProps<typeof Histories>;
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const historiesMock = Histories as unknown as jest.Mock;
+
+jest.mock('../../../pages/Histories', () => jest.fn(() => <div data-testid="histories" />));
+
+describe('HistorySidebar', () => {
+  beforeEach(() => {
+    historiesMock.mockClear();
+  });
+
+  it('shows launcher buttons when closed and opens with correct tab', () => {
+    const setOpen = jest.fn();
+    render(<HistorySidebar ticketId="ticket-1" open={false} setOpen={setOpen} />);
+
+    const statusButton = screen.getByRole('button', { name: 'Status History' });
+    const assignmentButton = screen.getByRole('button', { name: 'Assignment History' });
+
+    fireEvent.click(assignmentButton);
+    expect(setOpen).toHaveBeenCalledWith(true);
+
+    const lastCall = historiesMock.mock.calls[historiesMock.mock.calls.length - 1];
+    expect(lastCall?.[0].currentTab).toBe('assignment');
+
+    fireEvent.click(statusButton);
+    const lastStatusCall = historiesMock.mock.calls[historiesMock.mock.calls.length - 1];
+    expect(lastStatusCall?.[0].currentTab).toBe('status');
+  });
+
+  it('renders drawer content when open and handles tab change and close', async () => {
+    const setOpen = jest.fn();
+    render(<HistorySidebar ticketId="ticket-2" open setOpen={setOpen} />);
+
+    const lastCall = historiesMock.mock.calls[historiesMock.mock.calls.length - 1];
+    const props = lastCall?.[0] as HistoriesProps;
+    expect(props.ticketId).toBe('ticket-2');
+    expect(props.currentTab).toBe('status');
+
+    await act(async () => {
+      props.onTabChange?.('assignment');
+    });
+
+    const nextCall = historiesMock.mock.calls[historiesMock.mock.calls.length - 1];
+    expect(nextCall?.[0].currentTab).toBe('assignment');
+
+    const closeButton = screen.getByTestId('ChevronRightIcon').closest('button');
+    expect(closeButton).not.toBeNull();
+    fireEvent.click(closeButton!);
+    expect(setOpen).toHaveBeenCalledWith(false);
+  });
+});

--- a/ui/src/components/TicketView/__tests__/RootCauseAnalysisModal.test.tsx
+++ b/ui/src/components/TicketView/__tests__/RootCauseAnalysisModal.test.tsx
@@ -1,0 +1,221 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import RootCauseAnalysisModal from '../RootCauseAnalysisModal';
+import { useApi } from '../../../hooks/useApi';
+import { useSnackbar } from '../../../context/SnackbarContext';
+import { getRootCauseAnalysis, saveRootCauseAnalysis, deleteRootCauseAnalysisAttachment } from '../../../services/RootCauseAnalysisService';
+import { getTicket } from '../../../services/TicketService';
+
+type FileUploadProps = {
+  onFilesChange?: (files: File[]) => void;
+};
+
+type ThumbnailListProps = {
+  attachments?: (string | undefined)[];
+  onRemove?: (index: number) => void;
+};
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('../../../hooks/useApi', () => ({
+  useApi: jest.fn(),
+}));
+jest.mock('../../../context/SnackbarContext');
+
+jest.mock('../../../services/RootCauseAnalysisService', () => ({
+  getRootCauseAnalysis: jest.fn(),
+  saveRootCauseAnalysis: jest.fn(),
+  deleteRootCauseAnalysisAttachment: jest.fn(),
+}));
+
+jest.mock('../../../services/TicketService', () => ({
+  getTicket: jest.fn(),
+}));
+
+jest.mock('../../../services/api', () => ({
+  BASE_URL: 'http://localhost',
+}));
+
+const mockFileUpload = jest.fn((props: FileUploadProps) => (
+  <div>
+    <button type="button" onClick={() => props.onFilesChange?.([new File(['data'], 'new-file.txt')])}>
+      add-file
+    </button>
+  </div>
+));
+
+const mockThumbnailList = jest.fn((props: ThumbnailListProps) => (
+  <div>
+    {props.attachments?.map((att, index) => (
+      <button
+        type="button"
+        key={`${att}-${index}`}
+        data-testid={`attachment-${index}`}
+        onClick={() => props.onRemove?.(index)}
+      >
+        {att}
+      </button>
+    ))}
+  </div>
+));
+
+jest.mock('../../UI/FileUpload', () => ({
+  __esModule: true,
+  default: (props: FileUploadProps) => mockFileUpload(props),
+  ThumbnailList: (props: ThumbnailListProps) => mockThumbnailList(props),
+}));
+
+jest.mock('../../UI/Button', () => ({ children, onClick, type, disabled }: any) => (
+  <button type={type ?? 'button'} onClick={onClick} disabled={disabled}>
+    {children}
+  </button>
+));
+
+jest.mock('../../UI/Input/CustomFormInput', () => ({ register, name, label }: any) => {
+  const field = register(name);
+  return (
+    <label>
+      {label}
+      <textarea data-testid={name} {...field} />
+    </label>
+  );
+});
+
+jest.mock('../../UI/IconButton/CustomIconButton', () => ({ icon, onClick }: any) => (
+  <button type="button" data-testid={`icon-${icon}`} onClick={onClick}>
+    {icon}
+  </button>
+));
+
+const useApiMock = useApi as jest.MockedFunction<typeof useApi>;
+const useSnackbarMock = useSnackbar as jest.Mock;
+const getRootCauseAnalysisMock = getRootCauseAnalysis as jest.Mock;
+const saveRootCauseAnalysisMock = saveRootCauseAnalysis as jest.Mock;
+const deleteAttachmentMock = deleteRootCauseAnalysisAttachment as jest.Mock;
+const getTicketMock = getTicket as jest.Mock;
+let deleteHandlerSpy: jest.Mock;
+
+describe('RootCauseAnalysisModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useApiMock.mockReset();
+
+    const getTicketHandler = jest.fn((fn: () => Promise<any>) => Promise.resolve(fn()));
+    const fetchHandler = jest.fn((fn: () => Promise<any>) => Promise.resolve(fn()));
+    const saveHandler = jest.fn((fn: () => Promise<any>) => Promise.resolve(fn()));
+    deleteHandlerSpy = jest.fn((fn: () => Promise<any>) => Promise.resolve(fn()));
+
+    const defaultResponse = { data: null, pending: false, success: false, error: null } as any;
+    const useApiResponses = [
+      { ...defaultResponse, apiHandler: getTicketHandler },
+      { ...defaultResponse, apiHandler: fetchHandler },
+      { ...defaultResponse, apiHandler: saveHandler },
+      { ...defaultResponse, apiHandler: deleteHandlerSpy },
+    ];
+    let callIndex = 0;
+    useApiMock.mockImplementation(() => {
+      const response = useApiResponses[callIndex] ?? { ...defaultResponse, apiHandler: (fn: () => Promise<any>) => Promise.resolve(fn()) };
+      callIndex = (callIndex + 1) % useApiResponses.length;
+      return response;
+    });
+
+    useSnackbarMock.mockReturnValue({ showMessage: jest.fn() });
+
+    getRootCauseAnalysisMock.mockResolvedValue({
+      descriptionOfCause: 'Existing cause',
+      resolutionDescription: 'Existing resolution',
+      attachments: ['one.png'],
+      severityLabel: 'Critical',
+    });
+
+    saveRootCauseAnalysisMock.mockResolvedValue({
+      descriptionOfCause: 'Updated cause',
+      resolutionDescription: 'Updated resolution',
+      attachments: ['one.png'],
+    });
+
+    deleteAttachmentMock.mockResolvedValue({
+      attachments: [],
+    });
+
+    getTicketMock.mockResolvedValue({});
+  });
+
+  it('fetches data when opened and displays existing attachments', async () => {
+    render(
+      <RootCauseAnalysisModal
+        open
+        onClose={jest.fn()}
+        rcaStatus="IN_PROGRESS"
+        ticketId="ticket-1"
+        updatedBy="user-1"
+      />,
+    );
+
+    await waitFor(() => expect(getRootCauseAnalysisMock).toHaveBeenCalledWith('ticket-1'));
+
+    expect(screen.getByText(/Severity:/i)).toBeInTheDocument();
+    await waitFor(() => expect(mockThumbnailList).toHaveBeenCalled());
+    const lastCall = mockThumbnailList.mock.calls[mockThumbnailList.mock.calls.length - 1];
+    expect(lastCall?.[0].attachments).toEqual(['http://localhost/uploads/one.png']);
+  });
+
+  it('submits form and saves RCA data', async () => {
+    const onClose = jest.fn();
+    render(
+      <RootCauseAnalysisModal
+        open
+        onClose={onClose}
+        rcaStatus="DRAFT"
+        ticketId="ticket-2"
+        updatedBy="user-2"
+      />,
+    );
+
+    await waitFor(() => expect(getRootCauseAnalysisMock).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByTestId('descriptionOfCause'), { target: { value: 'New cause' } });
+    fireEvent.change(screen.getByTestId('resolutionDescription'), { target: { value: 'New resolution' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      expect(saveRootCauseAnalysisMock).toHaveBeenCalled();
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('allows deleting existing attachment when in edit mode', async () => {
+    render(
+      <RootCauseAnalysisModal
+        open
+        onClose={jest.fn()}
+        rcaStatus="IN_PROGRESS"
+        ticketId="ticket-3"
+        updatedBy="user-3"
+      />,
+    );
+
+    await waitFor(() => expect(getRootCauseAnalysisMock).toHaveBeenCalledWith('ticket-3'));
+
+    await waitFor(() => expect(mockThumbnailList).toHaveBeenCalled());
+    const thumbnailCall = mockThumbnailList.mock.calls[mockThumbnailList.mock.calls.length - 1];
+    expect(thumbnailCall).toBeDefined();
+    const thumbnailProps = thumbnailCall?.[0];
+    expect(thumbnailProps?.onRemove).toBeDefined();
+    expect(thumbnailProps?.attachments).toEqual(['http://localhost/uploads/one.png']);
+
+    await act(async () => {
+      await thumbnailProps?.onRemove?.(0);
+    });
+
+    await waitFor(() => expect(deleteHandlerSpy).toHaveBeenCalled());
+
+    await waitFor(() => {
+      expect(deleteAttachmentMock).toHaveBeenCalledWith('ticket-3', 'one.png', 'user-3');
+    });
+  });
+});

--- a/ui/src/components/TicketView/__tests__/SlaDetails.test.tsx
+++ b/ui/src/components/TicketView/__tests__/SlaDetails.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SlaDetails from '../SlaDetails';
+import { TicketSla } from '../../../types';
+
+describe('SlaDetails', () => {
+  const baseSla: TicketSla = {
+    id: '1',
+    ticketId: 'T-1',
+    createdAt: '2024-01-01T00:00:00Z',
+    dueAt: '2024-01-02T00:00:00Z',
+    dueAtAfterEscalation: '2024-01-03T00:00:00Z',
+    actualDueAt: '2024-01-04T00:00:00Z',
+    totalSlaMinutes: 300,
+    responseTimeMinutes: 45,
+    resolutionTimeMinutes: 120,
+    idleTimeMinutes: 30,
+    elapsedTimeMinutes: 200,
+    timeTillDueDate: 100,
+    breachedByMinutes: 0,
+    status: 'IN_PROGRESS',
+  } as any;
+
+  it('renders SLA dates and numbers', () => {
+    render(<SlaDetails sla={baseSla} />);
+
+    expect(screen.getByText(/Original Due Date/)).toBeInTheDocument();
+    expect(screen.getByText(/Due Date After Escalation/)).toBeInTheDocument();
+    expect(screen.getAllByText(/2024/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('45')).toBeInTheDocument();
+    expect(screen.getByText('120')).toBeInTheDocument();
+  });
+
+  it('renders fallback when values missing', () => {
+    const emptySla = { ...(baseSla as any), actualDueAt: undefined, responseTimeMinutes: null, resolutionTimeMinutes: undefined };
+    render(<SlaDetails sla={emptySla} />);
+
+    const placeholders = screen.getAllByText('-');
+    expect(placeholders.length).toBeGreaterThan(0);
+  });
+});

--- a/ui/src/components/TicketView/__tests__/SlaProgressBar.test.tsx
+++ b/ui/src/components/TicketView/__tests__/SlaProgressBar.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import SlaProgressBar from '../SlaProgressBar';
+import MultiValueProgressBar from '../../UI/MultiValueProgressBar';
+
+jest.mock('../../UI/MultiValueProgressBar', () => {
+  const mock = jest.fn(() => <div data-testid="multi-progress" />);
+  return {
+    __esModule: true,
+    default: mock,
+    LabelPosition: {} as any,
+    MultiValueProgressMarker: {} as any,
+    MultiValueProgressSegment: {} as any,
+  };
+});
+
+describe('SlaProgressBar', () => {
+  const sampleSla = {
+    responseTimeMinutes: 15,
+    resolutionTimeMinutes: 45,
+    idleTimeMinutes: 10,
+    elapsedTimeMinutes: 60,
+    totalSlaMinutes: 120,
+    breachedByMinutes: 0,
+    timeTillDueDate: 30,
+    dueAt: '2024-01-02T00:00:00Z',
+    createdAt: '2024-01-01T00:00:00Z',
+    actualDueAt: '2024-01-01T12:00:00Z',
+    dueAtAfterEscalation: '2024-01-03T00:00:00Z',
+  } as any;
+
+  it('returns null when no segments available', () => {
+    const { container } = render(<SlaProgressBar sla={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('builds progress segments and forwards them to MultiValueProgressBar', () => {
+    render(<SlaProgressBar sla={sampleSla} className="test-class" />);
+
+    const mock = MultiValueProgressBar as jest.Mock;
+    expect(mock).toHaveBeenCalled();
+    const props = mock.mock.calls[0][0];
+    expect(props.totalValue).toBe(120);
+    expect(props.className).toBe('test-class');
+    expect(props.segments.length).toBeGreaterThanOrEqual(4);
+    expect(props.segments[0].endLabel).toBeTruthy();
+  });
+});

--- a/ui/src/components/TicketView/__tests__/SlaProgressChart.test.tsx
+++ b/ui/src/components/TicketView/__tests__/SlaProgressChart.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import SlaProgressChart from '../SlaProgressChart';
+
+const mockReactECharts = jest.fn(() => <div data-testid="echarts" />);
+
+jest.mock('echarts-for-react', () => ({
+  __esModule: true,
+  default: (...args: any[]) => mockReactECharts(...args),
+}), { virtual: true });
+
+describe('SlaProgressChart', () => {
+  const baseSla = {
+    responseTimeMinutes: 10,
+    idleTimeMinutes: 8,
+    resolutionTimeMinutes: 20,
+    elapsedTimeMinutes: 45,
+    totalSlaMinutes: 90,
+    timeTillDueDate: 40,
+    breachedByMinutes: 0,
+  } as any;
+
+  it('returns null when no data available', () => {
+    const { container } = render(<SlaProgressChart sla={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('creates stacked bar chart configuration', () => {
+    render(<SlaProgressChart sla={baseSla} className="chart" />);
+
+    const mock = mockReactECharts;
+    expect(mock).toHaveBeenCalled();
+    const props = mock.mock.calls[0][0];
+    expect(props.className).toBe('chart');
+    expect(props.option.series.length).toBeGreaterThanOrEqual(3);
+    const segmentNames = props.option.series.map((series: any) => series.name);
+    expect(segmentNames).toContain('Idle Time');
+    expect(segmentNames).toContain('Resolution Time');
+  });
+});

--- a/ui/src/components/TicketView/__tests__/TicketView.test.tsx
+++ b/ui/src/components/TicketView/__tests__/TicketView.test.tsx
@@ -1,0 +1,263 @@
+import React from 'react';
+import { render, waitFor, screen, within } from '@testing-library/react';
+import TicketView from '../TicketView';
+import { useApi } from '../../../hooks/useApi';
+import { getTicketSla } from '../../../services/TicketService';
+import { getPriorities } from '../../../services/PriorityService';
+import { getSeverities } from '../../../services/SeverityService';
+import { getCategories, getSubCategories } from '../../../services/CategoryService';
+import { getFeedback } from '../../../services/FeedbackService';
+import { getStatusWorkflowMappings } from '../../../services/StatusService';
+import Histories from '../../../pages/Histories';
+import ChildTicketsList from '../ChildTicketsList';
+
+const mockTicket = {
+  id: 'T-1',
+  subject: 'Test Subject',
+  description: 'Test Description',
+  priority: 'High',
+  priorityId: 'P1',
+  severity: 'Critical',
+  recommendedSeverity: '',
+  category: 'Category',
+  subCategory: 'SubCategory',
+  categoryId: 'cat-1',
+  subCategoryId: 'sub-1',
+  assignedToName: 'Agent',
+  assignedTo: 'agent',
+  requestorName: 'Requester',
+  userId: 'user-1',
+  reportedDate: '2024-01-01T00:00:00Z',
+  lastModified: '2024-01-02T00:00:00Z',
+  updatedBy: 'Updater',
+  masterId: 'T-1',
+  isMaster: true,
+  statusLabel: 'Open',
+  statusId: '1',
+  attachmentPaths: [],
+  rcaStatus: 'IN_PROGRESS',
+  feedbackStatus: 'PENDING',
+};
+
+const mockSla = {
+  breachedByMinutes: -5,
+  timeTillDueDate: 10,
+  totalSlaMinutes: 100,
+  elapsedTimeMinutes: 20,
+  responseTimeMinutes: 5,
+  resolutionTimeMinutes: 10,
+  idleTimeMinutes: 5,
+  dueAt: '2024-01-02T00:00:00Z',
+  createdAt: '2024-01-01T00:00:00Z',
+} as any;
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+  useLocation: () => ({ pathname: '/tickets/T-1' }),
+}));
+
+jest.mock('../../../hooks/useApi', () => ({
+  useApi: jest.fn(),
+}));
+
+jest.mock('../../../context/SnackbarContext', () => ({
+  useSnackbar: () => ({ showMessage: jest.fn() }),
+}));
+
+jest.mock('../../../services/TicketService', () => ({
+  getTicket: jest.fn(async () => ({ data: { body: { data: mockTicket } } })),
+  updateTicket: jest.fn(),
+  addAttachments: jest.fn(),
+  deleteAttachment: jest.fn(),
+  getTicketSla: jest.fn(async () => ({ status: 200, data: { body: { data: mockSla } } })),
+  getChildTickets: jest.fn(),
+  unlinkTicketFromMaster: jest.fn(),
+}));
+
+jest.mock('../../../services/RootCauseAnalysisService', () => ({
+  getRootCauseAnalysisTicketById: jest.fn(),
+}));
+
+jest.mock('../../../services/PriorityService', () => ({
+  getPriorities: jest.fn(() => Promise.resolve({ data: { body: { data: [] } } })),
+}));
+
+jest.mock('../../../services/SeverityService', () => ({
+  getSeverities: jest.fn(() => Promise.resolve({ data: [] })),
+}));
+
+jest.mock('../../../services/CategoryService', () => ({
+  getCategories: jest.fn(() => Promise.resolve({ data: { body: { data: [] } } })),
+  getSubCategories: jest.fn(() => Promise.resolve({ data: { body: { data: [] } } })),
+}));
+
+jest.mock('../../../services/FeedbackService', () => ({
+  getFeedback: jest.fn(() => Promise.resolve({ data: null })),
+}));
+
+jest.mock('../../../services/StatusService', () => ({
+  getStatusWorkflowMappings: jest.fn(() => Promise.resolve({})),
+}));
+
+jest.mock('../../../utils/permissions', () => ({
+  checkAccessMaster: jest.fn(() => true),
+  checkFieldAccess: jest.fn(() => true),
+}));
+
+jest.mock('../../../utils/Utils', () => ({
+  getDropdownOptions: jest.fn((items: any[], label: string, value: string) =>
+    (items || []).map(item => ({ label: item[label], value: item[value] }))),
+  getStatusNameById: jest.fn(() => 'Open'),
+}));
+
+jest.mock('../../../config/config', () => ({
+  getCurrentUserDetails: jest.fn(() => ({
+    username: 'test-user',
+    userId: 'user-1',
+    role: ['1'],
+  })),
+}));
+
+jest.mock('../../UI/UserAvatar/UserAvatar', () => () => <div data-testid="avatar" />);
+jest.mock('../../UI/Button', () => ({ children, onClick, type, disabled }: any) => (
+  <button type={type ?? 'button'} onClick={onClick} disabled={disabled}>
+    {children}
+  </button>
+));
+
+jest.mock('../../UI/IconButton/CustomIconButton', () => ({ icon, onClick }: any) => (
+  <button type="button" data-testid={`icon-${icon}`} onClick={onClick}>
+    {icon}
+  </button>
+));
+
+jest.mock('../../UI/Dropdown/GenericDropdown', () => ({ options, value, onChange }: any) => (
+  <select data-testid="generic-dropdown" value={value || ''} onChange={e => onChange?.(e.target.value)}>
+    {(options || []).map((option: any) => (
+      <option key={option.value} value={option.value}>{option.label}</option>
+    ))}
+  </select>
+));
+
+jest.mock('../../UI/Remark/RemarkComponent', () => ({ onSubmit, onCancel }: any) => (
+  <div>
+    <button type="button" onClick={() => onSubmit?.('remark')}>submit-remark</button>
+    <button type="button" onClick={onCancel}>cancel-remark</button>
+  </div>
+));
+
+jest.mock('../../UI/FileUpload', () => ({ onFilesChange }: any) => (
+  <div>
+    <button type="button" onClick={() => onFilesChange?.([])}>upload</button>
+  </div>
+));
+
+jest.mock('../../UI/Icons/InfoIcon', () => () => <span data-testid="info-icon" />);
+
+jest.mock('../../CustomFieldset', () => ({ title, children }: any) => (
+  <section data-testid={`fieldset-${title}`}>{children}</section>
+));
+
+jest.mock('../../Comments/CommentsSection', () => () => <div data-testid="comments" />);
+
+jest.mock('../../Feedback/FeedbackModal', () => ({ open }: any) => (
+  open ? <div data-testid="feedback-modal" /> : null
+));
+
+const mockSlaProgressChart = jest.fn(() => <div data-testid="sla-chart" />);
+jest.mock('../SlaProgressChart', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    mockSlaProgressChart(props);
+    return <div data-testid="sla-chart" />;
+  },
+}));
+
+const mockHistories = jest.fn(() => <div data-testid="histories" />);
+jest.mock('../../../pages/Histories', () => ({
+  __esModule: true,
+  default: (props: any) => mockHistories(props),
+}));
+
+const mockChildTicketsList = jest.fn(() => <div data-testid="child-tickets" />);
+jest.mock('../ChildTicketsList', () => ({
+  __esModule: true,
+  default: (props: any) => mockChildTicketsList(props),
+}));
+
+jest.mock('../RootCauseAnalysisModal', () => () => <div data-testid="rca-modal" />);
+
+const useApiMock = useApi as jest.MockedFunction<typeof useApi>;
+const getPrioritiesMock = getPriorities as jest.Mock;
+const getSeveritiesMock = getSeverities as jest.Mock;
+const getCategoriesMock = getCategories as jest.Mock;
+const getSubCategoriesMock = getSubCategories as jest.Mock;
+const getFeedbackMock = getFeedback as jest.Mock;
+const getStatusWorkflowMappingsMock = getStatusWorkflowMappings as jest.Mock;
+const getTicketSlaMock = getTicketSla as jest.Mock;
+
+describe('TicketView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useApiMock.mockReset();
+
+    getPrioritiesMock.mockResolvedValue({ data: { body: { data: [] } } });
+    getSeveritiesMock.mockResolvedValue({ data: [] });
+    getCategoriesMock.mockResolvedValue({ data: { body: { data: [] } } });
+    getSubCategoriesMock.mockResolvedValue({ data: { body: { data: [] } } });
+    getFeedbackMock.mockResolvedValue({ data: null });
+    getStatusWorkflowMappingsMock.mockResolvedValue({});
+
+    const defaultResponse = {
+      data: null,
+      pending: false,
+      success: false,
+      error: null,
+      apiHandler: (cb: () => Promise<any>) => Promise.resolve(cb()),
+    } as any;
+
+    const useApiResponses = [
+      { ...defaultResponse, data: mockTicket, success: true },
+      { ...defaultResponse },
+      { ...defaultResponse, data: { '1': [] }, success: true },
+    ];
+    let callIndex = 0;
+    useApiMock.mockImplementation(() => {
+      const response = useApiResponses[callIndex] ?? defaultResponse;
+      callIndex = (callIndex + 1) % useApiResponses.length;
+      return response;
+    });
+
+    getTicketSlaMock.mockResolvedValue({ status: 200, data: { body: { data: mockSla } } });
+  });
+
+  it('renders history and SLA information for master tickets', async () => {
+    render(<TicketView ticketId="T-1" showHistory sidebar />);
+
+    await waitFor(() => expect(mockHistories).toHaveBeenCalled());
+    const historyProps = mockHistories.mock.calls[0][0];
+    expect(historyProps.ticketId).toBe('T-1');
+
+    await waitFor(() => expect(getTicketSlaMock).toHaveBeenCalled());
+
+    const breachedLabel = await screen.findByText('Breached By (mins)');
+    const breachedRow = breachedLabel.closest('tr');
+    expect(breachedRow).not.toBeNull();
+    expect(within(breachedRow!).getByText('0')).toBeInTheDocument();
+
+    const timeTillDueLabel = await screen.findByText('Time Till Due Date (mins)');
+    const timeTillDueRow = timeTillDueLabel.closest('tr');
+    expect(timeTillDueRow).not.toBeNull();
+    expect(within(timeTillDueRow!).getByText('5')).toBeInTheDocument();
+
+    await waitFor(() => expect(mockChildTicketsList).toHaveBeenCalled());
+    const childProps = mockChildTicketsList.mock.calls[0][0];
+    expect(childProps.parentId).toBe('T-1');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for TicketView rendering and SLA normalization
- cover SLA detail components and progress visuals
- add tests for child ticket list, history sidebar, and RCA modal behavior

## Testing
- `CI=true npm test -- TicketView.test.tsx`
- `CI=true npm test -- RootCauseAnalysisModal.test.tsx`
- `CI=true npm test -- --watch=false`

------
https://chatgpt.com/codex/tasks/task_e_68e4c0d10214833298489fd5adfe2aa4