### PR TITLE
Fix attachment error reset and validation on Raise Ticket form

### DIFF
--- a/ui/src/components/UI/FileUpload.tsx
+++ b/ui/src/components/UI/FileUpload.tsx
@@ -182,10 +182,11 @@ const FileUpload: React.FC<FileUploadProps> = ({ maxSizeMB, thumbnailSize, onFil
     const [error, setError] = useState<string>('');
 
     useEffect(() => {
-        if (files !== attachments) {
-            setFiles(attachments);
+        setFiles(attachments);
+        if (!attachments || attachments.length === 0) {
+            setError('');
         }
-    }, [attachments, files]);
+    }, [attachments]);
 
     const handleRemove = (index: number) => {
         const updated = files.filter((_, i) => i !== index);

--- a/ui/src/pages/RaiseTicket.tsx
+++ b/ui/src/pages/RaiseTicket.tsx
@@ -97,8 +97,16 @@ const RaiseTicket: React.FC<any> = () => {
     };
 
     const clearTicketDetailsFields = () => {
-        reset();
+        reset(undefined, {
+            keepErrors: false,
+            keepDirty: false,
+            keepTouched: false,
+            keepIsSubmitted: false,
+            keepSubmitCount: false,
+            keepValues: false,
+        });
         setAttachments([]);
+        setValue('attachments', []);
     };
 
     const handleClearForm = () => {


### PR DESCRIPTION
## Summary
- ensure clearing the Raise Ticket form resets form state and attachment values so required validations run again
- reset the attachment upload error state when the attachment list is cleared

## Testing
- CI=true npm test -- FileUpload.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e4db66070c8332921457d399f00b32