### PR TITLE
Add master ticket linking to TicketView

### DIFF
--- a/ui/src/components/RaiseTicket/LinkToMasterTicketModal.tsx
+++ b/ui/src/components/RaiseTicket/LinkToMasterTicketModal.tsx
@@ -14,6 +14,7 @@ interface LinkToMasterTicketModalProps {
     subject: string;
     currentTicketId?: string; // Optional prop to pass current ticket ID
     masterId?: string;
+    onLinkSuccess?: (masterId: string) => void;
 }
 
 interface TicketHit {
@@ -30,7 +31,7 @@ interface MasterTicket {
 
 const PAGE_SIZE = 20;
 
-const LinkToMasterTicketModal: React.FC<LinkToMasterTicketModalProps> = ({ open, onClose, subject, setMasterId, currentTicketId, masterId }) => {
+const LinkToMasterTicketModal: React.FC<LinkToMasterTicketModalProps> = ({ open, onClose, subject, setMasterId, currentTicketId, masterId, onLinkSuccess }) => {
     const [query, setQuery] = useState('');
     const [searchResults, setSearchResults] = useState<MasterTicket[]>([]);
     const [paginatedTickets, setPaginatedTickets] = useState<MasterTicket[]>([]);
@@ -149,6 +150,7 @@ const LinkToMasterTicketModal: React.FC<LinkToMasterTicketModalProps> = ({ open,
                 try {
                     await linkTicketToMaster(currentTicketId, selected.id, currentUsername || undefined);
                     setLinked(true);
+                    onLinkSuccess?.(selected.id);
                 } catch {
                     setLinked(false);
                 }

--- a/ui/src/components/TicketView/__tests__/TicketView.test.tsx
+++ b/ui/src/components/TicketView/__tests__/TicketView.test.tsx
@@ -170,6 +170,10 @@ jest.mock('../../Feedback/FeedbackModal', () => ({ open }: any) => (
   open ? <div data-testid="feedback-modal" /> : null
 ));
 
+jest.mock('../../RaiseTicket/LinkToMasterTicketModal', () => ({ open }: any) => (
+  open ? <div data-testid="link-master-modal" /> : null
+));
+
 const mockSlaProgressChart = jest.fn(() => <div data-testid="sla-chart" />);
 jest.mock('../SlaProgressChart', () => ({
   __esModule: true,


### PR DESCRIPTION
## Summary
- add link to master ticket button on ticket view for non-master tickets
- refetch ticket data and show feedback after linking to a master ticket
- expose link success hook on the modal and update unit tests

## Testing
- CI=true npm test -- TicketView

------
https://chatgpt.com/codex/tasks/task_e_68e4de944d888332b44c1ac090a76d25