### PR TITLE
Add Jest tests for ticketing pages

### DIFF
--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -33,6 +33,7 @@ jest.mock('./pages/MyWorkload', () => () => <div>MyWorkload</div>);
 jest.mock('./pages/Faq', () => () => <div>Faq</div>);
 jest.mock('./pages/FaqForm', () => () => <div>FaqForm</div>);
 jest.mock('./pages/RootCauseAnalysis', () => () => <div>RootCauseAnalysis</div>);
+jest.mock('./pages/MISReports', () => () => <div>MISReports</div>);
 jest.mock('./components/Layout/SidebarLayout', () => ({ children }: { children: React.ReactNode }) => <div>{children}</div>);
 
 jest.mock('jwt-decode', () => ({

--- a/ui/src/pages/__tests__/AllTickets.test.tsx
+++ b/ui/src/pages/__tests__/AllTickets.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { act, fireEvent, render } from '@testing-library/react';
+import AllTickets from '../AllTickets';
+
+jest.mock('react-router-dom', () => {
+  const navigate = jest.fn();
+  return {
+    useNavigate: () => navigate,
+    __navigateMock: navigate,
+  };
+});
+
+const navigateMock = jest.requireMock('react-router-dom').__navigateMock as jest.Mock;
+
+const ticketsListProps: any[] = [];
+
+jest.mock('../../components/AllTickets/TicketsList', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    ticketsListProps.push(props);
+    return (
+      <div
+        data-testid="tickets-list"
+        onClick={() => props.getViewTicketProps('ticket-1').onRecommendSeverityFocusHandled()}
+      >
+        TicketsList Mock
+      </div>
+    );
+  },
+}));
+
+describe('AllTickets', () => {
+  beforeEach(() => {
+    navigateMock.mockClear();
+    ticketsListProps.length = 0;
+  });
+
+  it('renders TicketsList with expected props and handles navigation', () => {
+    const { getByTestId } = render(<AllTickets />);
+
+    const latest = () => ticketsListProps.at(-1);
+
+    expect(getByTestId('tickets-list')).toBeInTheDocument();
+    expect(latest().titleKey).toBe('All Tickets');
+    expect(latest().permissionPathPrefix).toBe('allTickets');
+
+    latest().onRowClick('123');
+    expect(navigateMock).toHaveBeenCalledWith('/tickets/123');
+
+    act(() => {
+      latest().tableOptions.onRecommendEscalation('ticket-1');
+    });
+    expect(latest().getViewTicketProps('ticket-1').focusRecommendSeverity).toBe(true);
+
+    fireEvent.click(getByTestId('tickets-list'));
+    expect(latest().getViewTicketProps('ticket-1').focusRecommendSeverity).toBe(false);
+  });
+});

--- a/ui/src/pages/__tests__/CategoriesMaster.test.tsx
+++ b/ui/src/pages/__tests__/CategoriesMaster.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+
+const mockAddCategory = jest.fn(() => Promise.resolve());
+const mockFetchCategories = jest.fn(() => Promise.resolve([{ categoryId: '1', category: 'Existing', subCategories: [] }]));
+const mockFetchSubCategories = jest.fn(() => Promise.resolve([
+  { subCategoryId: '10', categoryId: '1', subCategory: 'Child', createdBy: '1' },
+]));
+
+const mockUseApi = jest.fn();
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('../../hooks/useApi', () => ({
+  useApi: (...args: unknown[]) => mockUseApi(...args),
+}));
+
+jest.mock('../../services/CategoryService', () => ({
+  getCategories: () => mockFetchCategories(),
+  getAllSubCategories: () => mockFetchSubCategories(),
+  addCategory: (...args: unknown[]) => mockAddCategory(...args),
+  updateCategory: jest.fn(() => Promise.resolve()),
+  deleteCategory: jest.fn(() => Promise.resolve()),
+  addSubCategory: jest.fn(() => Promise.resolve()),
+  updateSubCategory: jest.fn(() => Promise.resolve()),
+  deleteSubCategory: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../../config/config', () => ({
+  getCurrentUserDetails: () => ({ userId: 'user-1' }),
+}));
+
+jest.mock('../../components/UI/IconButton/CustomIconButton', () => ({
+  __esModule: true,
+  default: ({ onClick, icon }: { onClick: () => void; icon: string }) => (
+    <button data-testid={`icon-${icon}`} onClick={onClick}>{icon}</button>
+  ),
+}));
+
+import CategoriesMaster from '../CategoriesMaster';
+
+describe('CategoriesMaster', () => {
+  beforeEach(() => {
+    mockAddCategory.mockClear();
+    mockFetchCategories.mockClear();
+    mockFetchSubCategories.mockClear();
+    mockUseApi.mockReset();
+    mockAddCategory.mockResolvedValue(undefined);
+    mockFetchCategories.mockResolvedValue([{ categoryId: '1', category: 'Existing', subCategories: [] }]);
+    mockFetchSubCategories.mockResolvedValue([
+      { subCategoryId: '10', categoryId: '1', subCategory: 'Child', createdBy: '1' },
+    ]);
+
+    mockUseApi
+      .mockImplementationOnce(() => ({
+        data: [{ categoryId: '1', category: 'Existing', subCategories: [] }],
+        apiHandler: jest.fn((fn: () => Promise<any>) => fn()),
+      }))
+      .mockImplementationOnce(() => ({
+        data: [{ subCategoryId: '10', categoryId: '1', subCategory: 'Child', createdBy: '1' }],
+        apiHandler: jest.fn((fn: () => Promise<any>) => fn()),
+      }))
+      .mockImplementation(() => ({
+        data: null,
+        apiHandler: jest.fn((fn: () => Promise<any>) => fn()),
+      }));
+  });
+
+  it('allows adding a new category when unique name is entered', async () => {
+    const { getByLabelText, getByText } = render(<CategoriesMaster />);
+
+    const input = getByLabelText('Category') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'New Category' } });
+
+    const addButton = getByText('Add Category');
+    fireEvent.click(addButton);
+
+    await waitFor(() => {
+      expect(mockAddCategory).toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/src/pages/__tests__/CreateRole.test.tsx
+++ b/ui/src/pages/__tests__/CreateRole.test.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { act, fireEvent, render } from '@testing-library/react';
+
+const mockSubmit = jest.fn();
+const mockCancel = jest.fn();
+const mockSetCustomPerm = jest.fn();
+
+let mockAutocompleteCounter = 0;
+
+jest.mock('@mui/material', () => {
+  const actual = jest.requireActual('@mui/material');
+  return {
+    ...actual,
+    Autocomplete: ({ options = [], value, onChange, multiple = false, renderInput }: any) => {
+      const instanceId = mockAutocompleteCounter++;
+      const normalizeOption = (option: any) => {
+        if (typeof option === 'string') {
+          return option;
+        }
+        if (option?.id != null) {
+          return String(option.id);
+        }
+        if (option?.action) {
+          return option.action;
+        }
+        return String(option);
+      };
+
+      const normalizedValue = multiple
+        ? (Array.isArray(value) ? value : []).map((item: any) => normalizeOption(item))
+        : normalizeOption(value ?? '');
+
+      const handleChange = (event: any) => {
+        const rawValues = multiple
+          ? Array.from(event.target.selectedOptions || [])
+          : [event.target.value];
+        const selectedValues = multiple
+          ? rawValues.map((opt: any) => opt.value ?? opt)
+          : rawValues[0];
+        const mapToOption = (val: string) => options.find((opt: any) => normalizeOption(opt) === val) ?? val;
+        const payload = multiple
+          ? (selectedValues as string[]).map((val: string) => mapToOption(val))
+          : mapToOption(selectedValues as string);
+        onChange?.(event, payload);
+      };
+
+      return (
+        <div data-testid={`autocomplete-${instanceId}`}>
+          {renderInput?.({ InputProps: {}, inputProps: {}, InputLabelProps: {} })}
+          <select multiple={multiple} value={normalizedValue} onChange={handleChange}>
+            {options.map((option: any) => {
+              const optValue = normalizeOption(option);
+              return (
+                <option key={optValue} value={optValue}>
+                  {optValue}
+                </option>
+              );
+            })}
+          </select>
+        </div>
+      );
+    },
+  };
+});
+
+jest.mock('../../components/Permissions/PermissionsModal', () => ({
+  __esModule: true,
+  default: ({ open, onSubmit }: any) => (
+    <div data-testid="permissions-modal">
+      {open && (
+        <button onClick={() => {
+          onSubmit({ custom: true });
+          mockSetCustomPerm();
+        }}>Save Custom</button>
+      )}
+    </div>
+  ),
+}));
+
+jest.mock('../../config/config', () => ({
+  getCurrentUserDetails: () => ({ name: 'Tester' }),
+}));
+
+import CreateRole from '../CreateRole';
+
+describe('CreateRole', () => {
+  beforeEach(() => {
+    mockSubmit.mockClear();
+    mockCancel.mockClear();
+    mockSetCustomPerm.mockClear();
+    mockAutocompleteCounter = 0;
+  });
+
+  it('submits role details with selected permissions', async () => {
+    const { getByLabelText, getByText, getAllByTestId } = render(
+      <CreateRole
+        roles={['Admin']}
+        permissions={{}}
+        statusActions={[]}
+        onSubmit={mockSubmit}
+        onCancel={mockCancel}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.change(getByLabelText('Role name'), { target: { value: 'Supervisor' } });
+      fireEvent.change(getByLabelText('Description'), { target: { value: 'Handles escalations' } });
+    });
+
+    const permissionsSelect = getAllByTestId(/^autocomplete-/)[0].querySelector('select')!;
+    await act(async () => {
+      fireEvent.change(permissionsSelect, {
+        target: {
+          value: 'Admin',
+        },
+      } as any);
+    });
+
+    await act(async () => {
+      fireEvent.click(getByText('Submit'));
+    });
+
+    expect(mockSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      role: 'Supervisor',
+      description: 'Handles escalations',
+      permissionsList: ['Admin'],
+    }));
+  });
+
+  it('triggers cancel handler on cancel click', () => {
+    const { getByText } = render(
+      <CreateRole roles={[]} permissions={{}} statusActions={[]} onSubmit={mockSubmit} onCancel={mockCancel} />
+    );
+    fireEvent.click(getByText('Cancel'));
+    expect(mockCancel).toHaveBeenCalled();
+  });
+});

--- a/ui/src/pages/__tests__/CustomerSatisfactionForm.test.tsx
+++ b/ui/src/pages/__tests__/CustomerSatisfactionForm.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+
+const mockSubmitFeedback = jest.fn(() => Promise.resolve());
+const mockShowMessage = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  const navigate = jest.fn();
+  return {
+    useParams: () => ({ ticketId: 'T-1' }),
+    useNavigate: () => navigate,
+    useLocation: () => ({ state: undefined }),
+    __navigateMock: navigate,
+  };
+});
+
+const navigateMock = jest.requireMock('react-router-dom').__navigateMock as jest.Mock;
+
+jest.mock('../../components/Feedback/StarRating', () => ({
+  __esModule: true,
+  default: ({ label, value, onChange }: { label: string; value: number; onChange: (v: number) => void }) => (
+    <button data-testid={`rating-${label}`} onClick={() => onChange(value + 1)}>
+      {label}:{value}
+    </button>
+  ),
+}));
+
+jest.mock('../../context/SnackbarContext', () => ({
+  useSnackbar: () => ({ showMessage: mockShowMessage }),
+}));
+
+jest.mock('../../services/FeedbackService', () => ({
+  submitFeedback: (...args: unknown[]) => mockSubmitFeedback(...args),
+  getFeedbackForm: jest.fn(),
+  getFeedback: jest.fn(),
+}));
+
+jest.mock('../../hooks/useApi', () => ({
+  useApi: () => ({ data: null, apiHandler: jest.fn(), success: false }),
+}));
+
+import CustomerSatisfactionForm from '../CustomerSatisfactionForm';
+
+describe('CustomerSatisfactionForm', () => {
+  beforeEach(() => {
+    mockSubmitFeedback.mockClear();
+    mockShowMessage.mockClear();
+    navigateMock.mockClear();
+    mockSubmitFeedback.mockResolvedValue(undefined);
+  });
+
+  it('allows rating updates and submits feedback', async () => {
+    const { getByTestId, getByLabelText, getByText } = render(<CustomerSatisfactionForm />);
+
+    fireEvent.click(getByTestId('rating-Overall Satisfaction'));
+    fireEvent.click(getByTestId('rating-Resolution Effectiveness'));
+
+    fireEvent.change(getByLabelText('Additional Comments/Feedback'), { target: { value: 'Great!' } });
+
+    fireEvent.click(getByText('Submit'));
+
+    await waitFor(() => {
+      expect(mockSubmitFeedback).toHaveBeenCalled();
+      expect(mockShowMessage).toHaveBeenCalledWith('Feedback submitted', 'success');
+      expect(navigateMock).toHaveBeenCalledWith(-1);
+    });
+  });
+
+  it('handles cancel action', () => {
+    const { getByText } = render(<CustomerSatisfactionForm />);
+    fireEvent.click(getByText('Cancel'));
+    expect(navigateMock).toHaveBeenCalled();
+  });
+});

--- a/ui/src/pages/__tests__/EscalationMaster.test.tsx
+++ b/ui/src/pages/__tests__/EscalationMaster.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
+
+const mockUsers = [
+  { UserId: '1', name: 'Alice', emailId: 'alice@example.com', mobileNo: '123', office: 'Manager' },
+  { UserId: '2', name: 'Bob', emailId: 'bob@example.com', mobileNo: '456', office: 'Lead' },
+];
+
+const mockGetAllUsers = jest.fn(() => Promise.resolve(mockUsers));
+const mockAddUser = jest.fn(() => Promise.resolve({ message: 'Added' }));
+const mockDeleteUser = jest.fn(() => Promise.resolve());
+const mockUseApi = jest.fn();
+const mockShowMessage = jest.fn();
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('../../hooks/useApi', () => ({
+  useApi: (...args: unknown[]) => mockUseApi(...args),
+}));
+
+jest.mock('../../hooks/useDebounce', () => ({
+  useDebounce: (value: string) => value,
+}));
+
+jest.mock('../../services/UserService', () => ({
+  getAllUsers: () => mockGetAllUsers(),
+  addUser: (...args: unknown[]) => mockAddUser(...args),
+  deleteUser: (...args: unknown[]) => mockDeleteUser(...args),
+}));
+
+jest.mock('../../context/SnackbarContext', () => ({
+  useSnackbar: () => ({ showMessage: mockShowMessage }),
+}));
+
+jest.mock('../../components/UI/GenericTable', () => ({
+  __esModule: true,
+  default: ({ dataSource }: { dataSource: any[] }) => (
+    <div data-testid="table">{dataSource.map((item) => item.name).join(',')}</div>
+  ),
+}));
+
+jest.mock('../../components/UI/Button', () => ({
+  __esModule: true,
+  default: ({ children, onClick, type }: { children: React.ReactNode; onClick?: () => void; type?: string }) => (
+    <button type={type as 'button' | 'submit' | 'reset' | undefined} onClick={onClick}>{children}</button>
+  ),
+}));
+
+jest.mock('jwt-decode', () => ({
+  jwtDecode: () => ({}),
+}), { virtual: true });
+
+import EscalationMaster from '../EscalationMaster';
+
+describe('EscalationMaster', () => {
+  beforeEach(() => {
+    mockGetAllUsers.mockClear();
+    mockAddUser.mockClear();
+    mockDeleteUser.mockClear();
+    mockShowMessage.mockClear();
+    mockUseApi.mockReset();
+
+    mockAddUser.mockResolvedValue({ message: 'Added' });
+    mockDeleteUser.mockResolvedValue(undefined);
+
+    mockUseApi
+      .mockImplementationOnce(() => ({
+        data: mockUsers,
+        apiHandler: jest.fn((fn: () => Promise<any>) => fn()),
+      }))
+      .mockImplementationOnce(() => ({
+        data: null,
+        apiHandler: jest.fn((fn: () => Promise<any>) => fn()),
+      }))
+      .mockImplementation(() => ({
+        data: null,
+        apiHandler: jest.fn((fn: () => Promise<any>) => fn()),
+      }));
+  });
+
+  it('submits new user details and refreshes list', async () => {
+    const { getByLabelText, getByText } = render(<EscalationMaster />);
+
+    fireEvent.change(getByLabelText('Name'), { target: { value: 'Charlie' } });
+    fireEvent.change(getByLabelText('Email ID'), { target: { value: 'charlie@example.com' } });
+    fireEvent.change(getByLabelText('Phone Number'), { target: { value: '789' } });
+
+    await act(async () => {
+      fireEvent.click(getByText('Submit'));
+    });
+
+    await waitFor(() => {
+      expect(mockAddUser).toHaveBeenCalledWith({
+        name: 'Charlie',
+        emailId: 'charlie@example.com',
+        mobileNo: '789',
+      });
+      expect(mockShowMessage).toHaveBeenCalledWith('Added', 'success');
+    });
+  });
+
+  it('filters users based on search query', () => {
+    const { getByLabelText, getByTestId } = render(<EscalationMaster />);
+    fireEvent.change(getByLabelText('Search'), { target: { value: 'Alice' } });
+    expect(getByTestId('table')).toHaveTextContent('Alice');
+  });
+});

--- a/ui/src/pages/__tests__/Faq.test.tsx
+++ b/ui/src/pages/__tests__/Faq.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+const mockApiHandler = jest.fn(() => Promise.resolve());
+const mockUseApi = jest.fn(() => ({
+  data: [
+    { questionEn: 'Question EN', answerEn: 'Answer EN', keywords: 'test' },
+    { questionHi: 'प्रश्न', answerHi: 'उत्तर', keywords: 'hi' },
+  ],
+  apiHandler: mockApiHandler,
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+jest.mock('../../hooks/useApi', () => ({
+  useApi: (...args: unknown[]) => mockUseApi(...args),
+}));
+
+jest.mock('../../services/FaqService', () => ({
+  getFaqs: jest.fn(() => Promise.resolve([])),
+}));
+
+jest.mock('../../utils/permissions', () => ({
+  checkAccessMaster: jest.fn(() => true),
+}));
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => jest.fn(),
+}));
+
+import Faq from '../Faq';
+
+describe('Faq page', () => {
+  beforeEach(() => {
+    mockApiHandler.mockClear();
+    mockUseApi.mockClear();
+    mockUseApi.mockReturnValue({
+      data: [
+        { questionEn: 'Question EN', answerEn: 'Answer EN', keywords: 'test' },
+        { questionHi: 'प्रश्न', answerHi: 'उत्तर', keywords: 'hi' },
+      ],
+      apiHandler: mockApiHandler,
+    });
+  });
+
+  it('renders FAQ items and calls fetch on mount', () => {
+    const { getAllByText } = render(<Faq />);
+    expect(mockApiHandler).toHaveBeenCalled();
+    expect(getAllByText(/Question/)[0]).toBeInTheDocument();
+    expect(getAllByText(/Answer/)[0]).toBeInTheDocument();
+  });
+});

--- a/ui/src/pages/__tests__/FaqForm.test.tsx
+++ b/ui/src/pages/__tests__/FaqForm.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+
+const mockCreateFaq = jest.fn(() => Promise.resolve());
+const mockNavigate = jest.fn();
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock('../../services/FaqService', () => ({
+  createFaq: (...args: unknown[]) => mockCreateFaq(...(args as [any])),
+}));
+
+jest.mock('../../config/config', () => ({
+  getCurrentUserDetails: () => ({ userId: 'user-1' }),
+}));
+
+jest.mock('../../components/UI/SuccessModal', () => ({
+  __esModule: true,
+  default: ({ open, title }: { open: boolean; title: string }) => (
+    <div data-testid="success-modal">{open ? title : 'closed'}</div>
+  ),
+}));
+
+jest.mock('../../components/UI/FailureModal', () => ({
+  __esModule: true,
+  default: ({ open, title }: { open: boolean; title: string }) => (
+    <div data-testid="failure-modal">{open ? title : 'closed'}</div>
+  ),
+}));
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+import FaqForm from '../FaqForm';
+
+describe('FaqForm', () => {
+  const originalConfirm = window.confirm;
+  const originalAlert = window.alert;
+
+  beforeEach(() => {
+    mockCreateFaq.mockClear();
+    mockNavigate.mockClear();
+    window.confirm = jest.fn(() => true);
+    window.alert = jest.fn();
+  });
+
+  afterEach(() => {
+    window.confirm = originalConfirm;
+    window.alert = originalAlert;
+  });
+
+  it('submits form when valid data is provided', async () => {
+    const { getByPlaceholderText, getByText, getByTestId } = render(<FaqForm />);
+
+    fireEvent.change(getByPlaceholderText('Question (English)'), { target: { value: 'What?' } });
+    fireEvent.change(getByPlaceholderText('Question (Hindi)'), { target: { value: 'क्या?' } });
+    fireEvent.change(getByPlaceholderText('Answer (English)'), { target: { value: 'Because.' } });
+    fireEvent.change(getByPlaceholderText('Answer (Hindi)'), { target: { value: 'क्योंकि.' } });
+    fireEvent.change(getByPlaceholderText('Keywords (pipe separated)'), { target: { value: 'test' } });
+
+    fireEvent.click(getByText('Submit'));
+
+    await waitFor(() => {
+      expect(mockCreateFaq).toHaveBeenCalled();
+      expect(getByTestId('success-modal')).toHaveTextContent('Question and answer created successfully');
+    });
+  });
+
+  it('navigates back when cancel is clicked', () => {
+    const { getByText } = render(<FaqForm />);
+    fireEvent.click(getByText('Cancel'));
+    expect(mockNavigate).toHaveBeenCalledWith(-1);
+  });
+});

--- a/ui/src/pages/__tests__/Histories.test.tsx
+++ b/ui/src/pages/__tests__/Histories.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Histories from '../Histories';
+
+const tabsProps: any[] = [];
+
+jest.mock('../../components/UI/CustomTabsComponent', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    tabsProps.push(props);
+    return <div data-testid="tabs">Tabs</div>;
+  },
+}));
+
+jest.mock('../../components/StatusHistory', () => ({
+  __esModule: true,
+  default: ({ ticketId }: { ticketId: string }) => <div>Status {ticketId}</div>,
+}));
+
+jest.mock('../../components/AssignmentHistory', () => ({
+  __esModule: true,
+  default: ({ ticketId }: { ticketId: string }) => <div>Assignment {ticketId}</div>,
+}));
+
+describe('Histories', () => {
+  it('renders tabs with status and assignment history', () => {
+    render(<Histories ticketId="T-1" currentTab="status" onTabChange={jest.fn()} />);
+
+    expect(tabsProps[0].tabs).toHaveLength(2);
+    expect(tabsProps[0].tabs[0].tabTitle).toBe('Status History');
+    expect(tabsProps[0].tabs[1].tabTitle).toBe('Assignment History');
+  });
+});

--- a/ui/src/pages/__tests__/KnowledgeBase.test.tsx
+++ b/ui/src/pages/__tests__/KnowledgeBase.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import KnowledgeBase from '../KnowledgeBase';
+
+const mockInitSession = jest.fn(() => Promise.resolve());
+
+jest.mock('../../services/FilegatorService', () => ({
+  initFilegatorSession: (...args: unknown[]) => mockInitSession(...args),
+}));
+
+describe('KnowledgeBase', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockInitSession.mockClear();
+    mockInitSession.mockResolvedValue(undefined);
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('initializes filegator session and sets iframe src', async () => {
+    const { container } = render(<KnowledgeBase />);
+    const frame = container.querySelector('iframe');
+    expect(frame).not.toBeNull();
+
+    await waitFor(() => {
+      expect(frame).toHaveAttribute('src', 'http://localhost:8080');
+    });
+    expect(mockInitSession).toHaveBeenCalled();
+  });
+});

--- a/ui/src/pages/__tests__/Login.test.tsx
+++ b/ui/src/pages/__tests__/Login.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+
+const mockLoginUser = jest.fn(() => Promise.resolve({ token: 'abc' }));
+const mockUseApi = jest.fn();
+
+jest.mock('../../services/AuthService', () => ({
+  loginUser: (...args: unknown[]) => mockLoginUser(...args),
+}));
+
+jest.mock('../../services/RoleService', () => ({
+  getRoleSummaries: jest.fn(() => Promise.resolve({ data: [] })),
+}));
+
+jest.mock('../../utils/permissions', () => ({
+  setPermissions: jest.fn(),
+}));
+
+jest.mock('../../utils/Utils', () => ({
+  setRoleLookup: jest.fn(),
+  setUserDetails: jest.fn(),
+}));
+
+jest.mock('../../utils/authToken', () => ({
+  storeToken: jest.fn(),
+  getDecodedAuthDetails: jest.fn(() => null),
+}));
+
+jest.mock('../../hooks/useApi', () => ({
+  useApi: (...args: unknown[]) => mockUseApi(...args),
+}));
+
+jest.mock('../../context/DevModeContext', () => {
+  const ReactModule = require('react');
+  return {
+    DevModeContext: ReactModule.createContext({
+      devMode: false,
+      jwtBypass: false,
+      toggleJwtBypass: jest.fn(),
+      toggleDevMode: jest.fn(),
+    }),
+  };
+});
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => jest.fn(),
+}));
+
+import Login from '../Login';
+
+describe('Login page', () => {
+  beforeEach(() => {
+    mockLoginUser.mockClear();
+    mockUseApi.mockReset();
+    mockUseApi.mockReturnValue({ data: null, error: null, apiHandler: jest.fn((fn: () => Promise<any>) => fn()) });
+  });
+
+  it('allows portal selection and form submission', async () => {
+    const { getByText, getAllByRole, container } = render(<Login />);
+
+    fireEvent.click(getByText('Requestor Login'));
+    const [userIdInput] = getAllByRole('textbox');
+    fireEvent.change(userIdInput, { target: { value: 'tester' } });
+    const passwordInput = container.querySelector('input[type="password"]') as HTMLInputElement;
+    fireEvent.change(passwordInput, { target: { value: 'secret' } });
+    fireEvent.click(getByText('Login'));
+
+    expect(mockLoginUser).toHaveBeenCalledWith({ username: 'tester', password: 'secret', portal: 'requestor' });
+  });
+
+  it('returns to portal selection', () => {
+    const { getByText } = render(<Login />);
+    fireEvent.click(getByText('Helpdesk Login'));
+    fireEvent.click(getByText('Choose a different portal'));
+    expect(getByText('Select your portal')).toBeInTheDocument();
+  });
+});

--- a/ui/src/pages/__tests__/MyTickets.test.tsx
+++ b/ui/src/pages/__tests__/MyTickets.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import MyTickets from '../MyTickets';
+
+jest.mock('react-router-dom', () => {
+  const navigate = jest.fn();
+  return {
+    useNavigate: () => navigate,
+    __navigateMock: navigate,
+  };
+});
+
+const navigateMock = jest.requireMock('react-router-dom').__navigateMock as jest.Mock;
+
+jest.mock('../../config/config', () => ({
+  getCurrentUserDetails: () => ({
+    userId: 'user-1',
+    username: 'tester',
+    role: ['4', '5', '9'],
+  }),
+}));
+
+const ticketsListProps: any[] = [];
+
+jest.mock('../../components/AllTickets/TicketsList', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    ticketsListProps.push(props);
+    return <div data-testid="tickets-list">My Tickets List</div>;
+  },
+}));
+
+describe('MyTickets', () => {
+  beforeEach(() => {
+    ticketsListProps.length = 0;
+    navigateMock.mockClear();
+  });
+
+  it('builds search overrides and transforms tickets using user roles', () => {
+    render(<MyTickets />);
+    expect(ticketsListProps.length).toBeGreaterThan(0);
+
+    const latestProps = ticketsListProps[ticketsListProps.length - 1];
+
+    const overrides = latestProps.buildSearchOverrides({} as any);
+    expect(overrides).toMatchObject({ requestorId: 'user-1', createdBy: 'tester' });
+
+    const transformed = latestProps.transformTickets([
+      { id: '1', statusId: '1' },
+      { id: '2', statusId: '6' },
+      { id: '3', statusId: '3' },
+    ]);
+    expect(transformed).toEqual([]);
+    latestProps.onRowClick('T-1');
+    expect(navigateMock).toHaveBeenCalledWith('/tickets/T-1');
+  });
+});

--- a/ui/src/pages/__tests__/MyWorkload.test.tsx
+++ b/ui/src/pages/__tests__/MyWorkload.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import MyWorkload from '../MyWorkload';
+
+jest.mock('react-router-dom', () => {
+  const navigate = jest.fn();
+  return {
+    useNavigate: () => navigate,
+    __navigateMock: navigate,
+  };
+});
+
+const navigateMock = jest.requireMock('react-router-dom').__navigateMock as jest.Mock;
+
+jest.mock('../../config/config', () => ({
+  getCurrentUserDetails: () => ({
+    userId: 'user-1',
+    username: 'tester',
+    role: ['4', 'TEAM_LEAD'],
+  }),
+}));
+
+const ticketsListProps: any[] = [];
+
+jest.mock('../../components/AllTickets/TicketsList', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    ticketsListProps.push(props);
+    return <div data-testid="tickets-list">My Workload List</div>;
+  },
+}));
+
+describe('MyWorkload', () => {
+  beforeEach(() => {
+    ticketsListProps.length = 0;
+    navigateMock.mockClear();
+  });
+
+  it('builds search overrides and filters tickets based on roles', () => {
+    render(<MyWorkload />);
+    expect(ticketsListProps.length).toBeGreaterThan(0);
+
+    const latestProps = ticketsListProps[ticketsListProps.length - 1];
+
+    const overrides = latestProps.buildSearchOverrides({} as any);
+    expect(overrides).toEqual({ assignedTo: 'tester' });
+
+    const transformed = latestProps.transformTickets([
+      { id: '1', statusId: '1' },
+      { id: '2', statusId: 'OPEN' },
+      { id: '3', statusId: 'ESCALATED' },
+      { id: '4', statusId: 'ASSIGNED' },
+    ]);
+    expect(transformed).toEqual([
+      { id: '1', statusId: '1' },
+      { id: '2', statusId: 'OPEN' },
+      { id: '4', statusId: 'ASSIGNED' },
+    ]);
+    latestProps.onRowClick('W-1');
+    expect(navigateMock).toHaveBeenCalledWith('/tickets/W-1');
+  });
+});

--- a/ui/src/pages/__tests__/RaiseTicket.test.tsx
+++ b/ui/src/pages/__tests__/RaiseTicket.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+
+const mockAddTicket = jest.fn(() => Promise.resolve({ id: 'T-100' }));
+const mockAddAttachments = jest.fn(() => Promise.resolve());
+const mockApiHandler = jest.fn((fn: () => Promise<any>) => Promise.resolve(fn()));
+
+let mockFormValues: Record<string, any>;
+
+jest.mock('jwt-decode', () => ({
+  jwtDecode: () => ({}),
+}), { virtual: true });
+
+jest.mock('react-hook-form', () => ({
+  useForm: () => {
+    mockFormValues = mockFormValues || {
+      isMaster: false,
+      masterId: null,
+      subject: 'Issue',
+    };
+    return {
+      register: jest.fn(),
+      handleSubmit: (fn: (values: any) => void) => () => fn(mockFormValues),
+      control: {},
+      setValue: (name: string, value: any) => {
+        mockFormValues[name] = value;
+      },
+      getValues: () => mockFormValues,
+      formState: { errors: {} },
+      resetField: (name: string) => {
+        delete mockFormValues[name];
+      },
+    };
+  },
+  useWatch: ({ name }: { name: string }) => mockFormValues?.[name],
+}));
+
+jest.mock('../../components/RaiseTicket/RequestDetails', () => ({
+  __esModule: true,
+  default: () => <div data-testid="request-details" />,
+}));
+
+jest.mock('../../components/RaiseTicket/RequestorDetails', () => ({
+  __esModule: true,
+  default: () => <div data-testid="requestor-details" />,
+}));
+
+jest.mock('../../components/RaiseTicket/TicketDetails', () => ({
+  __esModule: true,
+  default: ({ setAttachments }: { setAttachments: (files: File[]) => void }) => (
+    <button data-testid="add-attachment" onClick={() => setAttachments([new File(['x'], 'test.txt')])}>
+      Attach
+    </button>
+  ),
+}));
+
+jest.mock('../../components/RaiseTicket/SuccessfulModal', () => ({
+  __esModule: true,
+  default: ({ open }: { open: boolean }) => <div data-testid="success-modal">{open ? 'open' : 'closed'}</div>,
+}));
+
+jest.mock('../../components/RaiseTicket/LinkToMasterTicketModal', () => ({
+  __esModule: true,
+  default: ({ open, onClose }: { open: boolean; onClose: () => void }) => (
+    open ? <button data-testid="close-link-modal" onClick={onClose}>Close</button> : null
+  ),
+}));
+
+jest.mock('../../components/UI/Button', () => ({
+  __esModule: true,
+  default: ({ textKey, children, onClick, type }: any) => (
+    <button type={type} onClick={onClick}>{textKey || children}</button>
+  ),
+}));
+
+jest.mock('../../hooks/useApi', () => ({
+  useApi: () => ({ data: null, pending: false, error: null, success: false, apiHandler: mockApiHandler }),
+}));
+
+jest.mock('../../services/TicketService', () => ({
+  addTicket: (...args: unknown[]) => mockAddTicket(...args),
+  addAttachments: (...args: unknown[]) => mockAddAttachments(...args),
+}));
+
+jest.mock('../../context/DevModeContext', () => {
+  const ReactModule = require('react');
+  return {
+    DevModeContext: ReactModule.createContext({ devMode: false }),
+  };
+});
+
+jest.mock('../../utils/permissions', () => ({
+  checkAccessMaster: () => true,
+}));
+
+jest.mock('../../components/UI/IconButton/CustomIconButton', () => ({
+  __esModule: true,
+  default: ({ onClick, icon }: { onClick: () => void; icon: string }) => (
+    <button data-testid={`icon-${icon}`} onClick={onClick}>{icon}</button>
+  ),
+}));
+
+import RaiseTicket from '../RaiseTicket';
+
+describe('RaiseTicket', () => {
+  beforeEach(() => {
+    mockFormValues = {
+      isMaster: false,
+      masterId: null,
+      subject: 'Issue subject',
+    };
+    mockAddTicket.mockClear();
+    mockAddAttachments.mockClear();
+    mockApiHandler.mockClear();
+    mockAddTicket.mockResolvedValue({ id: 'T-100' });
+    mockAddAttachments.mockResolvedValue(undefined);
+    mockApiHandler.mockImplementation((fn: () => Promise<any>) => Promise.resolve(fn()));
+  });
+
+  it('submits ticket and opens success modal', async () => {
+    const { getByText, getByTestId } = render(<RaiseTicket />);
+
+    fireEvent.click(getByTestId('add-attachment'));
+    fireEvent.click(getByText('Submit Ticket'));
+
+    await waitFor(() => {
+      expect(mockAddTicket).toHaveBeenCalled();
+      expect(mockAddAttachments).toHaveBeenCalledWith('T-100', expect.any(Array));
+      expect(getByTestId('success-modal')).toHaveTextContent('open');
+    });
+  });
+
+  it('opens link to master ticket modal', () => {
+    const { getByText, getByTestId } = render(<RaiseTicket />);
+    fireEvent.click(getByText('Link to a Master Ticket'));
+    fireEvent.click(getByTestId('close-link-modal'));
+  });
+});

--- a/ui/src/pages/__tests__/RoleDetails.test.tsx
+++ b/ui/src/pages/__tests__/RoleDetails.test.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+
+const mockUpdateRolePermission = jest.fn(() => Promise.resolve());
+const mockUpdateRole = jest.fn(() => Promise.resolve());
+const mockRenameRole = jest.fn(() => Promise.resolve());
+const mockLoadPermissions = jest.fn(() => Promise.resolve());
+const mockGetAllRoles = jest.fn(() => Promise.resolve([{ roleId: 1, role: 'Admin', allowedStatusActionIds: '1|2', description: 'Administrator' }]));
+const mockGetStatusActions = jest.fn(() => Promise.resolve([{ id: 1, action: 'Approve' }]));
+const mockShowMessage = jest.fn();
+const mockUseApi = jest.fn();
+
+let mockAutocompleteCounter = 0;
+
+jest.mock('@mui/material/Autocomplete', () => ({
+  __esModule: true,
+  default: ({ options = [], value, onChange, renderInput }: any) => {
+    const instanceId = mockAutocompleteCounter++;
+    const normalize = (option: any) => {
+      if (typeof option === 'string') return option;
+      if (option?.id != null) return String(option.id);
+      if (option?.action) return option.action;
+      return String(option ?? '');
+    };
+    const normalizedValue = Array.isArray(value) ? value.map((v: any) => normalize(v)) : normalize(value);
+    const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+      const selected = Array.from(event.target.selectedOptions || []).map(opt => opt.value);
+      const mapped = selected.map(val => options.find((opt: any) => normalize(opt) === val) ?? val);
+      onChange?.(event, mapped);
+    };
+    return (
+      <div data-testid={`autocomplete-${instanceId}`}>
+        {renderInput?.({ InputProps: {}, inputProps: {}, InputLabelProps: {} })}
+        <select multiple value={normalizedValue} onChange={handleChange}>
+          {options.map((opt: any) => {
+            const val = normalize(opt);
+            return <option key={val} value={val}>{val}</option>;
+          })}
+        </select>
+      </div>
+    );
+  },
+}));
+
+jest.mock('../../hooks/useApi', () => ({
+  useApi: (...args: unknown[]) => mockUseApi(...args),
+}));
+
+jest.mock('../../services/RoleService', () => ({
+  updateRolePermission: (...args: unknown[]) => mockUpdateRolePermission(...args),
+  updateRole: (...args: unknown[]) => mockUpdateRole(...args),
+  loadPermissions: (...args: unknown[]) => mockLoadPermissions(...args),
+  renameRole: (...args: unknown[]) => mockRenameRole(...args),
+  getAllRoles: () => mockGetAllRoles(),
+}));
+
+jest.mock('../../services/StatusService', () => ({
+  getStatusActions: () => mockGetStatusActions(),
+}));
+
+jest.mock('../../config/config', () => ({
+  getCurrentUserDetails: () => ({ userId: 'u1', username: 'user.one' }),
+}));
+
+jest.mock('../../components/Permissions/PermissionTree', () => ({
+  __esModule: true,
+  default: ({ onChange }: { onChange: (p: any) => void }) => (
+    <button data-testid="permission-tree" onClick={() => onChange({ updated: true })}>Tree</button>
+  ),
+}));
+
+jest.mock('../../components/Permissions/JsonEditModal', () => ({
+  __esModule: true,
+  default: ({ open, onSubmit, onCancel }: any) => (
+    open ? (
+      <div>
+        <button onClick={() => onSubmit({ json: true })}>Submit JSON</button>
+        <button onClick={onCancel}>Cancel</button>
+      </div>
+    ) : null
+  ),
+}));
+
+jest.mock('../../components/UI/IconButton/CustomIconButton', () => ({
+  __esModule: true,
+  default: ({ onClick, icon }: { onClick: () => void; icon: string }) => (
+    <button data-testid={`icon-${icon}`} onClick={onClick}>{icon}</button>
+  ),
+}));
+
+jest.mock('../../context/SnackbarContext', () => ({
+  useSnackbar: () => ({ showMessage: mockShowMessage }),
+}));
+
+jest.mock('../../context/DevModeContext', () => {
+  const ReactModule = require('react');
+  return {
+    DevModeContext: ReactModule.createContext({ devMode: true }),
+  };
+});
+
+jest.mock('react-router-dom', () => {
+  const navigate = jest.fn();
+  return {
+    useParams: () => ({ roleId: '1' }),
+    useNavigate: () => navigate,
+    useLocation: () => ({ state: { permissions: { dashboard: true }, role: 'Admin' } }),
+    __navigateMock: navigate,
+  };
+});
+
+const navigateMock = jest.requireMock('react-router-dom').__navigateMock as jest.Mock;
+
+import RoleDetails from '../RoleDetails';
+
+describe('RoleDetails', () => {
+  beforeEach(() => {
+    mockUpdateRolePermission.mockClear();
+    mockUpdateRole.mockClear();
+    mockRenameRole.mockClear();
+    mockLoadPermissions.mockClear();
+    mockShowMessage.mockClear();
+    navigateMock.mockClear();
+    mockAutocompleteCounter = 0;
+    mockUseApi.mockReset();
+    mockUpdateRolePermission.mockResolvedValue(undefined);
+    mockUpdateRole.mockResolvedValue(undefined);
+    mockRenameRole.mockResolvedValue(undefined);
+    mockLoadPermissions.mockResolvedValue(undefined);
+
+    mockUseApi
+      .mockImplementationOnce(() => ({
+        data: [{ id: 1, action: 'Approve' }],
+        apiHandler: jest.fn((fn: () => Promise<any>) => fn()),
+      }))
+      .mockImplementationOnce(() => ({
+        data: [{ roleId: 1, role: 'Admin', allowedStatusActionIds: '1|2', description: 'Administrator', permissions: { dashboard: true } }],
+        pending: false,
+        success: true,
+        apiHandler: jest.fn((fn: () => Promise<any>) => fn()),
+      }))
+      .mockImplementation(() => ({
+        data: null,
+        apiHandler: jest.fn((fn: () => Promise<any>) => fn()),
+      }));
+  });
+
+  it('saves permissions and status actions', async () => {
+    const { getByText } = render(<RoleDetails />);
+
+    fireEvent.click(getByText('Save'));
+
+    await waitFor(() => {
+      expect(mockUpdateRolePermission).toHaveBeenCalled();
+      expect(mockUpdateRole).toHaveBeenCalledWith('1', expect.objectContaining({ allowedStatusActionIds: expect.any(String) }));
+      expect(mockShowMessage).toHaveBeenCalledWith('Permissions updated successfully', 'success');
+    });
+  });
+
+  it('allows renaming the role', () => {
+    const { getByTestId, getByDisplayValue } = render(<RoleDetails />);
+    fireEvent.click(getByTestId('icon-edit'));
+    fireEvent.change(getByDisplayValue('Admin'), { target: { value: 'Admin Updated' } });
+    fireEvent.click(getByTestId('icon-check'));
+    expect(mockRenameRole).toHaveBeenCalledWith('1', 'Admin Updated', 'user.one');
+  });
+});

--- a/ui/src/pages/__tests__/RoleMaster.test.tsx
+++ b/ui/src/pages/__tests__/RoleMaster.test.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
+
+const mockAddRole = jest.fn(() => Promise.resolve());
+const mockLoadPermissions = jest.fn(() => Promise.resolve());
+const mockGetAllPermissions = jest.fn(() => Promise.resolve({ roles: { Admin: {} } }));
+const mockGetAllRoles = jest.fn(() => Promise.resolve([{ roleId: '1', role: 'Admin', description: 'Desc', createdOn: '2024-01-01' }]));
+const mockDeleteRole = jest.fn(() => Promise.resolve());
+const mockDeleteRoles = jest.fn(() => Promise.resolve());
+const mockGetStatusActions = jest.fn(() => Promise.resolve([{ id: 1, action: 'Approve' }]));
+const mockUseApi = jest.fn();
+
+jest.mock('../../hooks/useApi', () => ({
+  useApi: (...args: unknown[]) => mockUseApi(...args),
+}));
+
+jest.mock('../../services/RoleService', () => ({
+  addRole: (...args: unknown[]) => mockAddRole(...args),
+  getAllPermissions: () => mockGetAllPermissions(),
+  loadPermissions: (...args: unknown[]) => mockLoadPermissions(...args),
+  getAllRoles: () => mockGetAllRoles(),
+  deleteRole: (...args: unknown[]) => mockDeleteRole(...args),
+  deleteRoles: (...args: unknown[]) => mockDeleteRoles(...args),
+}));
+
+jest.mock('../../services/StatusService', () => ({
+  getStatusActions: () => mockGetStatusActions(),
+}));
+
+jest.mock('../../components/UI/ViewToggle', () => ({
+  __esModule: true,
+  default: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+    <button data-testid="view-toggle" onClick={() => onChange(value === 'table' ? 'grid' : 'table')}>
+      toggle
+    </button>
+  ),
+}));
+
+let capturedTableProps: any = null;
+
+jest.mock('../../components/UI/GenericTable', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    capturedTableProps = props;
+    return <div data-testid="roles-table">Table</div>;
+  },
+}));
+
+jest.mock('../../components/UI/IconButton/CustomIconButton', () => ({
+  __esModule: true,
+  default: ({ onClick, icon }: { onClick: () => void; icon: string }) => (
+    <button onClick={onClick}>{icon}</button>
+  ),
+}));
+
+jest.mock('../../context/DevModeContext', () => {
+  const ReactModule = require('react');
+  return {
+    DevModeContext: ReactModule.createContext({ devMode: false }),
+  };
+});
+
+jest.mock('../CreateRole', () => ({
+  __esModule: true,
+  default: ({ onSubmit, onCancel }: { onSubmit: (payload: any) => void; onCancel: () => void }) => (
+    <div>
+      <button data-testid="create-role-submit" onClick={() => onSubmit({ role: 'NewRole' })}>Submit Create</button>
+      <button data-testid="create-role-cancel" onClick={onCancel}>Cancel Create</button>
+    </div>
+  ),
+}));
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: jest.fn(),
+}));
+
+const navigateMock = jest.fn();
+const useNavigateMock = jest.requireMock('react-router-dom').useNavigate as jest.Mock;
+useNavigateMock.mockReturnValue(navigateMock);
+
+import RoleMaster from '../RoleMaster';
+
+describe('RoleMaster', () => {
+  const originalConfirm = window.confirm;
+
+  beforeEach(() => {
+    mockAddRole.mockClear();
+    mockLoadPermissions.mockClear();
+    mockGetAllPermissions.mockClear();
+    mockGetAllRoles.mockClear();
+    mockDeleteRole.mockClear();
+    mockDeleteRoles.mockClear();
+    mockGetStatusActions.mockClear();
+    capturedTableProps = null;
+    navigateMock.mockClear();
+    window.confirm = jest.fn(() => true);
+    mockUseApi.mockReset();
+
+    mockAddRole.mockResolvedValue(undefined);
+    mockLoadPermissions.mockResolvedValue(undefined);
+    mockDeleteRole.mockResolvedValue(undefined);
+    mockDeleteRoles.mockResolvedValue(undefined);
+    mockGetAllPermissions.mockResolvedValue({ roles: { Admin: {} } });
+    mockGetAllRoles.mockResolvedValue([{ roleId: '1', role: 'Admin', description: 'Desc', createdOn: '2024-01-01' }]);
+    mockGetStatusActions.mockResolvedValue([{ id: 1, action: 'Approve' }]);
+
+    mockUseApi
+      .mockImplementationOnce(() => ({
+        data: [{ roleId: '1', role: 'Admin', description: 'Desc', createdOn: '2024-01-01' }],
+        apiHandler: jest.fn((fn: () => Promise<any>) => fn()),
+      }))
+      .mockImplementationOnce(() => ({
+        data: { roles: { Admin: {} } },
+        apiHandler: jest.fn((fn: () => Promise<any>) => fn()),
+      }))
+      .mockImplementationOnce(() => ({
+        data: [{ id: 1, action: 'Approve' }],
+        apiHandler: jest.fn((fn: () => Promise<any>) => fn()),
+      }))
+      .mockImplementation(() => ({
+        data: null,
+        apiHandler: jest.fn((fn: () => Promise<any>) => fn()),
+      }));
+  });
+
+  afterEach(() => {
+    window.confirm = originalConfirm;
+  });
+
+  it('creates a role when create flow is submitted', async () => {
+    const { getByText, getByTestId } = render(<RoleMaster />);
+
+    await act(async () => {
+      fireEvent.click(getByText('Create Role'));
+    });
+
+    await act(async () => {
+      fireEvent.click(getByTestId('create-role-submit'));
+    });
+
+    await waitFor(() => {
+      expect(mockAddRole).toHaveBeenCalledWith({ role: 'NewRole' });
+      expect(mockGetAllRoles).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('deletes selected roles', async () => {
+    const { getByText } = render(<RoleMaster />);
+    expect(capturedTableProps).not.toBeNull();
+    await act(async () => {
+      capturedTableProps.rowSelection.onChange(['1']);
+    });
+
+    await act(async () => {
+      fireEvent.click(getByText('Delete Selected'));
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteRoles).toHaveBeenCalledWith(['1'], false);
+    });
+  });
+});

--- a/ui/src/pages/__tests__/RootCauseAnalysis.test.tsx
+++ b/ui/src/pages/__tests__/RootCauseAnalysis.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+
+const mockGetTickets = jest.fn(() => Promise.resolve({ items: [{ id: '1', severity: 'S1', severityLabel: 'Critical', rcaStatus: 'PENDING' }], totalPages: 2 }));
+const mockGetWorkflow = jest.fn(() => Promise.resolve({}));
+const mockUseApi = jest.fn();
+const mockCategoryFilters = {
+  categoryOptions: ['All', 'Category1'],
+  subCategoryOptions: ['All'],
+  loadSubCategories: jest.fn(),
+};
+
+jest.mock('../../hooks/useApi', () => ({
+  useApi: (...args: unknown[]) => mockUseApi(...args),
+}));
+
+jest.mock('../../services/RootCauseAnalysisService', () => ({
+  getRootCauseAnalysisTickets: (...args: unknown[]) => mockGetTickets(...args),
+}));
+
+jest.mock('../../services/StatusService', () => ({
+  getStatusWorkflowMappings: (...args: unknown[]) => mockGetWorkflow(...args),
+}));
+
+jest.mock('../../hooks/useCategoryFilters', () => ({
+  useCategoryFilters: () => mockCategoryFilters,
+}));
+
+let capturedTicketsProps: any = null;
+
+jest.mock('../../components/AllTickets/TicketsTable', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    capturedTicketsProps = props;
+    return <div data-testid="tickets-table">Tickets</div>;
+  },
+}));
+
+jest.mock('../../components/PaginationControls', () => ({
+  __esModule: true,
+  default: ({ onChange }: { onChange: (e: unknown, value: number) => void }) => (
+    <button data-testid="pagination" onClick={() => onChange({}, 2)}>Next</button>
+  ),
+}));
+
+jest.mock('../../components/Filters/DateRangeFilter', () => ({
+  __esModule: true,
+  default: ({ onChange }: { onChange: (v: any) => void }) => (
+    <button data-testid="date-range" onClick={() => onChange({ preset: 'LAST_7_DAYS' })}>DateRange</button>
+  ),
+  getDateRangeApiParams: () => ({ fromDate: undefined, toDate: undefined }),
+}));
+
+jest.mock('../../components/UI/Dropdown/DropdownController', () => ({
+  __esModule: true,
+  default: ({ label, onChange }: { label: string; onChange: (v: string) => void }) => (
+    <button data-testid={`dropdown-${label}`} onClick={() => onChange('All')}>{label}</button>
+  ),
+}));
+
+jest.mock('react-router-dom', () => {
+  const navigate = jest.fn();
+  return {
+    useNavigate: () => navigate,
+    __navigateMock: navigate,
+  };
+});
+
+const navigateMock = jest.requireMock('react-router-dom').__navigateMock as jest.Mock;
+
+jest.mock('../../config/config', () => ({
+  getCurrentUserDetails: () => ({ username: 'tester', userId: 'tester', role: ['AGENT'] }),
+}));
+
+import RootCauseAnalysis from '../RootCauseAnalysis';
+
+describe('RootCauseAnalysis', () => {
+  beforeEach(() => {
+    mockGetTickets.mockClear();
+    mockGetWorkflow.mockClear();
+    navigateMock.mockClear();
+    mockCategoryFilters.loadSubCategories.mockClear();
+    capturedTicketsProps = null;
+    mockUseApi.mockReset();
+
+    mockUseApi
+      .mockImplementationOnce(() => ({
+        data: { items: [{ id: '1', severity: 'S1', severityLabel: 'Critical', rcaStatus: 'PENDING' }], totalPages: 2 },
+        apiHandler: jest.fn((fn: () => Promise<any>) => fn()),
+      }))
+      .mockImplementationOnce(() => ({
+        data: {},
+        apiHandler: jest.fn((fn: () => Promise<any>) => fn()),
+      }))
+      .mockImplementation(() => ({
+        data: null,
+        apiHandler: jest.fn((fn: () => Promise<any>) => fn()),
+      }));
+  });
+
+  it('fetches tickets and renders table with normalized severity', async () => {
+    const { getByTestId } = render(<RootCauseAnalysis />);
+
+    await waitFor(() => {
+      expect(mockGetTickets).toHaveBeenCalled();
+      expect(capturedTicketsProps.tickets[0]).toMatchObject({ severity: 'Critical', severityLabel: 'Critical' });
+    });
+
+    fireEvent.click(getByTestId('tickets-table'));
+    capturedTicketsProps.onRowClick('1');
+    expect(navigateMock).toHaveBeenCalledWith('/root-cause-analysis/1');
+  });
+});

--- a/ui/src/pages/__tests__/TicketDetails.test.tsx
+++ b/ui/src/pages/__tests__/TicketDetails.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import TicketDetails from '../TicketDetails';
+
+jest.mock('react-router-dom', () => ({
+  useParams: () => ({ ticketId: 'T-123' }),
+}));
+
+jest.mock('../../components/TicketView/TicketView', () => ({
+  __esModule: true,
+  default: ({ ticketId }: { ticketId: string }) => <div data-testid="ticket-view">Ticket {ticketId}</div>,
+}));
+
+jest.mock('../../components/TicketView/HistorySidebar', () => ({
+  __esModule: true,
+  default: ({ open, setOpen }: { open: boolean; setOpen: (v: boolean) => void }) => (
+    <button data-testid="history-toggle" onClick={() => setOpen(!open)}>
+      {open ? 'Close' : 'Open'}
+    </button>
+  ),
+}));
+
+describe('TicketDetails', () => {
+  it('renders TicketView and toggles history sidebar state', () => {
+    const { getByTestId } = render(<TicketDetails />);
+
+    expect(getByTestId('ticket-view')).toHaveTextContent('Ticket T-123');
+
+    fireEvent.click(getByTestId('history-toggle'));
+    fireEvent.click(getByTestId('history-toggle'));
+  });
+});


### PR DESCRIPTION
## Summary
- add React Testing Library coverage for the AllTickets, MyTickets, MyWorkload, and TicketDetails pages to verify navigation, filtering, and ticket normalization behaviors
- cover CreateRole, CustomerSatisfactionForm, RaiseTicket, and EscalationMaster with form interaction tests and API mock assertions
- add regression suites for CategoriesMaster, KnowledgeBase, Login, FAQ, Histories, RoleDetails, RoleMaster, RootCauseAnalysis, and FAQ form flows while stubbing external services

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68e4c81df55083328470c1f1b5652814