### PR TITLE
Add UI tests for AllTickets components

### DIFF
--- a/ui/src/components/AllTickets/__tests__/AdvancedAssignmentOptionsDialog.test.tsx
+++ b/ui/src/components/AllTickets/__tests__/AdvancedAssignmentOptionsDialog.test.tsx
@@ -1,0 +1,193 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import AdvancedAssignmentOptionsDialog from '../AdvancedAssignmentOptionsDialog';
+
+const mockUpdateTicket = jest.fn(() => Promise.resolve({}));
+jest.mock('../../../services/TicketService', () => ({
+    updateTicket: (...args: any[]) => mockUpdateTicket(...args),
+}));
+
+const mockGetCurrentUserDetails = jest.fn(() => ({ username: 'agent.user' }));
+jest.mock('../../../config/config', () => ({
+    getCurrentUserDetails: (...args: any[]) => mockGetCurrentUserDetails(...args),
+}));
+
+const mockRemarkComponent = jest.fn(({ actionName, onSubmit, onCancel }: any) => (
+    <div>
+        <span>{actionName}</span>
+        <button type="button" data-testid={`submit-${actionName}`} onClick={() => onSubmit('test remark')}>
+            submit
+        </button>
+        <button type="button" onClick={onCancel}>
+            cancel
+        </button>
+    </div>
+));
+jest.mock('../../UI/Remark/RemarkComponent', () => ({
+    __esModule: true,
+    default: (props: any) => mockRemarkComponent(props),
+}));
+
+jest.mock('../../UI/CustomTabsComponent', () => {
+    const React = require('react');
+    const MockTabs = ({ tabs, currentTab, onTabChange }: any) => {
+        const [active, setActive] = React.useState(currentTab ?? tabs[0]?.key);
+        React.useEffect(() => {
+            if (currentTab) setActive(currentTab);
+        }, [currentTab]);
+        const handleClick = (key: string) => {
+            setActive(key);
+            onTabChange?.(key);
+        };
+        const activeTab = tabs.find((t: any) => t.key === active);
+        return (
+            <div>
+                {tabs.map((tab: any) => (
+                    <button key={tab.key} type="button" onClick={() => handleClick(tab.key)}>
+                        {tab.tabTitle}
+                    </button>
+                ))}
+                <div data-testid={`tab-content-${active}`}>{activeTab?.tabComponent}</div>
+            </div>
+        );
+    };
+    return {
+        __esModule: true,
+        default: MockTabs,
+    };
+});
+
+describe('AdvancedAssignmentOptionsDialog', () => {
+    const defaultProps = {
+        open: true,
+        onClose: jest.fn(),
+        ticketId: 'INC-1',
+        requestorId: 'user-1',
+        canRequester: false,
+        canRno: false,
+        levels: [
+            { levelId: 'L1', levelName: 'Level 1' },
+            { levelId: 'L2', levelName: 'Level 2' },
+        ],
+        users: [
+            { userId: '1', username: 'john', name: 'John Doe', roles: '3', levels: ['L1'] },
+            { userId: '2', username: 'mary', name: 'Mary Jane', roles: '9', levels: ['L2'] },
+        ],
+        rnoUsers: [
+            { userId: 'r1', username: 'rno', name: 'Rno User', roles: '16', levels: [] },
+        ],
+        updateTicketApiHandler: jest.fn(() => Promise.resolve()),
+        searchCurrentTicketsPaginatedApi: jest.fn(),
+        onAssigned: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        defaultProps.updateTicketApiHandler.mockImplementation((callback: any) => Promise.resolve(callback()));
+        defaultProps.searchCurrentTicketsPaginatedApi.mockClear();
+        defaultProps.onAssigned.mockClear();
+        defaultProps.onClose.mockClear();
+        mockGetCurrentUserDetails.mockReturnValue({ username: 'agent.user' });
+        mockUpdateTicket.mockResolvedValue({});
+    });
+
+    it('renders available tabs based on permissions', () => {
+        render(
+            <AdvancedAssignmentOptionsDialog
+                {...defaultProps}
+                canRequester
+                canRno
+            />
+        );
+
+        expect(screen.getByText('Assign User')).toBeInTheDocument();
+        expect(screen.getByText('Requester')).toBeInTheDocument();
+        expect(screen.getByText('Regional Nodal Officer')).toBeInTheDocument();
+    });
+
+    it('assigns selected user and refreshes tickets', async () => {
+        render(<AdvancedAssignmentOptionsDialog {...defaultProps} />);
+
+        fireEvent.click(screen.getByText('John Doe'));
+        await waitFor(() => {
+            expect(mockRemarkComponent).toHaveBeenCalledWith(expect.objectContaining({ actionName: 'Assign' }));
+        });
+        const assignCall = mockRemarkComponent.mock.calls.find(([props]) => props.actionName === 'Assign');
+        expect(assignCall).toBeDefined();
+        const assignProps = assignCall![0];
+        assignProps.onSubmit('test remark');
+
+        await waitFor(() => {
+            expect(defaultProps.updateTicketApiHandler).toHaveBeenCalled();
+        });
+
+        expect(mockUpdateTicket).toHaveBeenCalledWith('INC-1', expect.objectContaining({
+            assignedTo: 'john',
+            assignedToLevel: 'L1',
+            levelId: 'L1',
+            remark: expect.any(String),
+        }));
+        expect(defaultProps.searchCurrentTicketsPaginatedApi).toHaveBeenCalledWith('INC-1');
+        expect(defaultProps.onAssigned).toHaveBeenCalledWith('John Doe');
+        expect(defaultProps.onClose).toHaveBeenCalled();
+    });
+
+    it('assigns to requester when requester tab used', async () => {
+        render(
+            <AdvancedAssignmentOptionsDialog
+                {...defaultProps}
+                canRequester
+            />
+        );
+
+        fireEvent.click(screen.getByText('Requester'));
+        await waitFor(() => {
+            expect(mockRemarkComponent).toHaveBeenCalledWith(expect.objectContaining({ actionName: 'Assign to Requester' }));
+        });
+        const requesterCall = mockRemarkComponent.mock.calls.find(([props]) => props.actionName === 'Assign to Requester');
+        expect(requesterCall).toBeDefined();
+        const requesterProps = requesterCall![0];
+        requesterProps.onSubmit('test remark');
+
+        await waitFor(() => {
+            expect(defaultProps.updateTicketApiHandler).toHaveBeenCalled();
+        });
+
+        expect(mockUpdateTicket).toHaveBeenCalledWith('INC-1', expect.objectContaining({
+            assignedTo: 'user-1',
+            status: { statusId: '3' },
+        }));
+        expect(defaultProps.searchCurrentTicketsPaginatedApi).toHaveBeenCalledWith('INC-1');
+        expect(defaultProps.onClose).toHaveBeenCalled();
+    });
+
+    it('assigns to regional nodal officer when RNO tab used', async () => {
+        render(
+            <AdvancedAssignmentOptionsDialog
+                {...defaultProps}
+                canRno
+            />
+        );
+
+        fireEvent.click(screen.getByText('Regional Nodal Officer'));
+        fireEvent.click(screen.getByText('Rno User'));
+        await waitFor(() => {
+            expect(mockRemarkComponent).toHaveBeenCalledWith(expect.objectContaining({ actionName: 'Assign' }));
+        });
+        const rnoCall = mockRemarkComponent.mock.calls.filter(([props]) => props.actionName === 'Assign').pop();
+        expect(rnoCall).toBeDefined();
+        const rnoProps = rnoCall![0];
+        rnoProps.onSubmit('test remark');
+
+        await waitFor(() => {
+            expect(defaultProps.updateTicketApiHandler).toHaveBeenCalled();
+        });
+
+        expect(mockUpdateTicket).toHaveBeenCalledWith('INC-1', expect.objectContaining({
+            assignedTo: 'rno',
+            status: { statusId: '5' },
+        }));
+        expect(defaultProps.searchCurrentTicketsPaginatedApi).toHaveBeenCalledWith('INC-1');
+        expect(defaultProps.onClose).toHaveBeenCalled();
+    });
+});

--- a/ui/src/components/AllTickets/__tests__/RequestorDetails.test.tsx
+++ b/ui/src/components/AllTickets/__tests__/RequestorDetails.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import RequestorDetails from '../RequestorDetails';
+
+describe('RequestorDetails', () => {
+    const writeTextMock = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        writeTextMock.mockReset();
+        Object.assign(navigator, {
+            clipboard: {
+                writeText: writeTextMock,
+            },
+        });
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        act(() => {
+            jest.runOnlyPendingTimers();
+        });
+        jest.useRealTimers();
+    });
+
+    it('renders provided email and phone values', () => {
+        render(<RequestorDetails email="john@example.com" phone="1234567890" />);
+
+        expect(screen.getByText('john@example.com')).toBeInTheDocument();
+        expect(screen.getByText('1234567890')).toBeInTheDocument();
+    });
+
+    it('copies email to clipboard and shows confirmation', async () => {
+        render(<RequestorDetails email="john@example.com" phone="1234567890" />);
+
+        const [emailCopyIcon] = screen.getAllByTestId('ContentCopyIcon');
+        fireEvent.click(emailCopyIcon);
+
+        expect(writeTextMock).toHaveBeenCalledWith('john@example.com');
+        expect(screen.getByText('Email copied')).toBeInTheDocument();
+
+        await act(async () => {
+            jest.runAllTimers();
+        });
+        await waitFor(() => {
+            expect(screen.queryByText('Email copied')).not.toBeInTheDocument();
+        });
+    });
+
+    it('does not attempt to copy when value is missing', () => {
+        render(<RequestorDetails phone="1234567890" />);
+
+        const [emailCopyIcon] = screen.getAllByTestId('ContentCopyIcon');
+        fireEvent.click(emailCopyIcon);
+
+        expect(writeTextMock).not.toHaveBeenCalled();
+        expect(screen.getByText('-')).toBeInTheDocument();
+    });
+});

--- a/ui/src/components/AllTickets/__tests__/TicketCard.test.tsx
+++ b/ui/src/components/AllTickets/__tests__/TicketCard.test.tsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import TicketCard, { TicketCardData } from '../TicketCard';
+
+type TicketStatusWorkflow = {
+    id: string;
+    action: string;
+    nextStatus: string;
+};
+
+const mockAssigneeDropdown = jest.fn((props: any) => (
+    <span data-testid="assignee-dropdown">Assignee Dropdown for {props.assigneeName}</span>
+));
+jest.mock('../AssigneeDropdown', () => ({
+    __esModule: true,
+    default: (props: any) => mockAssigneeDropdown(props),
+}));
+
+const mockCustomIconButton = jest.fn(({ icon, onClick }: any) => (
+    <button type="button" data-testid={`custom-icon-${icon}`} onClick={onClick}>
+        {icon}
+    </button>
+));
+const mockIconComponent = jest.fn(({ icon }: any) => <span data-testid={`icon-${icon}`}>{icon}</span>);
+jest.mock('../../UI/IconButton/CustomIconButton', () => ({
+    __esModule: true,
+    default: (props: any) => mockCustomIconButton(props),
+    IconComponent: (props: any) => mockIconComponent(props),
+}));
+
+const mockRemarkComponent = jest.fn(({ actionName, onSubmit, onCancel }: any) => (
+    <span>
+        <span>{actionName}</span>
+        <button type="button" data-testid="remark-submit" onClick={() => onSubmit('remark')}>
+            submit
+        </button>
+        <button type="button" onClick={onCancel}>
+            cancel
+        </button>
+    </span>
+));
+jest.mock('../../UI/Remark/RemarkComponent', () => ({
+    __esModule: true,
+    default: (props: any) => mockRemarkComponent(props),
+}));
+
+jest.mock('../../UI/Icons/MasterIcon', () => () => <span data-testid="master-icon">Master</span>);
+jest.mock('../../UI/UserAvatar/UserAvatar', () => ({ name }: any) => <span data-testid="user-avatar">{name}</span>);
+jest.mock('../../UI/Icons/PriorityIcon', () => ({ priorityText }: any) => (
+    <span data-testid="priority-icon">{priorityText}</span>
+));
+
+const mockUseApi = jest.fn();
+jest.mock('../../../hooks/useApi', () => ({
+    useApi: (...args: any[]) => mockUseApi(...args),
+}));
+
+const mockUpdateTicket = jest.fn(() => Promise.resolve({}));
+jest.mock('../../../services/TicketService', () => ({
+    updateTicket: (...args: any[]) => mockUpdateTicket(...args),
+}));
+
+const mockGetCurrentUserDetails = jest.fn(() => ({ username: 'agent.user' }));
+jest.mock('../../../config/config', () => ({
+    getCurrentUserDetails: (...args: any[]) => mockGetCurrentUserDetails(...args),
+}));
+
+const mockGetStatusNameById = jest.fn(() => 'In Progress');
+const mockGetStatusColorById = jest.fn(() => '#000');
+const mockTruncateWithEllipsis = jest.fn((value: string) => value);
+jest.mock('../../../utils/Utils', () => ({
+    getStatusNameById: (...args: any[]) => mockGetStatusNameById(...args),
+    getStatusColorById: (...args: any[]) => mockGetStatusColorById(...args),
+    truncateWithEllipsis: (...args: any[]) => mockTruncateWithEllipsis(...args),
+}));
+
+const mockUseNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+    useNavigate: () => mockUseNavigate,
+}));
+
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('TicketCard', () => {
+    const ticket: TicketCardData = {
+        id: 'INC-100',
+        subject: 'Printer not working',
+        description: 'The office printer is jammed',
+        category: 'IT',
+        subCategory: 'Hardware',
+        priority: 'P1',
+        isMaster: true,
+        userId: 'user-123',
+        requestorName: 'John Doe',
+        assignedTo: 'agent1',
+        assignedToName: 'Agent One',
+        statusId: 'open',
+    };
+
+    const searchCurrentTicketsPaginatedApi = jest.fn();
+    const updateTicketApiHandler = jest.fn((callback: any) => Promise.resolve(callback()));
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        updateTicketApiHandler.mockImplementation((callback: any) => Promise.resolve(callback()));
+        mockUseApi.mockReturnValue({ apiHandler: updateTicketApiHandler });
+        mockUpdateTicket.mockResolvedValue({});
+        mockGetCurrentUserDetails.mockReturnValue({ username: 'agent.user' });
+        searchCurrentTicketsPaginatedApi.mockClear();
+    });
+
+    it('shows assignee dropdown when assign action is available', () => {
+        const workflows: Record<string, TicketStatusWorkflow[]> = {
+            open: [
+                { id: '1', action: 'Assign', nextStatus: '2' },
+                { id: '2', action: 'Resolve', nextStatus: '3' },
+            ],
+        };
+
+        render(
+            <TicketCard
+                ticket={ticket}
+                priorityConfig={{}}
+                statusWorkflows={workflows}
+                searchCurrentTicketsPaginatedApi={searchCurrentTicketsPaginatedApi}
+            />
+        );
+
+        expect(mockAssigneeDropdown).toHaveBeenCalledTimes(1);
+        const assigneeProps = mockAssigneeDropdown.mock.calls[0][0];
+        expect(assigneeProps).toMatchObject({
+            ticketId: 'INC-100',
+            assigneeName: 'Agent One',
+            requestorId: 'user-123',
+        });
+    });
+
+    it('renders menu button when more than two actions are available', async () => {
+        const workflows: Record<string, TicketStatusWorkflow[]> = {
+            open: [
+                { id: '1', action: 'Resolve', nextStatus: '2' },
+                { id: '2', action: 'Cancel/ Reject', nextStatus: '3' },
+                { id: '3', action: 'Close', nextStatus: '4' },
+            ],
+        };
+
+        const { container } = render(
+            <TicketCard
+                ticket={ticket}
+                priorityConfig={{}}
+                statusWorkflows={workflows}
+                searchCurrentTicketsPaginatedApi={searchCurrentTicketsPaginatedApi}
+            />
+        );
+
+        fireEvent.mouseEnter(container.firstChild as HTMLElement);
+        await waitFor(() => {
+            expect(mockCustomIconButton).toHaveBeenCalledWith(expect.objectContaining({ icon: 'moreVert' }));
+        });
+    });
+
+    it('submits remark when action is chosen', async () => {
+        const workflows: Record<string, TicketStatusWorkflow[]> = {
+            open: [
+                { id: '1', action: 'Resolve', nextStatus: '2' },
+            ],
+        };
+
+        const { container } = render(
+            <TicketCard
+                ticket={ticket}
+                priorityConfig={{}}
+                statusWorkflows={workflows}
+                searchCurrentTicketsPaginatedApi={searchCurrentTicketsPaginatedApi}
+            />
+        );
+
+        fireEvent.mouseEnter(container.firstChild as HTMLElement);
+        await waitFor(() => {
+            expect(mockCustomIconButton).toHaveBeenCalledWith(expect.objectContaining({ icon: 'check' }));
+        });
+        const actionCall = mockCustomIconButton.mock.calls.find(([props]) => props.icon === 'check');
+        expect(actionCall).toBeDefined();
+        const actionProps = actionCall![0];
+        await act(async () => {
+            actionProps.onClick?.({ stopPropagation: jest.fn() } as any);
+        });
+        await waitFor(() => {
+            expect(mockRemarkComponent).toHaveBeenCalledWith(expect.objectContaining({ actionName: 'Resolve' }));
+        });
+        const remarkCall = mockRemarkComponent.mock.calls.find(([props]) => props.actionName === 'Resolve');
+        expect(remarkCall).toBeDefined();
+        remarkCall![0].onSubmit('remark');
+
+        await waitFor(() => {
+            expect(mockUpdateTicket).toHaveBeenCalled();
+        });
+
+        expect(mockUpdateTicket).toHaveBeenCalledWith('INC-100', expect.objectContaining({
+            status: { statusId: '2' },
+            remark: 'remark',
+            updatedBy: 'agent.user',
+        }));
+        expect(searchCurrentTicketsPaginatedApi).toHaveBeenCalledWith('INC-100');
+        expect(mockRemarkComponent).toHaveBeenCalledWith(expect.objectContaining({ actionName: 'Resolve' }));
+    });
+});

--- a/ui/src/components/AllTickets/__tests__/ViewTicket.test.tsx
+++ b/ui/src/components/AllTickets/__tests__/ViewTicket.test.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import ViewTicket from '../ViewTicket';
+
+const mockUseApi = jest.fn();
+jest.mock('../../../hooks/useApi', () => ({
+    useApi: (...args: any[]) => mockUseApi(...args),
+}));
+
+const mockGetTicket = jest.fn(() => Promise.resolve({ data: {} }));
+const mockUpdateTicket = jest.fn(() => Promise.resolve({}));
+jest.mock('../../../services/TicketService', () => ({
+    getTicket: (...args: any[]) => mockGetTicket(...args),
+    updateTicket: (...args: any[]) => mockUpdateTicket(...args),
+}));
+
+const mockGetCurrentUserDetails = jest.fn(() => ({ username: 'agent.user' }));
+jest.mock('../../../config/config', () => ({
+    getCurrentUserDetails: (...args: any[]) => mockGetCurrentUserDetails(...args),
+}));
+
+const mockGetPriorities = jest.fn(() => Promise.resolve({ data: [] }));
+const mockGetSeverities = jest.fn(() => Promise.resolve({ data: [] }));
+jest.mock('../../../services/PriorityService', () => ({
+    getPriorities: (...args: any[]) => mockGetPriorities(...args),
+}));
+jest.mock('../../../services/SeverityService', () => ({
+    getSeverities: (...args: any[]) => mockGetSeverities(...args),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+    useNavigate: () => mockNavigate,
+}));
+
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockTicketView = jest.fn(() => <div data-testid="ticket-view" />);
+jest.mock('../../TicketView/TicketView', () => ({
+    __esModule: true,
+    default: (props: any) => mockTicketView(props),
+}));
+
+const flushPromises = async () => {
+    await act(async () => {
+        await Promise.resolve();
+    });
+};
+
+describe('ViewTicket', () => {
+    let consoleErrorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseApi.mockReset();
+        mockGetPriorities.mockResolvedValue({ data: [] });
+        mockGetSeverities.mockResolvedValue({ data: [] });
+        consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore();
+    });
+
+    it('returns null when not open', () => {
+        mockUseApi.mockReturnValue({ data: null, apiHandler: jest.fn() });
+
+        const { container } = render(
+            <ViewTicket ticketId="INC-1" open={false} onClose={jest.fn()} />
+        );
+
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('fetches ticket data when opened with ticketId', async () => {
+        const ticketData = {
+            subject: 'Printer not working',
+            description: 'Printer is jammed',
+            priority: 'P1',
+            severity: 'S1',
+            recommendedSeverity: 'S2',
+            requestorName: 'John Doe',
+            reportedDate: '2024-01-01T00:00:00Z',
+            updatedBy: 'agent.user',
+            lastModified: '2024-01-02T00:00:00Z',
+        };
+
+        const getTicketHandler = jest.fn((callback: any) => callback());
+        const updateTicketHandler = jest.fn();
+        const primaryReturn = { data: ticketData, apiHandler: getTicketHandler };
+        const secondaryReturn = { data: null, apiHandler: updateTicketHandler };
+        let callCount = 0;
+        mockUseApi.mockImplementation(() => (callCount++ % 2 === 0 ? primaryReturn : secondaryReturn));
+
+        render(
+            <ViewTicket
+                ticketId="INC-1"
+                open
+                onClose={jest.fn()}
+                focusRecommendSeverity
+                onRecommendSeverityFocusHandled={jest.fn()}
+            />
+        );
+
+        await flushPromises();
+        await flushPromises();
+
+        await waitFor(() => {
+            expect(mockGetTicket).toHaveBeenCalledWith('INC-1');
+        });
+        await waitFor(() => {
+            expect(mockGetPriorities).toHaveBeenCalled();
+        });
+        await waitFor(() => {
+            expect(mockGetSeverities).toHaveBeenCalled();
+        });
+        await flushPromises();
+        expect(mockTicketView).toHaveBeenCalledWith(expect.objectContaining({
+            ticketId: 'INC-1',
+            focusRecommendSeverity: true,
+        }));
+    });
+
+    it('calls onClose when close button clicked', () => {
+        const getTicketHandler = jest.fn();
+        const updateTicketHandler = jest.fn();
+        const primaryReturn = { data: {}, apiHandler: getTicketHandler };
+        const secondaryReturn = { data: null, apiHandler: updateTicketHandler };
+        let callCount = 0;
+        mockUseApi.mockImplementation(() => (callCount++ % 2 === 0 ? primaryReturn : secondaryReturn));
+
+        const onClose = jest.fn();
+
+        render(<ViewTicket ticketId="INC-1" open onClose={onClose} />);
+
+        const closeButton = screen.getAllByRole('button')[0];
+        fireEvent.click(closeButton);
+
+        expect(onClose).toHaveBeenCalled();
+    });
+
+    it('navigates to ticket view when visibility icon clicked', () => {
+        const getTicketHandler = jest.fn();
+        const updateTicketHandler = jest.fn();
+        const primaryReturn = { data: { id: 'INC-1' }, apiHandler: getTicketHandler };
+        const secondaryReturn = { data: null, apiHandler: updateTicketHandler };
+        let callCount = 0;
+        mockUseApi.mockImplementation(() => (callCount++ % 2 === 0 ? primaryReturn : secondaryReturn));
+
+        render(<ViewTicket ticketId="INC-1" open onClose={jest.fn()} />);
+
+        const buttons = screen.getAllByRole('button');
+        const viewButton = buttons[1];
+        fireEvent.click(viewButton);
+
+        expect(mockNavigate).toHaveBeenCalledWith('/tickets/INC-1');
+    });
+});


### PR DESCRIPTION
## Summary
- add testing-library suites for AdvancedAssignmentOptionsDialog interactions and assignment flows
- cover RequestorDetails clipboard behavior
- exercise TicketCard action handling and ViewTicket data loading/navigation

## Testing
- CI=true npm test -- --runTestsByPath src/components/AllTickets/__tests__/AdvancedAssignmentOptionsDialog.test.tsx src/components/AllTickets/__tests__/RequestorDetails.test.tsx src/components/AllTickets/__tests__/TicketCard.test.tsx src/components/AllTickets/__tests__/ViewTicket.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e4ee382f388332a99819f772dfc34d