### PR TITLE
Add role selection menu to RoleDetails page

### DIFF
--- a/ui/src/components/Title.tsx
+++ b/ui/src/components/Title.tsx
@@ -5,15 +5,22 @@ interface TitleProps {
     text?: string;
     textKey?: string;
     rightContent?: React.ReactNode;
+    onClick?: React.MouseEventHandler<HTMLHeadingElement>;
 }
 
-const Title: React.FC<TitleProps> = ({ text, textKey, rightContent }) => {
+const Title: React.FC<TitleProps> = ({ text, textKey, rightContent, onClick }) => {
     const { t } = useTranslation();
     const label = textKey ? t(textKey) : t(text ?? "");
     return (
         <>
             <div className="d-flex justify-content-between align-items-center mb-4 pb-2">
-                <h2 className="m-0">{label}</h2>
+                <h2
+                    className="m-0"
+                    onClick={onClick}
+                    style={onClick ? { cursor: 'pointer' } : undefined}
+                >
+                    {label}
+                </h2>
                 <div>{rightContent}</div>
             </div>
             {/* <div className="position-relative">


### PR DESCRIPTION
## Summary
- make the RoleDetails title clickable and show a menu of available roles
- load the selected role when a different entry is chosen from the menu
- update tests to cover the new role selection flow

## Testing
- CI=true npm test -- RoleDetails

------
https://chatgpt.com/codex/tasks/task_e_68e4f13ad600833293104f77353b967d