### PR TITLE
Add tests for CustomFieldset and PaginationControls

### DIFF
--- a/ui/src/components/__tests__/CustomFieldset.test.tsx
+++ b/ui/src/components/__tests__/CustomFieldset.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CustomFieldset from '../CustomFieldset';
+import { ThemeModeContext } from '../../context/ThemeContext';
+import { renderWithTheme } from '../../test/testUtils';
+
+type ThemeContextValue = React.ContextType<typeof ThemeModeContext>;
+
+const createContextValue = (overrides?: Partial<ThemeContextValue>): ThemeContextValue => ({
+  mode: 'light',
+  toggle: () => undefined,
+  layout: 1,
+  toggleLayout: () => undefined,
+  ...overrides,
+});
+
+const renderFieldset = (
+  element: React.ReactElement,
+  contextOverrides?: Partial<ThemeContextValue>,
+) =>
+  renderWithTheme(
+    <ThemeModeContext.Provider value={createContextValue(contextOverrides)}>
+      {element}
+    </ThemeModeContext.Provider>,
+  );
+
+describe('CustomFieldset', () => {
+  it('renders the underlined variant and toggles collapse from the header', async () => {
+    renderFieldset(
+      <CustomFieldset title="Details" variant="underlined">
+        <div>Underlined content</div>
+      </CustomFieldset>,
+    );
+
+    expect(screen.getByText('Underlined content')).toBeInTheDocument();
+
+    const header = screen.getByText('Details').closest('div');
+    expect(header).not.toBeNull();
+
+    await userEvent.click(header!);
+    expect(screen.queryByText('Underlined content')).not.toBeInTheDocument();
+
+    await userEvent.click(header!);
+    expect(screen.getByText('Underlined content')).toBeInTheDocument();
+  });
+
+  it('renders the bordered variant with an action element and collapses via the legend', async () => {
+    const { container } = renderFieldset(
+      <CustomFieldset
+        title="Settings"
+        variant="bordered"
+        actionElement={<button type="button">Action</button>}
+      >
+        <div>Bordered content</div>
+      </CustomFieldset>,
+    );
+
+    expect(container.querySelector('fieldset')).toBeInTheDocument();
+    expect(screen.getByText('Bordered content')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Action' })).toBeInTheDocument();
+
+    const legend = container.querySelector('legend');
+    expect(legend).not.toBeNull();
+
+    await userEvent.click(legend!);
+    expect(screen.queryByText('Bordered content')).not.toBeInTheDocument();
+
+    await userEvent.click(legend!);
+    expect(screen.getByText('Bordered content')).toBeInTheDocument();
+  });
+
+  it('updates the rendered variant when the prop changes', async () => {
+    const { container, rerender } = renderFieldset(
+      <CustomFieldset title="Dynamic" variant="bordered">
+        <div>Dynamic content</div>
+      </CustomFieldset>,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('fieldset')).toBeInTheDocument();
+    });
+    expect(container.querySelector('.form-container')).toBeNull();
+
+    rerender(
+      <ThemeModeContext.Provider value={createContextValue()}>
+        <CustomFieldset title="Dynamic" variant="basic">
+          <div>Dynamic content</div>
+        </CustomFieldset>
+      </ThemeModeContext.Provider>,
+    );
+
+    await waitFor(() => {
+      const basicFieldset = container.querySelector('fieldset');
+      expect(basicFieldset).toBeInTheDocument();
+      expect(basicFieldset?.className).toContain('px-3');
+    });
+
+    rerender(
+      <ThemeModeContext.Provider value={createContextValue()}>
+        <CustomFieldset title="Dynamic" variant="underlined">
+          <div>Dynamic content</div>
+        </CustomFieldset>
+      </ThemeModeContext.Provider>,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('.form-container')).toBeInTheDocument();
+    });
+    expect(container.querySelector('fieldset')).toBeNull();
+  });
+});

--- a/ui/src/components/__tests__/PaginationControls.test.tsx
+++ b/ui/src/components/__tests__/PaginationControls.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PaginationControls from '../PaginationControls';
+import { renderWithTheme } from '../../test/testUtils';
+
+jest.mock('../../i18n', () => ({}), { virtual: true });
+jest.mock('i18next', () => {
+  const fake = {
+    use: () => fake,
+    init: () => undefined,
+  };
+  return fake;
+}, { virtual: true });
+jest.mock('jwt-decode', () => ({
+  jwtDecode: () => ({}),
+}), { virtual: true });
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => `t:${key}`,
+  }),
+}), { virtual: true });
+
+describe('PaginationControls', () => {
+  it('renders pagination with the provided class name', () => {
+    const { container } = renderWithTheme(
+      <PaginationControls page={1} totalPages={3} onChange={jest.fn()} className="custom-class" />,
+    );
+
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper).toHaveClass('d-flex', 'align-items-center');
+    expect(wrapper.className).toContain('custom-class');
+  });
+
+  it('shows the page size controls when pageSize and handler are provided', () => {
+    renderWithTheme(
+      <PaginationControls
+        page={2}
+        totalPages={5}
+        onChange={jest.fn()}
+        pageSize={10}
+        onPageSizeChange={jest.fn()}
+        pageSizeLabel="items"
+      />,
+    );
+
+    expect(screen.getByText('items')).toBeInTheDocument();
+    expect(screen.getByRole('spinbutton')).toHaveValue(10);
+  });
+
+  it('calls onPageSizeChange when the input value changes to a valid number', () => {
+    const onPageSizeChange = jest.fn();
+
+    renderWithTheme(
+      <PaginationControls
+        page={1}
+        totalPages={2}
+        onChange={jest.fn()}
+        pageSize={15}
+        onPageSizeChange={onPageSizeChange}
+      />,
+    );
+
+    const input = screen.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '25' } });
+
+    expect(onPageSizeChange).toHaveBeenCalledWith(25);
+  });
+
+  it('does not call onPageSizeChange for invalid page size values', () => {
+    const onPageSizeChange = jest.fn();
+
+    renderWithTheme(
+      <PaginationControls
+        page={1}
+        totalPages={2}
+        onChange={jest.fn()}
+        pageSize={10}
+        onPageSizeChange={onPageSizeChange}
+      />,
+    );
+
+    const input = screen.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '0' } });
+
+    expect(onPageSizeChange).not.toHaveBeenCalled();
+  });
+
+  it('uses the increment and decrement buttons to adjust the page size', async () => {
+    const onPageSizeChange = jest.fn();
+
+    renderWithTheme(
+      <PaginationControls
+        page={1}
+        totalPages={2}
+        onChange={jest.fn()}
+        pageSize={5}
+        onPageSizeChange={onPageSizeChange}
+      />,
+    );
+
+    const label = screen.getByText('/ page');
+    const controlsContainer = label.closest('div');
+    expect(controlsContainer).not.toBeNull();
+
+    const buttons = controlsContainer!.querySelectorAll('button');
+    expect(buttons).toHaveLength(2);
+
+    await userEvent.click(buttons[0]);
+    expect(onPageSizeChange).toHaveBeenCalledWith(4);
+
+    await userEvent.click(buttons[1]);
+    expect(onPageSizeChange).toHaveBeenCalledWith(6);
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for CustomFieldset collapse interactions and variant changes
- add PaginationControls tests covering page size input validation and increment/decrement buttons

## Testing
- CI=true npm test -- CustomFieldset.test.tsx
- CI=true npm test -- PaginationControls.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e4f730e2c883328c3a4680e912a3aa