### PR TITLE
Add UI tests for assignment history, comments, and feedback components

### DIFF
--- a/ui/src/components/AssignmentHistory/__tests__/AssignmentHistory.test.tsx
+++ b/ui/src/components/AssignmentHistory/__tests__/AssignmentHistory.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AssignmentHistory from '../index';
+import { renderWithTheme } from '../../../test/testUtils';
+
+const mockUseApi = jest.fn();
+const mockGetAssignmentHistory = jest.fn();
+
+jest.mock('../../../hooks/useApi', () => ({
+  useApi: () => mockUseApi(),
+}));
+
+jest.mock('../../../services/AssignmentHistoryService', () => ({
+  getAssignmentHistory: (...args: unknown[]) => mockGetAssignmentHistory(...args),
+}));
+
+jest.mock('@mui/lab', () => ({
+  Timeline: ({ children }: any) => <div data-testid="timeline">{children}</div>,
+  TimelineItem: ({ children }: any) => <div data-testid="timeline-item">{children}</div>,
+  TimelineSeparator: ({ children }: any) => <div>{children}</div>,
+  TimelineDot: ({ children }: any) => <div>{children}</div>,
+  TimelineConnector: ({ children }: any) => <div>{children}</div>,
+  TimelineContent: ({ children }: any) => <div>{children}</div>,
+}), { virtual: true });
+
+jest.mock('../../UI/GenericTable', () => ({
+  __esModule: true,
+  default: ({ dataSource, columns, rowClassName }: any) => (
+    <table data-testid="generic-table">
+      <tbody>
+        {dataSource.map((row: any, index: number) => (
+          <tr key={row.id} data-rowclass={rowClassName ? rowClassName(row, index) : ''}>
+            {columns.map((column: any) => {
+              const value = column.dataIndex ? row[column.dataIndex] : undefined;
+              return (
+                <td key={column.key || column.dataIndex}>
+                  {column.render ? column.render(value, row) : value}
+                </td>
+              );
+            })}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  ),
+}));
+
+jest.mock('../../UI/ViewToggle', () => ({
+  __esModule: true,
+  default: ({ value, onChange, options }: any) => (
+    <div>
+      {options.map((option: any) => (
+        <button
+          key={option.value}
+          type="button"
+          onClick={() => onChange(option.value)}
+        >
+          {option.value}
+        </button>
+      ))}
+      <span data-testid="current-view">{value}</span>
+    </div>
+  ),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('AssignmentHistory', () => {
+  const mockHistory = [
+    {
+      id: '1',
+      assignedBy: 'Manager A',
+      assignedTo: 'Agent A',
+      timestamp: '2023-01-01T10:00:00.000Z',
+      remark: 'Oldest remark',
+    },
+    {
+      id: '2',
+      assignedBy: 'Manager B',
+      assignedTo: 'Agent B',
+      timestamp: '2023-02-01T12:00:00.000Z',
+      remark: 'Latest remark',
+    },
+  ];
+
+  let apiHandlerMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseApi.mockReset();
+
+    apiHandlerMock = jest.fn((fn: () => Promise<unknown>) => fn());
+
+    mockGetAssignmentHistory.mockResolvedValue(mockHistory);
+
+    mockUseApi.mockReturnValue({
+      data: mockHistory,
+      apiHandler: apiHandlerMock,
+      success: true,
+      pending: false,
+      error: null,
+    });
+  });
+
+  it('renders table view with sorted history and triggers API call', async () => {
+    renderWithTheme(<AssignmentHistory ticketId="INC-1" />);
+
+    await waitFor(() => expect(apiHandlerMock).toHaveBeenCalled());
+
+    const handler = apiHandlerMock.mock.calls[0][0];
+    await handler();
+
+    expect(mockGetAssignmentHistory).toHaveBeenCalledWith('INC-1');
+
+    const rows = screen.getAllByRole('row');
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveTextContent('Agent B');
+    expect(rows[0]).toHaveAttribute('data-rowclass', 'latest-row');
+  });
+
+  it('switches to timeline view when selected', async () => {
+    renderWithTheme(<AssignmentHistory ticketId="INC-2" />);
+
+    const timelineButton = screen.getByRole('button', { name: 'timeline' });
+    await userEvent.click(timelineButton);
+
+    expect(screen.getByTestId('current-view')).toHaveTextContent('timeline');
+    expect(screen.queryByTestId('generic-table')).not.toBeInTheDocument();
+    expect(screen.getByText('Latest remark')).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/Comments/__tests__/CommentsSection.test.tsx
+++ b/ui/src/components/Comments/__tests__/CommentsSection.test.tsx
@@ -1,0 +1,147 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CommentsSection from '../CommentsSection';
+import { renderWithTheme } from '../../../test/testUtils';
+
+const mockUseApi = jest.fn();
+
+jest.mock('../../../hooks/useApi', () => ({
+  useApi: () => mockUseApi(),
+}));
+
+const mockGetComments = jest.fn();
+const mockAddComment = jest.fn();
+const mockUpdateComment = jest.fn();
+const mockDeleteComment = jest.fn();
+
+jest.mock('../../../services/TicketService', () => ({
+  getComments: (...args: unknown[]) => mockGetComments(...args),
+  addComment: (...args: unknown[]) => mockAddComment(...args),
+  updateComment: (...args: unknown[]) => mockUpdateComment(...args),
+  deleteComment: (...args: unknown[]) => mockDeleteComment(...args),
+}));
+
+jest.mock('../../UI/IconButton/CustomIconButton', () => ({
+  __esModule: true,
+  default: ({ icon, onClick, color }: any) => (
+    <button type="button" data-testid={`icon-${icon}`} data-color={color} onClick={onClick}>
+      {icon}
+    </button>
+  ),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('CommentsSection', () => {
+  const ticketId = 'INC-123';
+  const buildComments = (count: number) =>
+    Array.from({ length: count }, (_, index) => ({
+      id: `${index + 1}`,
+      comment: `Comment ${index + 1}`,
+      createdAt: new Date(2024, 0, index + 1).toISOString(),
+    }));
+
+  let commentsApiHandler: jest.Mock;
+  let addCommentApiHandler: jest.Mock;
+  let updateCommentApiHandler: jest.Mock;
+  let deleteCommentApiHandler: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseApi.mockReset();
+
+    const createHandler = () => jest.fn((fn: () => Promise<unknown>) => Promise.resolve(fn()));
+    commentsApiHandler = createHandler();
+    addCommentApiHandler = createHandler();
+    updateCommentApiHandler = createHandler();
+    deleteCommentApiHandler = createHandler();
+  });
+
+  const setupUseApiMocks = () => {
+    const responses = [
+      { apiHandler: commentsApiHandler },
+      { apiHandler: addCommentApiHandler },
+      { apiHandler: updateCommentApiHandler },
+      { apiHandler: deleteCommentApiHandler },
+    ];
+    let callIndex = 0;
+    mockUseApi.mockImplementation(() => responses[(callIndex++) % responses.length]);
+  };
+
+  it('loads initial comments and allows showing more', async () => {
+    const comments = buildComments(6);
+    mockGetComments.mockResolvedValue(comments);
+    setupUseApiMocks();
+
+    renderWithTheme(<CommentsSection ticketId={ticketId} />);
+
+    await waitFor(() => expect(commentsApiHandler).toHaveBeenCalledTimes(1));
+    await screen.findByText('Comment 1');
+
+    expect(mockGetComments).toHaveBeenCalledWith(ticketId);
+    expect(screen.queryByText('Comment 6')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show more' })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Show more' }));
+
+    await waitFor(() => expect(commentsApiHandler).toHaveBeenCalledTimes(2));
+    await screen.findByText('Comment 6');
+    expect(screen.queryByRole('button', { name: 'Show more' })).not.toBeInTheDocument();
+  });
+
+  it('submits a new comment and reloads the list', async () => {
+    const comments = buildComments(2);
+    mockGetComments.mockResolvedValue(comments);
+    mockAddComment.mockResolvedValue({});
+    setupUseApiMocks();
+
+    renderWithTheme(<CommentsSection ticketId={ticketId} />);
+
+    const textarea = await screen.findByRole('textbox');
+    await userEvent.type(textarea, 'New comment');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Post' }));
+
+    await waitFor(() => expect(addCommentApiHandler).toHaveBeenCalledTimes(1));
+    expect(mockAddComment).toHaveBeenCalledWith(ticketId, 'New comment');
+    await waitFor(() => expect(commentsApiHandler).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(textarea).toHaveValue(''));
+  });
+
+  it('allows editing and deleting a comment', async () => {
+    const comments = buildComments(2);
+    mockGetComments.mockResolvedValue(comments);
+    mockUpdateComment.mockResolvedValue({});
+    mockDeleteComment.mockResolvedValue({});
+    setupUseApiMocks();
+
+    renderWithTheme(<CommentsSection ticketId={ticketId} />);
+
+    await screen.findByText('Comment 1');
+
+    const editButtons = screen.getAllByTestId('icon-Edit');
+    await userEvent.click(editButtons[0]);
+
+    const editTextarea = screen.getByDisplayValue('Comment 1');
+    await userEvent.clear(editTextarea);
+    await userEvent.type(editTextarea, 'Updated comment');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(updateCommentApiHandler).toHaveBeenCalledTimes(1));
+    expect(mockUpdateComment).toHaveBeenCalledWith('1', 'Updated comment');
+    await waitFor(() => expect(commentsApiHandler).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument());
+
+    const deleteButtons = screen.getAllByTestId('icon-Delete');
+    await userEvent.click(deleteButtons[0]);
+
+    await waitFor(() => expect(deleteCommentApiHandler).toHaveBeenCalledTimes(1));
+    expect(mockDeleteComment).toHaveBeenCalledWith('1');
+    await waitFor(() => expect(commentsApiHandler).toHaveBeenCalledTimes(3));
+  });
+});

--- a/ui/src/components/Feedback/__tests__/FeedbackModal.test.tsx
+++ b/ui/src/components/Feedback/__tests__/FeedbackModal.test.tsx
@@ -1,0 +1,143 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithTheme } from '../../../test/testUtils';
+
+const mockUseApi = jest.fn();
+const mockShowMessage = jest.fn();
+const mockStarRating = jest.fn((props: any) => (
+  <button
+    type="button"
+    data-testid={`rating-${props.label}`}
+    disabled={props.readOnly}
+    onClick={() => props.onChange?.(4)}
+  >
+    {props.label}:{props.value}
+  </button>
+));
+
+jest.mock('../../../hooks/useApi', () => ({
+  useApi: () => mockUseApi(),
+}));
+
+jest.mock('../../../context/SnackbarContext', () => ({
+  useSnackbar: () => ({
+    showMessage: mockShowMessage,
+  }),
+}));
+
+const mockSubmitFeedback = jest.fn();
+const mockGetFeedback = jest.fn();
+
+jest.mock('../../../services/FeedbackService', () => ({
+  submitFeedback: (...args: unknown[]) => mockSubmitFeedback(...args),
+  getFeedback: (...args: unknown[]) => mockGetFeedback(...args),
+  getFeedbackForm: jest.fn(),
+}));
+
+jest.mock('../StarRating', () => ({
+  __esModule: true,
+  default: (props: any) => mockStarRating(props),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const FeedbackModal = require('../FeedbackModal').default;
+
+describe('FeedbackModal', () => {
+  const ticketId = 'INC-9';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseApi.mockReset();
+    mockStarRating.mockReset();
+  });
+
+  it('submits feedback with updated values', async () => {
+    const apiHandlerMock = jest.fn((fn: () => Promise<unknown>) => fn());
+    mockUseApi.mockReturnValue({
+      data: null,
+      success: false,
+      pending: false,
+      error: null,
+      apiHandler: apiHandlerMock,
+    });
+
+    mockSubmitFeedback.mockResolvedValue({});
+
+    const onClose = jest.fn();
+
+    renderWithTheme(
+      <FeedbackModal open ticketId={ticketId} onClose={onClose} />,
+    );
+
+    const commentField = screen.getByLabelText('Additional Comments/Feedback');
+    await userEvent.type(commentField, 'Great support');
+
+    await waitFor(() => expect(mockStarRating).toHaveBeenCalled());
+    const overallCall = mockStarRating.mock.calls.find(([props]) => props.label === 'Overall Satisfaction');
+    overallCall?.[0].onChange?.(4);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => expect(mockSubmitFeedback).toHaveBeenCalledTimes(1));
+    expect(mockSubmitFeedback).toHaveBeenCalledWith(ticketId, {
+      overallSatisfaction: 4,
+      resolutionEffectiveness: 0,
+      communicationSupport: 0,
+      timeliness: 0,
+      comments: 'Great support',
+    });
+
+    await waitFor(() => expect(mockShowMessage).toHaveBeenCalledWith('Feedback submitted', 'success'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows provided feedback in view mode', async () => {
+    const existingFeedback = {
+      overallSatisfaction: 5,
+      resolutionEffectiveness: 4,
+      communicationSupport: 3,
+      timeliness: 2,
+      comments: 'Resolved quickly',
+    };
+
+    const apiHandlerMock = jest.fn((fn: () => Promise<unknown>) => fn());
+    mockUseApi.mockReturnValue({
+      data: existingFeedback,
+      success: true,
+      pending: false,
+      error: null,
+      apiHandler: apiHandlerMock,
+    });
+
+    mockGetFeedback.mockResolvedValue(existingFeedback);
+
+    const onClose = jest.fn();
+
+    renderWithTheme(
+      <FeedbackModal open ticketId={ticketId} onClose={onClose} feedbackStatus="PROVIDED" />,
+    );
+
+    await waitFor(() => expect(apiHandlerMock).toHaveBeenCalled());
+    const handler = apiHandlerMock.mock.calls[0][0];
+    await handler();
+    expect(mockGetFeedback).toHaveBeenCalledWith(ticketId);
+
+    await waitFor(() => expect(mockStarRating).toHaveBeenCalled());
+
+    const closeButton = await screen.findByRole('button', { name: 'Close' });
+    expect(closeButton).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Submit' })).not.toBeInTheDocument();
+    const commentField = screen.getByLabelText('Additional Comments/Feedback');
+    expect(commentField).toBeDisabled();
+
+    const hasMatchingCall = mockStarRating.mock.calls.some(([props]) =>
+      props.label === 'Overall Satisfaction' && props.value === 5 && props.readOnly === true,
+    );
+    expect(hasMatchingCall).toBe(true);
+  });
+});

--- a/ui/src/components/Feedback/__tests__/StarRating.test.tsx
+++ b/ui/src/components/Feedback/__tests__/StarRating.test.tsx
@@ -1,0 +1,60 @@
+import { renderWithTheme } from '../../../test/testUtils';
+
+const mockRating = jest.fn(({ readOnly, onChange }: any) => (
+  <button
+    type="button"
+    data-testid="mock-rating"
+    disabled={readOnly}
+    onClick={() => onChange?.({}, 3)}
+  >
+    rating
+  </button>
+));
+
+jest.mock('@mui/material', () => {
+  const actual = jest.requireActual('@mui/material');
+  return {
+    ...actual,
+    Rating: (props: any) => mockRating(props),
+  };
+});
+
+const StarRating = require('../StarRating').default;
+
+describe('StarRating', () => {
+  beforeEach(() => {
+    mockRating.mockClear();
+  });
+
+  it('displays the provided label and rating description', () => {
+    const { getByText } = renderWithTheme(
+      <StarRating label="Timeliness" value={4} readOnly />,
+    );
+
+    expect(getByText('Timeliness')).toBeInTheDocument();
+    expect(getByText('Good')).toBeInTheDocument();
+  });
+
+  it('calls onChange when a new rating is selected', () => {
+    const onChange = jest.fn();
+    renderWithTheme(<StarRating label="Support" value={0} onChange={onChange} />);
+
+    expect(mockRating).toHaveBeenCalled();
+    const ratingProps = mockRating.mock.calls[0][0];
+    ratingProps.onChange?.({}, 3);
+
+    expect(onChange).toHaveBeenCalledWith(3);
+  });
+
+  it('does not call onChange when readOnly is true', () => {
+    const onChange = jest.fn();
+    renderWithTheme(<StarRating label="Support" value={3} onChange={onChange} readOnly />);
+
+    expect(mockRating).toHaveBeenCalled();
+    const ratingProps = mockRating.mock.calls[0][0];
+    expect(ratingProps.readOnly).toBe(true);
+    ratingProps.onChange?.({}, 4);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add assignment history tests covering API loading, table rendering, and view toggling【F:ui/src/components/AssignmentHistory/__tests__/AssignmentHistory.test.tsx†L1-L136】
- exercise comments section flows for pagination, posting, editing, and deleting notes via mocked API handlers【F:ui/src/components/Comments/__tests__/CommentsSection.test.tsx†L1-L146】
- verify feedback modal submission/view states and star rating callbacks with dedicated unit tests【F:ui/src/components/Feedback/__tests__/FeedbackModal.test.tsx†L1-L142】【F:ui/src/components/Feedback/__tests__/StarRating.test.tsx†L1-L60】

## Testing
- npm test -- --runTestsByPath src/components/AssignmentHistory/__tests__/AssignmentHistory.test.tsx src/components/Comments/__tests__/CommentsSection.test.tsx src/components/Feedback/__tests__/FeedbackModal.test.tsx src/components/Feedback/__tests__/StarRating.test.tsx --watchAll=false【6b97a6†L1-L25】

------
https://chatgpt.com/codex/tasks/task_e_68e55211c20c83329f90c0c78711d1ad