### PR TITLE
Add layout UI component tests

### DIFF
--- a/ui/src/components/Layout/__tests__/Header.test.tsx
+++ b/ui/src/components/Layout/__tests__/Header.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Header from '../Header';
+import { ThemeModeContext } from '../../../context/ThemeContext';
+import { LanguageContext } from '../../../context/LanguageContext';
+import { DevModeContext } from '../../../context/DevModeContext';
+import { renderWithTheme, createTestTheme } from '../../../test/testUtils';
+
+jest.mock('../UserMenu', () => ({ open }: { open: boolean }) => (
+  <div data-testid="user-menu" data-open={open} />
+));
+
+jest.mock('../../Notifications/NotificationBell', () => ({ iconColor }: { iconColor: string }) => (
+  <div data-testid="notification-bell" data-icon-color={iconColor} />
+));
+
+jest.mock('../../../config/config', () => ({
+  getCurrentUserDetails: jest.fn(() => ({
+    name: 'John Doe',
+    username: 'johnd',
+    userId: 'user-1',
+  })),
+}));
+
+describe('Header', () => {
+  const toggleSidebar = jest.fn();
+  const toggleTheme = jest.fn();
+  const toggleLanguage = jest.fn();
+  const toggleDevMode = jest.fn();
+  const toggleJwtBypass = jest.fn();
+  const toggleLayout = jest.fn();
+
+  const renderHeader = ({
+    mode = 'light',
+    devMode = false,
+    jwtBypass = false,
+    collapsed = false,
+  }: {
+    mode?: 'light' | 'dark';
+    devMode?: boolean;
+    jwtBypass?: boolean;
+    collapsed?: boolean;
+  } = {}) => {
+    const theme = createTestTheme({ palette: { mode } });
+
+    return renderWithTheme(
+      <ThemeModeContext.Provider value={{ mode, toggle: toggleTheme, layout: 1, toggleLayout }}>
+        <LanguageContext.Provider value={{ language: 'en', toggleLanguage }}>
+          <DevModeContext.Provider
+            value={{
+              devMode,
+              toggleDevMode,
+              jwtBypass,
+              toggleJwtBypass,
+              setJwtBypass: jest.fn(),
+            }}
+          >
+            <Header collapsed={collapsed} toggleSidebar={toggleSidebar} />
+          </DevModeContext.Provider>
+        </LanguageContext.Provider>
+      </ThemeModeContext.Provider>,
+      { theme },
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('opens the user menu from the avatar and toggles the sidebar button', async () => {
+    renderHeader({ collapsed: true });
+
+    const menuButton = screen.getByTestId('MenuIcon').closest('button');
+    expect(menuButton).toBeInTheDocument();
+
+    await userEvent.click(menuButton!);
+    expect(toggleSidebar).toHaveBeenCalledTimes(1);
+
+    const avatar = screen.getByTestId('PersonIcon').closest('div');
+    expect(avatar).not.toBeNull();
+
+    await userEvent.click(avatar!);
+    expect(screen.getByTestId('user-menu')).toHaveAttribute('data-open', 'true');
+  });
+
+  it('triggers theme, language and dev mode toggles', async () => {
+    renderHeader({ devMode: true, jwtBypass: true });
+
+    const darkModeButton = screen.getByTestId('DarkModeIcon').closest('button');
+    const translateButton = screen.getByTestId('TranslateIcon').closest('button');
+    const devModeButton = screen.getByTestId('CodeIcon').closest('button');
+    const jwtBypassButton = screen.getByTestId('LockOpenIcon').closest('button');
+    const layoutButton = screen.getByRole('button', { name: '1' });
+
+    await userEvent.click(darkModeButton!);
+    await userEvent.click(translateButton!);
+    await userEvent.click(devModeButton!);
+    await userEvent.click(jwtBypassButton!);
+    await userEvent.click(layoutButton);
+
+    expect(toggleTheme).toHaveBeenCalledTimes(1);
+    expect(toggleLanguage).toHaveBeenCalledTimes(1);
+    expect(toggleDevMode).toHaveBeenCalledTimes(1);
+    expect(toggleJwtBypass).toHaveBeenCalledTimes(1);
+    expect(toggleLayout).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders appropriate logo for light and dark themes', () => {
+    const { unmount } = renderHeader({ mode: 'light' });
+
+    expect(screen.getByRole('img')).toHaveAttribute('src', '/logo.png');
+
+    unmount();
+
+    renderWithTheme(
+      <ThemeModeContext.Provider value={{ mode: 'dark', toggle: toggleTheme, layout: 1, toggleLayout }}>
+        <LanguageContext.Provider value={{ language: 'en', toggleLanguage }}>
+          <DevModeContext.Provider
+            value={{
+              devMode: false,
+              toggleDevMode,
+              jwtBypass: false,
+              toggleJwtBypass,
+              setJwtBypass: jest.fn(),
+            }}
+          >
+            <Header collapsed={false} toggleSidebar={toggleSidebar} />
+          </DevModeContext.Provider>
+        </LanguageContext.Provider>
+      </ThemeModeContext.Provider>,
+      { theme: createTestTheme({ palette: { mode: 'dark' } }) },
+    );
+
+    const logo = screen.getByRole('img');
+    expect(logo).toHaveAttribute('src', '/fciLogo.png');
+  });
+});

--- a/ui/src/components/Layout/__tests__/Sidebar.test.tsx
+++ b/ui/src/components/Layout/__tests__/Sidebar.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import Sidebar from '../Sidebar';
+import { renderWithTheme } from '../../../test/testUtils';
+import * as permissions from '../../../utils/permissions';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (value: string) => `t:${value}` }),
+}));
+
+describe('Sidebar', () => {
+  const checkSidebarAccessSpy = jest.spyOn(permissions, 'checkSidebarAccess');
+
+  beforeEach(() => {
+    checkSidebarAccessSpy.mockReset();
+  });
+
+  afterAll(() => {
+    checkSidebarAccessSpy.mockRestore();
+  });
+
+  it('renders translated menu items when expanded', () => {
+    checkSidebarAccessSpy.mockReturnValue(true);
+
+    renderWithTheme(<Sidebar collapsed={false} />);
+
+    expect(screen.getByText('t:All Tickets')).toBeInTheDocument();
+    expect(screen.getByText('t:Root Cause Analysis')).toBeInTheDocument();
+  });
+
+  it('hides labels when collapsed', () => {
+    checkSidebarAccessSpy.mockReturnValue(true);
+
+    renderWithTheme(<Sidebar collapsed />);
+
+    expect(screen.queryByText('t:All Tickets')).not.toBeInTheDocument();
+    expect(screen.queryByText('t:Raise Ticket')).not.toBeInTheDocument();
+  });
+
+  it('only renders menu items with sidebar access', () => {
+    checkSidebarAccessSpy.mockImplementation((key: string) => key === 'myTickets');
+
+    renderWithTheme(<Sidebar collapsed={false} />);
+
+    expect(screen.getByText('t:My Tickets')).toBeInTheDocument();
+    expect(screen.queryByText('t:All Tickets')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/components/Layout/__tests__/SidebarLayout.test.tsx
+++ b/ui/src/components/Layout/__tests__/SidebarLayout.test.tsx
@@ -1,0 +1,93 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SidebarLayout from '../SidebarLayout';
+import { renderWithTheme } from '../../../test/testUtils';
+import React from 'react';
+
+const mockUseMediaQuery = jest.fn();
+
+jest.mock('@mui/material', () => {
+  const actual = jest.requireActual('@mui/material');
+  return {
+    ...actual,
+    useMediaQuery: (query: unknown) => mockUseMediaQuery(query),
+  };
+});
+
+jest.mock('@mui/material/Drawer', () => ({ open, children }: { open: boolean; children: React.ReactNode }) => (
+  <div data-testid="drawer" data-open={open}>
+    {open ? children : null}
+  </div>
+));
+
+jest.mock('react-router-dom', () => ({
+  Outlet: () => <div data-testid="outlet">content</div>,
+}));
+
+jest.mock('../Header', () => ({
+  __esModule: true,
+  default: ({ collapsed, toggleSidebar }: { collapsed: boolean; toggleSidebar: () => void }) => (
+    <div data-testid="header" data-collapsed={collapsed}>
+      <button type="button" onClick={toggleSidebar}>
+        toggle
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock('../Sidebar', () => ({
+  __esModule: true,
+  default: ({ collapsed }: { collapsed: boolean }) => (
+    <div data-testid="sidebar" data-collapsed={collapsed} />
+  ),
+}));
+
+jest.mock('../../../hooks/useAuthGuard', () => ({
+  useAuthGuard: jest.fn(),
+}));
+
+jest.mock('../../../hooks/usePageTitle', () => ({
+  usePageTitle: jest.fn(),
+}));
+
+const renderLayout = () => renderWithTheme(<SidebarLayout />);
+
+describe('SidebarLayout', () => {
+  beforeEach(() => {
+    mockUseMediaQuery.mockReset();
+  });
+
+  it('toggles the desktop sidebar collapse state', async () => {
+    mockUseMediaQuery.mockReturnValue(false);
+
+    renderLayout();
+
+    const header = screen.getByTestId('header');
+    expect(header).toHaveAttribute('data-collapsed', 'false');
+
+    const sidebar = screen.getByTestId('sidebar');
+    expect(sidebar).toHaveAttribute('data-collapsed', 'false');
+
+    await userEvent.click(screen.getByRole('button', { name: 'toggle' }));
+
+    expect(sidebar).toHaveAttribute('data-collapsed', 'true');
+    expect(header).toHaveAttribute('data-collapsed', 'true');
+  });
+
+  it('opens a temporary drawer on mobile and toggles collapsed state accordingly', async () => {
+    mockUseMediaQuery.mockReturnValue(true);
+
+    renderLayout();
+
+    const header = screen.getByTestId('header');
+    expect(header).toHaveAttribute('data-collapsed', 'true');
+
+    const drawer = screen.getByTestId('drawer');
+    expect(drawer).toHaveAttribute('data-open', 'false');
+
+    await userEvent.click(screen.getByRole('button', { name: 'toggle' }));
+
+    expect(screen.getByTestId('drawer')).toHaveAttribute('data-open', 'true');
+    expect(screen.getByTestId('header')).toHaveAttribute('data-collapsed', 'false');
+  });
+});

--- a/ui/src/components/Layout/__tests__/UserMenu.test.tsx
+++ b/ui/src/components/Layout/__tests__/UserMenu.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserMenu from '../UserMenu';
+import { renderWithTheme } from '../../../test/testUtils';
+
+const mockGetCurrentUserDetails = jest.fn();
+const mockGetRoleLookup = jest.fn();
+const mockLogout = jest.fn();
+
+jest.mock('../../../config/config', () => ({
+  getCurrentUserDetails: () => mockGetCurrentUserDetails(),
+}));
+
+jest.mock('../../../utils/Utils', () => ({
+  ...jest.requireActual('../../../utils/Utils'),
+  getRoleLookup: () => mockGetRoleLookup(),
+  logout: () => mockLogout(),
+}));
+
+describe('UserMenu', () => {
+  beforeEach(() => {
+    mockGetCurrentUserDetails.mockReset();
+    mockGetRoleLookup.mockReset();
+    mockLogout.mockReset();
+  });
+
+  const createAnchor = () => {
+    const anchor = document.createElement('div');
+    document.body.appendChild(anchor);
+    return anchor;
+  };
+
+  it('renders user information and resolved role names', () => {
+    mockGetCurrentUserDetails.mockReturnValue({
+      name: 'Jane Doe',
+      username: 'jane',
+      userId: 'user-123',
+      email: 'jane.doe@example.com',
+      phone: '1234567890',
+      role: ['1', 'custom'],
+    });
+    mockGetRoleLookup.mockReturnValue([
+      { roleId: 1, role: 'Manager' },
+      { roleId: 'CUSTOM', role: 'Custom Role' },
+    ]);
+
+    renderWithTheme(
+      <UserMenu anchorEl={createAnchor()} open onClose={jest.fn()} />,
+    );
+
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+    expect(screen.getByText('jane')).toBeInTheDocument();
+    expect(screen.getByText('jane.doe@example.com')).toBeInTheDocument();
+    expect(screen.getByText('1234567890')).toBeInTheDocument();
+
+    const rolesSection = screen.getByText('ROLES').closest('div');
+    expect(rolesSection).not.toBeNull();
+    expect(within(rolesSection as HTMLElement).getByText('Manager')).toBeInTheDocument();
+    expect(within(rolesSection as HTMLElement).getByText('Custom Role')).toBeInTheDocument();
+  });
+
+  it('calls logout when confirmed by the user', async () => {
+    mockGetCurrentUserDetails.mockReturnValue({ userId: 'user-1' });
+    mockGetRoleLookup.mockReturnValue([]);
+    const onClose = jest.fn();
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+
+    renderWithTheme(
+      <UserMenu anchorEl={createAnchor()} open onClose={onClose} />,
+    );
+
+    await userEvent.click(screen.getByRole('menuitem', { name: /logout/i }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(confirmSpy).toHaveBeenCalledWith('Are you sure you want to logout?');
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+
+    confirmSpy.mockRestore();
+  });
+
+  it('shows fallback values when user information is incomplete', () => {
+    mockGetCurrentUserDetails.mockReturnValue({ username: 'sample-user' });
+    mockGetRoleLookup.mockReturnValue(undefined);
+
+    renderWithTheme(
+      <UserMenu anchorEl={createAnchor()} open onClose={jest.fn()} />,
+    );
+
+    const occurrences = screen.getAllByText('sample-user');
+    expect(occurrences.length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Not available')).toHaveLength(3);
+  });
+});

--- a/ui/src/test/setupTests.ts
+++ b/ui/src/test/setupTests.ts
@@ -47,6 +47,10 @@ jest.mock('msw/node', () => {
   };
 }, { virtual: true });
 
+jest.mock('jwt-decode', () => ({
+  jwtDecode: jest.fn(),
+}), { virtual: true });
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { setupServer } = require('msw/node');
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/ui/src/test/testUtils.tsx
+++ b/ui/src/test/testUtils.tsx
@@ -9,6 +9,13 @@ export const createTestTheme = (options?: ThemeOptions): Theme =>
       primary: { main: '#1976d2' },
       success: { main: '#2e7d32', dark: '#1b5e20' },
     },
+    components: {
+      MuiButtonBase: {
+        defaultProps: {
+          disableRipple: true,
+        },
+      },
+    },
     ...options,
   });
 


### PR DESCRIPTION
## Summary
- add React Testing Library coverage for the layout Header, Sidebar, SidebarLayout, and UserMenu components
- stub jwt-decode and disable Material UI ripples in the shared test utilities to stabilize tests

## Testing
- CI=true npm test -- --runTestsByPath src/components/Layout/__tests__/Header.test.tsx src/components/Layout/__tests__/Sidebar.test.tsx src/components/Layout/__tests__/SidebarLayout.test.tsx src/components/Layout/__tests__/UserMenu.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e587d398f08332a68e92937039b836