### PR TITLE
Notify IT managers on escalation approval status

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/repository/RoleRepository.java
+++ b/api/src/main/java/com/ticketingSystem/api/repository/RoleRepository.java
@@ -6,7 +6,9 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
+
 import java.util.List;
+import java.util.Optional;
 
 public interface RoleRepository extends JpaRepository<Role, Integer> {
     interface RoleSummaryView {
@@ -17,6 +19,8 @@ public interface RoleRepository extends JpaRepository<Role, Integer> {
     List<Role> findByIsDeletedFalse();
 
     List<RoleSummaryView> findByIsDeletedFalseOrderByRoleAsc();
+
+    Optional<Role> findByRoleIgnoreCaseAndIsDeletedFalse(String role);
 
     @Modifying
     @Transactional


### PR DESCRIPTION
## Summary
- allow looking up roles by name in the role repository
- send status update notifications to IT Managers when a ticket enters Awaiting Escalation Approval

## Testing
- ./gradlew test *(fails: Gradle toolchain could not locate a Java 17 installation in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e58907d71c8332b6ebcebf81faeea8