### PR TITLE
Add UI tests for permissions components

### DIFF
--- a/ui/src/components/Permissions/__tests__/JsonEditModal.test.tsx
+++ b/ui/src/components/Permissions/__tests__/JsonEditModal.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import JsonEditModal from '../JsonEditModal';
+
+jest.mock('@monaco-editor/react', () => ({
+  __esModule: true,
+  default: ({ value, onChange }: { value: string; onChange?: (value?: string) => void }) => (
+    <textarea
+      data-testid="mock-monaco-editor"
+      value={value}
+      onChange={(event) => onChange?.(event.target.value)}
+    />
+  ),
+}), { virtual: true });
+
+describe('JsonEditModal', () => {
+  it('renders provided data and submits parsed json', async () => {
+    const handleSubmit = jest.fn();
+    const handleCancel = jest.fn();
+    render(
+      <JsonEditModal
+        open
+        data={{ foo: 'bar' }}
+        onSubmit={handleSubmit}
+        onCancel={handleCancel}
+      />
+    );
+
+    const editor = screen.getByTestId('mock-monaco-editor') as HTMLTextAreaElement;
+    expect(editor.value).toContain('"foo": "bar"');
+
+    fireEvent.change(editor, { target: { value: '{"baz":"qux"}' } });
+
+    await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    expect(handleSubmit).toHaveBeenCalledWith({ baz: 'qux' });
+    expect(handleCancel).not.toHaveBeenCalled();
+  });
+
+  it('alerts on invalid json and keeps modal open', async () => {
+    const handleSubmit = jest.fn();
+    const handleCancel = jest.fn();
+    const originalAlert = window.alert;
+    const alertMock = jest.fn();
+    Object.defineProperty(window, 'alert', { configurable: true, writable: true, value: alertMock });
+
+    render(
+      <JsonEditModal
+        open
+        data={{ foo: 'bar' }}
+        onSubmit={handleSubmit}
+        onCancel={handleCancel}
+      />
+    );
+
+    const editor = screen.getByTestId('mock-monaco-editor');
+    fireEvent.change(editor, { target: { value: '{invalid json' } });
+
+    await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    expect(alertMock).toHaveBeenCalledWith('Invalid JSON');
+    expect(handleSubmit).not.toHaveBeenCalled();
+    expect(screen.getByTestId('mock-monaco-editor')).toBeInTheDocument();
+
+    Object.defineProperty(window, 'alert', { configurable: true, writable: true, value: originalAlert });
+  });
+
+  it('invokes cancel handler when cancel button clicked', async () => {
+    const handleCancel = jest.fn();
+    render(
+      <JsonEditModal
+        open
+        data={{ foo: 'bar' }}
+        onSubmit={jest.fn()}
+        onCancel={handleCancel}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(handleCancel).toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/Permissions/__tests__/PermissionTree.test.tsx
+++ b/ui/src/components/Permissions/__tests__/PermissionTree.test.tsx
@@ -1,0 +1,190 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PermissionTree from '../PermissionTree';
+import { DevModeContext } from '../../../context/DevModeContext';
+
+jest.mock('../JsonEditModal', () => ({
+  __esModule: true,
+  default: ({ open, onSubmit, onCancel }: { open: boolean; onSubmit: (value: any) => void; onCancel: () => void }) => (
+    open ? (
+      <div data-testid="json-edit-modal">
+        <button type="button" onClick={() => onSubmit({ show: false })}>
+          Save JSON
+        </button>
+        <button type="button" onClick={onCancel}>
+          Close JSON
+        </button>
+      </div>
+    ) : null
+  ),
+}));
+
+const devModeValue = {
+  devMode: true,
+  toggleDevMode: jest.fn(),
+  jwtBypass: false,
+  toggleJwtBypass: jest.fn(),
+  setJwtBypass: jest.fn(),
+};
+
+const renderWithContext = (ui: React.ReactNode, value = { ...devModeValue, devMode: false }) => {
+  return render(
+    <DevModeContext.Provider value={value as any}>
+      {ui}
+    </DevModeContext.Provider>
+  );
+};
+
+const findCheckboxForLabel = (label: string): HTMLInputElement => {
+  const textEl = screen.getByText(label);
+  let current: HTMLElement | null = textEl.parentElement as HTMLElement | null;
+  while (current && !current.querySelector('input[type="checkbox"]')) {
+    current = current.parentElement as HTMLElement | null;
+  }
+  if (!current) {
+    throw new Error(`Checkbox for ${label} not found`);
+  }
+  return current.querySelector('input[type="checkbox"]') as HTMLInputElement;
+};
+
+describe('PermissionTree', () => {
+  it('toggles show state for a node', async () => {
+    const initialData = {
+      sidebar: { show: true, metadata: { name: 'Sidebar' }, children: null },
+    };
+
+    const Wrapper = () => {
+      const [data, setData] = React.useState(initialData);
+      return (
+        <PermissionTree
+          data={data}
+          onChange={setData}
+        />
+      );
+    };
+
+    renderWithContext(<Wrapper />);
+
+    const checkboxBefore = findCheckboxForLabel('Sidebar');
+    expect(checkboxBefore).toBeChecked();
+
+    await userEvent.click(checkboxBefore);
+
+    await waitFor(() => expect(screen.getAllByRole('checkbox')[0]).not.toBeChecked());
+  });
+
+  it('allows adding a child node when structure editing is enabled in dev mode', async () => {
+    const initialData = {
+      pages: { show: false, metadata: { name: 'Pages' }, children: null },
+    };
+
+    const Wrapper = () => {
+      const [data, setData] = React.useState(initialData);
+      return (
+        <PermissionTree
+          data={data}
+          onChange={setData}
+          allowStructureEdit
+          defaultShowForNewNodes
+        />
+      );
+    };
+
+    renderWithContext(<Wrapper />, devModeValue);
+
+    const addButton = screen.getByLabelText('Add child attribute');
+    await userEvent.click(addButton);
+
+    const input = screen.getByRole('textbox');
+    await userEvent.type(input, 'New Child');
+
+    const confirmButton = screen.getByTestId('CheckIcon').closest('button');
+    await userEvent.click(confirmButton!);
+
+    await waitFor(() => expect(screen.getByText('New Child')).toBeInTheDocument());
+
+    const newChildCheckbox = findCheckboxForLabel('New Child');
+    expect(newChildCheckbox).toBeChecked();
+  });
+
+  it('cycles all children visibility via the chip', async () => {
+    const initialData = {
+      pages: {
+        show: true,
+        metadata: { name: 'Pages' },
+        children: {
+          dashboard: { show: true, metadata: { name: 'Dashboard' }, children: null },
+          reports: { show: false, metadata: { name: 'Reports' }, children: null },
+        },
+      },
+    };
+
+    const Wrapper = () => {
+      const [data, setData] = React.useState(initialData);
+      return (
+        <PermissionTree
+          data={data}
+          onChange={setData}
+          allowStructureEdit
+        />
+      );
+    };
+
+    renderWithContext(<Wrapper />);
+
+    const chip = screen.getByRole('button', { name: /all children/i });
+
+    expect(findCheckboxForLabel('Dashboard')).toBeChecked();
+    expect(findCheckboxForLabel('Reports')).not.toBeChecked();
+
+    await userEvent.click(chip);
+    await waitFor(() => {
+      expect(findCheckboxForLabel('Dashboard')).toBeChecked();
+      expect(findCheckboxForLabel('Reports')).toBeChecked();
+    });
+
+    await userEvent.click(chip);
+    await waitFor(() => {
+      expect(findCheckboxForLabel('Dashboard')).not.toBeChecked();
+      expect(findCheckboxForLabel('Reports')).not.toBeChecked();
+    });
+
+    await userEvent.click(chip);
+    await waitFor(() => {
+      expect(findCheckboxForLabel('Dashboard')).toBeChecked();
+      expect(findCheckboxForLabel('Reports')).not.toBeChecked();
+    });
+  });
+
+  it('opens the json editor and applies submitted changes', async () => {
+    const handleChange = jest.fn();
+    const data = {
+      pages: {
+        show: true,
+        metadata: { name: 'Pages' },
+        children: null,
+      },
+    };
+
+    renderWithContext(
+      <PermissionTree
+        data={data}
+        onChange={handleChange}
+        allowStructureEdit
+      />, devModeValue
+    );
+
+    const editJsonButton = screen.getAllByLabelText('Edit JSON').find(el => el.tagName === 'BUTTON') as HTMLElement;
+    await userEvent.click(editJsonButton);
+
+    expect(screen.getByTestId('json-edit-modal')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /save json/i }));
+
+    expect(handleChange).toHaveBeenCalledWith({
+      pages: { show: false },
+    });
+    await waitFor(() => expect(screen.queryByTestId('json-edit-modal')).not.toBeInTheDocument());
+  });
+});

--- a/ui/src/components/Permissions/__tests__/PermissionsModal.test.tsx
+++ b/ui/src/components/Permissions/__tests__/PermissionsModal.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PermissionsModal from '../PermissionsModal';
+
+const mockPermissionTree = jest.fn(({ data, onChange }: { data: any; onChange: (value: any) => void }) => (
+  <div data-testid="permission-tree">
+    <button type="button" onClick={() => onChange({ mutated: true })}>
+      Update permissions
+    </button>
+    <span data-testid="tree-data">{JSON.stringify(data)}</span>
+  </div>
+));
+
+jest.mock('../PermissionTree', () => ({
+  __esModule: true,
+  default: (props: any) => mockPermissionTree(props),
+}));
+
+jest.mock('../../UI/Dropdown/GenericDropdown', () => ({
+  __esModule: true,
+  default: ({ label, value, onChange, options }: any) => (
+    <label>
+      {label}
+      <select aria-label={label} value={value} onChange={(event) => onChange({ target: { value: event.target.value } })}>
+        {options.map((option: any) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  ),
+}));
+
+describe('PermissionsModal', () => {
+  const roles = ['Admin', 'User'];
+  const permissions = {
+    Admin: {
+      sidebar: { show: true, metadata: { name: 'Admin Sidebar' }, children: null },
+    },
+    User: {
+      sidebar: { show: false, metadata: { name: 'User Sidebar' }, children: null },
+    },
+  };
+
+  beforeEach(() => {
+    mockPermissionTree.mockClear();
+  });
+
+  it('renders the modal with the default role permissions', async () => {
+    render(
+      <PermissionsModal
+        open
+        roles={roles}
+        permissions={permissions}
+        defaultRole="Admin"
+        onClose={jest.fn()}
+        onSubmit={jest.fn()}
+        title="Edit permissions"
+      />
+    );
+
+    await waitFor(() => expect(mockPermissionTree).toHaveBeenCalled());
+
+    expect(screen.getByText('Edit permissions')).toBeInTheDocument();
+    const firstCall = mockPermissionTree.mock.calls[0][0];
+    expect(firstCall.data).toEqual(permissions.Admin);
+    expect(firstCall.data).not.toBe(permissions.Admin);
+  });
+
+  it('switches the displayed permissions when selecting a different role', async () => {
+    render(
+      <PermissionsModal
+        open
+        roles={roles}
+        permissions={permissions}
+        defaultRole="Admin"
+        onClose={jest.fn()}
+        onSubmit={jest.fn()}
+      />
+    );
+
+    await waitFor(() => expect(mockPermissionTree).toHaveBeenCalled());
+    mockPermissionTree.mockClear();
+
+    await userEvent.selectOptions(screen.getByLabelText('Select Base Permissions'), 'User');
+
+    await waitFor(() => expect(mockPermissionTree).toHaveBeenCalled());
+    const props = mockPermissionTree.mock.calls[mockPermissionTree.mock.calls.length - 1][0];
+    expect(props.data).toEqual(permissions.User);
+    expect(props.data).not.toBe(permissions.User);
+  });
+
+  it('submits updated permissions emitted by the tree', async () => {
+    const handleSubmit = jest.fn();
+
+    render(
+      <PermissionsModal
+        open
+        roles={roles}
+        permissions={permissions}
+        defaultRole="Admin"
+        onClose={jest.fn()}
+        onSubmit={handleSubmit}
+      />
+    );
+
+    await waitFor(() => expect(mockPermissionTree).toHaveBeenCalled());
+    const latestProps = mockPermissionTree.mock.calls[mockPermissionTree.mock.calls.length - 1][0];
+    latestProps.onChange({ mutated: true });
+    await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+
+    expect(handleSubmit).toHaveBeenCalledWith({ mutated: true });
+  });
+
+  it('invokes close handler when cancel button is pressed', async () => {
+    const handleClose = jest.fn();
+
+    render(
+      <PermissionsModal
+        open
+        roles={roles}
+        permissions={permissions}
+        defaultRole="Admin"
+        onClose={handleClose}
+        onSubmit={jest.fn()}
+      />
+    );
+
+    await waitFor(() => expect(mockPermissionTree).toHaveBeenCalled());
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(handleClose).toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/Permissions/components/AllChildrenChip.test.tsx
+++ b/ui/src/components/Permissions/components/AllChildrenChip.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AllChildrenChip from './AllChildrenChip';
+
+jest.mock('@mui/material', () => ({
+  __esModule: true,
+  Chip: ({ label, onClick, disabled }: any) => (
+    <button type="button" onClick={disabled ? undefined : onClick} disabled={disabled}>
+      {label}
+    </button>
+  ),
+}));
+
+describe('AllChildrenChip', () => {
+  it('renders the chip label and triggers click handler', async () => {
+    const handleClick = jest.fn();
+
+    render(<AllChildrenChip state="all" onClick={handleClick} />);
+
+    const chip = screen.getByRole('button', { name: /all children/i });
+    expect(chip).toBeInTheDocument();
+
+    await userEvent.click(chip);
+
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('respects the disabled state', () => {
+    const handleClick = jest.fn();
+
+    render(<AllChildrenChip state="none" onClick={handleClick} disabled />);
+
+    const chip = screen.getByRole('button', { name: /all children/i });
+    expect(chip).toBeDisabled();
+
+    fireEvent.click(chip);
+
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for JsonEditModal behaviors including submit, validation, and cancel flows
- exercise PermissionTree structure editing, child visibility toggling, and JSON editing
- add PermissionsModal integration tests and coverage for the AllChildrenChip helper

## Testing
- npm test -- --watchAll=false --runTestsByPath src/components/Permissions/__tests__/JsonEditModal.test.tsx src/components/Permissions/__tests__/PermissionTree.test.tsx src/components/Permissions/__tests__/PermissionsModal.test.tsx src/components/Permissions/components/AllChildrenChip.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e5e9a476288332ab23dbab78731110