### PR TITLE
Ensure requestors can view their tickets irrespective of other roles

### DIFF
--- a/ui/src/pages/__tests__/MyTickets.test.tsx
+++ b/ui/src/pages/__tests__/MyTickets.test.tsx
@@ -48,9 +48,14 @@ describe('MyTickets', () => {
     const transformed = latestProps.transformTickets([
       { id: '1', statusId: '1' },
       { id: '2', statusId: '6' },
-      { id: '3', statusId: '3' },
+      { id: '3', statusId: '3', createdBy: 'tester' },
+      { id: '4', statusId: '4', requestorId: 'user-1' },
+      { id: '5', statusId: '5', createdBy: 'another-user' },
     ]);
-    expect(transformed).toEqual([]);
+    expect(transformed).toEqual([
+      { id: '3', statusId: '3', createdBy: 'tester' },
+      { id: '4', statusId: '4', requestorId: 'user-1' },
+    ]);
     latestProps.onRowClick('T-1');
     expect(navigateMock).toHaveBeenCalledWith('/tickets/T-1');
   });


### PR DESCRIPTION
## Summary
- keep requestor-created and requested tickets visible even when other role filters apply in MyTickets
- update the MyTickets page test to cover the requestor-specific visibility logic

## Testing
- CI=true npm test -- MyTickets

------
https://chatgpt.com/codex/tasks/task_e_68e5ed8413dc8332b3e759fe92deb1d1