### PR TITLE
Stop counting SLA idle time after resolution

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/service/TicketSlaService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/TicketSlaService.java
@@ -70,6 +70,9 @@ public class TicketSlaService {
                 ? new ArrayList<>(history)
                 : new ArrayList<>();
         orderedHistory.removeIf(h -> h == null || h.getTimestamp() == null);
+        if (resolvedAt != null) {
+            orderedHistory.removeIf(h -> h.getTimestamp().isAfter(resolvedAt));
+        }
         orderedHistory.sort(Comparator.comparing(StatusHistory::getTimestamp));
 
 //        START OF RESOLUTION TIME


### PR DESCRIPTION
## Summary
- ignore status history entries that occur after a ticket's resolution timestamp when calculating SLA metrics
- prevent idle time from continuing to accumulate once the ticket has been resolved

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6112f17ac83329386280359d79889