### PR TITLE
Add tests for RaiseTicket components

### DIFF
--- a/ui/src/components/RaiseTicket/__tests__/LinkToMasterTicketModal.test.tsx
+++ b/ui/src/components/RaiseTicket/__tests__/LinkToMasterTicketModal.test.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+
+jest.mock('../../../hooks/useDebounce', () => ({
+  useDebounce: (value: any) => value,
+}));
+
+jest.mock('../../../config/config', () => ({
+  getCurrentUserDetails: () => ({ username: 'agent' }),
+}));
+
+jest.mock('../../CustomFieldset', () => ({
+  __esModule: true,
+  default: ({ title, children }: { title: string; children: React.ReactNode }) => (
+    <div>
+      <h3>{title}</h3>
+      {children}
+    </div>
+  ),
+}));
+
+jest.mock('../../UI/Input/GenericInput', () => ({
+  __esModule: true,
+  default: ({ value, onChange, placeholder }: any) => (
+    <input placeholder={placeholder} value={value} onChange={onChange} />
+  ),
+}));
+
+const mockSearchTickets = jest.fn(() => Promise.resolve({ body: { data: { hits: [] } } }));
+const mockGetTicket = jest.fn(() => Promise.resolve({ body: { data: { id: 'MT-1', subject: 'Master ticket' } } }));
+const mockLinkTicketToMaster = jest.fn(() => Promise.resolve());
+const mockMakeTicketMaster = jest.fn(() => Promise.resolve({ body: { data: { id: 'MT-1', subject: 'Master ticket', isMaster: true } } }));
+const mockSearchTicketsPaginated = jest.fn(() => Promise.resolve({ body: { data: { items: [{ id: 'MT-1', subject: 'Master ticket' }], totalPages: 1, page: 0 } } }));
+
+jest.mock('../../../services/TicketService', () => ({
+  searchTickets: (...args: any[]) => mockSearchTickets(...args),
+  getTicket: (...args: any[]) => mockGetTicket(...args),
+  linkTicketToMaster: (...args: any[]) => mockLinkTicketToMaster(...args),
+  makeTicketMaster: (...args: any[]) => mockMakeTicketMaster(...args),
+  searchTicketsPaginated: (...args: any[]) => mockSearchTicketsPaginated(...args),
+}));
+
+const LinkToMasterTicketModal = require('../LinkToMasterTicketModal').default;
+
+describe('LinkToMasterTicketModal', () => {
+  const baseProps = {
+    open: true,
+    onClose: jest.fn(),
+    subject: 'New ticket',
+    setMasterId: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearchTickets.mockImplementation(() => Promise.resolve({ body: { data: { hits: [] } } }));
+    mockGetTicket.mockImplementation(() => Promise.resolve({ body: { data: { id: 'MT-1', subject: 'Master ticket' } } }));
+    mockSearchTicketsPaginated.mockImplementation(() => Promise.resolve({ body: { data: { items: [{ id: 'MT-1', subject: 'Master ticket' }], totalPages: 1, page: 0 } } }));
+    mockLinkTicketToMaster.mockResolvedValue(undefined);
+    mockMakeTicketMaster.mockImplementation(() => Promise.resolve({ body: { data: { id: 'MT-1', subject: 'Master ticket', isMaster: true } } }));
+  });
+
+  it('loads master tickets when opened', async () => {
+    render(<LinkToMasterTicketModal {...baseProps} />);
+
+    await waitFor(() => {
+      expect(mockSearchTicketsPaginated).toHaveBeenCalledWith('', undefined, true, 0, 20);
+    });
+
+    expect(await screen.findByText(/MT-1/)).toBeInTheDocument();
+  });
+
+  it('allows searching and linking a master ticket during creation', async () => {
+    mockSearchTickets.mockResolvedValueOnce({
+      body: {
+        data: {
+          hits: [
+            { document: { id: 'MT-2', subject: 'Another ticket' } },
+          ],
+        },
+      },
+    });
+    mockGetTicket.mockResolvedValueOnce({
+      body: { data: { id: 'MT-2', subject: 'Another ticket' } },
+    });
+
+    render(<LinkToMasterTicketModal {...baseProps} />);
+
+    fireEvent.change(screen.getByPlaceholderText('Search tickets by id or subject'), {
+      target: { value: 'MT' },
+    });
+
+    await waitFor(() => {
+      expect(mockSearchTickets).toHaveBeenCalledWith('MT');
+    });
+
+    fireEvent.click(await screen.findByText(/Another ticket/));
+
+    await waitFor(() => {
+      expect(mockGetTicket).toHaveBeenCalledWith('MT-2');
+    });
+
+    expect(await screen.findByText('Master Ticket MT-2')).toBeInTheDocument();
+
+    const linkToggle = await screen.findByText('Link');
+    fireEvent.click(linkToggle);
+
+    expect(baseProps.setMasterId).toHaveBeenCalledWith('MT-2');
+    expect(screen.getByText(/will be linked to Master ticket MT-2/)).toBeInTheDocument();
+  });
+
+  it('links an existing ticket using the API', async () => {
+    const onLinkSuccess = jest.fn();
+    render(
+      <LinkToMasterTicketModal
+        {...baseProps}
+        currentTicketId="T-1"
+        onLinkSuccess={onLinkSuccess}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockSearchTicketsPaginated).toHaveBeenCalled();
+    });
+
+    fireEvent.click(await screen.findByText(/Master ticket/));
+
+    await waitFor(() => {
+      expect(mockGetTicket).toHaveBeenCalledWith('MT-1');
+    });
+
+    expect(await screen.findByText('Master Ticket MT-1')).toBeInTheDocument();
+    const linkToggle = await screen.findByText('Link');
+    fireEvent.click(linkToggle);
+
+    await waitFor(() => {
+      expect(mockLinkTicketToMaster).toHaveBeenCalledWith('T-1', 'MT-1', 'agent');
+      expect(onLinkSuccess).toHaveBeenCalledWith('MT-1');
+    });
+  });
+
+  it('resets state when cancelled', async () => {
+    render(<LinkToMasterTicketModal {...baseProps} />);
+
+    await waitFor(() => {
+      expect(mockSearchTicketsPaginated).toHaveBeenCalled();
+    });
+
+    fireEvent.click(await screen.findByText(/Master ticket/));
+
+    await waitFor(() => {
+      expect(mockGetTicket).toHaveBeenCalledWith('MT-1');
+    });
+
+    fireEvent.click(screen.getByText('Cancel'));
+
+    expect(baseProps.setMasterId).toHaveBeenCalledWith('');
+    expect(baseProps.onClose).toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/RaiseTicket/__tests__/RequestDetails.test.tsx
+++ b/ui/src/components/RaiseTicket/__tests__/RequestDetails.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+
+const mockSetValue = jest.fn();
+const mockUseWatch = jest.fn();
+
+jest.mock('react-hook-form', () => ({
+  useWatch: (args: any) => mockUseWatch(args),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@mui/material/styles', () => ({
+  ...jest.requireActual('@mui/material/styles'),
+  useTheme: () => ({
+    palette: {
+      primary: { main: '#111' },
+      secondary: { main: '#222' },
+    },
+  }),
+}));
+
+jest.mock('../../../utils/permissions', () => ({
+  checkFieldAccess: jest.fn(() => true),
+  getFieldChildren: jest.fn(() => ({
+    self: { show: true },
+    call: { show: true },
+    email: { show: true },
+  })),
+}));
+
+jest.mock('../../UI/IconButton/CustomIconButton', () => ({
+  __esModule: true,
+  default: ({ icon, onClick }: { icon: string; onClick: () => void }) => (
+    <button onClick={onClick}>{icon}</button>
+  ),
+}));
+
+const RequestDetails = require('../RequestDetails').default;
+
+describe('RequestDetails', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseWatch.mockImplementation(({ name, defaultValue }: { name: string; defaultValue?: any }) => {
+      if (name === 'mode') {
+        return defaultValue ?? 'Self';
+      }
+      return '';
+    });
+    const permissions = jest.requireMock('../../../utils/permissions');
+    permissions.checkFieldAccess.mockReturnValue(true);
+    permissions.getFieldChildren.mockReturnValue({
+      self: { show: true },
+      call: { show: true },
+      email: { show: true },
+    });
+  });
+
+  const baseProps = {
+    register: jest.fn(),
+    control: {},
+    errors: {},
+    setValue: mockSetValue,
+    disableAll: false,
+    isFieldSetDisabled: false,
+    createMode: true,
+  } as any;
+
+  it('renders mode toggle buttons when access is allowed', () => {
+    render(<RequestDetails {...baseProps} />);
+
+    expect(screen.getByText('Request Mode')).toBeInTheDocument();
+    expect(screen.getByText('Self')).toBeInTheDocument();
+    expect(screen.getByText('Call')).toBeInTheDocument();
+    expect(screen.getByText('Email')).toBeInTheDocument();
+  });
+
+  it('calls setValue when clicking on a different mode', () => {
+    mockUseWatch.mockImplementation(({ name }: { name: string }) => {
+      if (name === 'mode') {
+        return 'Self';
+      }
+      return '';
+    });
+
+    render(<RequestDetails {...baseProps} />);
+
+    fireEvent.click(screen.getByText('call'));
+
+    expect(mockSetValue).toHaveBeenCalledWith('mode', 'Call');
+  });
+
+  it('does not render request mode selector when only self is allowed', () => {
+    const permissions = jest.requireMock('../../../utils/permissions');
+    permissions.getFieldChildren.mockReturnValueOnce({
+      self: { show: true },
+      call: { show: false },
+      email: { show: false },
+    });
+
+    render(<RequestDetails {...baseProps} />);
+
+    expect(screen.queryByText('Request Mode')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/components/RaiseTicket/__tests__/SuccessfulModal.test.tsx
+++ b/ui/src/components/RaiseTicket/__tests__/SuccessfulModal.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+const SuccessfulModal = require('../SuccessfulModal').default;
+
+describe('SuccessfulModal', () => {
+  const baseProps = {
+    open: true,
+    ticketId: 'T-123',
+    onClose: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('displays ticket information when open', () => {
+    render(<SuccessfulModal {...baseProps} />);
+
+    expect(screen.getByText('Thank you! Your ticket has been submitted successfully.')).toBeInTheDocument();
+    expect(screen.getByText(/Ticket ID/)).toBeInTheDocument();
+    expect(screen.getByText('T-123')).toBeInTheDocument();
+  });
+
+  it('invokes callbacks from action buttons', () => {
+    render(<SuccessfulModal {...baseProps} />);
+
+    fireEvent.click(screen.getByText('Raise New Ticket'));
+    expect(baseProps.onClose).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText('Go to My Tickets'));
+    expect(baseProps.onClose).toHaveBeenCalledTimes(2);
+    expect(mockNavigate).toHaveBeenCalledWith('/my-tickets');
+  });
+});

--- a/ui/src/components/RaiseTicket/__tests__/TicketDetails.test.tsx
+++ b/ui/src/components/RaiseTicket/__tests__/TicketDetails.test.tsx
@@ -1,0 +1,197 @@
+import React from 'react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+
+const mockUseWatch = jest.fn();
+
+jest.mock('react-hook-form', () => ({
+  useWatch: (args: any) => mockUseWatch(args),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('../../../utils/permissions', () => ({
+  checkFieldAccess: jest.fn(() => true),
+}));
+
+jest.mock('../../../config/config', () => ({
+  getCurrentUserDetails: () => ({ username: 'agent', role: ['ADMIN'] }),
+}));
+
+const mockUseApi = jest.fn();
+
+jest.mock('../../../hooks/useApi', () => ({
+  useApi: () => mockUseApi(),
+}));
+
+const mockGetAllLevels = jest.fn(() => Promise.resolve([]));
+const mockGetAllUsersByLevel = jest.fn(() => Promise.resolve([]));
+
+jest.mock('../../../services/LevelService', () => ({
+  getAllLevels: (...args: any[]) => mockGetAllLevels(...args),
+  getAllUsersByLevel: (...args: any[]) => mockGetAllUsersByLevel(...args),
+}));
+
+const mockGetCategories = jest.fn(() => Promise.resolve([]));
+const mockGetSubCategories = jest.fn(() => Promise.resolve([]));
+
+jest.mock('../../../services/CategoryService', () => ({
+  getCategories: (...args: any[]) => mockGetCategories(...args),
+  getSubCategories: (...args: any[]) => mockGetSubCategories(...args),
+}));
+
+const mockGetNextStatuses = jest.fn(() => Promise.resolve([]));
+
+jest.mock('../../../services/StatusService', () => ({
+  getNextStatusListByStatusId: (...args: any[]) => mockGetNextStatuses(...args),
+}));
+
+const mockGetPriorities = jest.fn(() => Promise.resolve([]));
+
+jest.mock('../../../services/PriorityService', () => ({
+  getPriorities: (...args: any[]) => mockGetPriorities(...args),
+}));
+
+const mockGetSeverities = jest.fn(() => Promise.resolve([]));
+
+jest.mock('../../../services/SeverityService', () => ({
+  getSeverities: (...args: any[]) => mockGetSeverities(...args),
+}));
+
+jest.mock('../../UI/Dropdown/GenericDropdownController', () => ({
+  __esModule: true,
+  default: ({ name, label, options, disabled }: any) => (
+    <select aria-label={label} name={name} disabled={disabled}>
+      {options.map((opt: any) => (
+        <option key={String(opt.value)} value={String(opt.value)}>{opt.label}</option>
+      ))}
+    </select>
+  ),
+}));
+
+jest.mock('../../CustomFieldset', () => ({
+  __esModule: true,
+  default: ({ title, children }: { title: string; children: React.ReactNode }) => (
+    <section>
+      <h2>{title}</h2>
+      {children}
+    </section>
+  ),
+}));
+
+jest.mock('../../UI/Input/CustomFormInput', () => ({
+  __esModule: true,
+  default: ({ label, name, disabled }: any) => (
+    <input aria-label={label} name={name} disabled={disabled} />
+  ),
+}));
+
+jest.mock('../../UI/FileUpload', () => {
+  const mock = jest.fn(({ onFilesChange }: { onFilesChange: (files: File[]) => void }) => (
+    <button onClick={() => onFilesChange([new File(['data'], 'file.txt')])}>upload</button>
+  ));
+  return {
+    __esModule: true,
+    default: mock,
+  };
+});
+
+const FileUploadMock = require('../../UI/FileUpload').default as jest.Mock;
+
+jest.mock('../../UI/Icons/InfoIcon', () => ({
+  __esModule: true,
+  default: ({ content }: { content: React.ReactNode }) => (
+    <span data-testid="info-icon">{content ? 'info' : ''}</span>
+  ),
+}));
+
+const TicketDetails = require('../TicketDetails').default;
+
+describe('TicketDetails', () => {
+  const baseProps = {
+    register: jest.fn(() => ({})),
+    control: {},
+    errors: {},
+    setValue: jest.fn(),
+    disableAll: false,
+    subjectDisabled: false,
+    attachments: [],
+    setAttachments: jest.fn(),
+    createMode: true,
+  } as any;
+
+  const setupUseApiMocks = () => {
+    const handlers: jest.Mock[] = [];
+    const makeReturn = (data: any = []) => {
+      const handler = jest.fn(async (fn: () => any) => fn());
+      handlers.push(handler);
+      return { data, pending: false, error: null, apiHandler: handler };
+    };
+
+    mockUseApi
+      .mockReturnValueOnce(makeReturn([]))
+      .mockReturnValueOnce(makeReturn([]))
+      .mockReturnValueOnce(makeReturn([{ category: 'Hardware', categoryId: 'cat-1' }]))
+      .mockReturnValueOnce(makeReturn([{ subCategory: 'Laptop', subCategoryId: 'sub-1' }]))
+      .mockReturnValueOnce(makeReturn([]))
+      .mockReturnValueOnce(makeReturn([{ id: 'p1', level: 'High', description: 'High impact' }]))
+      .mockReturnValueOnce(makeReturn([{ id: 's1', level: 'Critical', description: 'Critical issue' }]));
+
+    return handlers;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseApi.mockReset();
+    const watchValues: Record<string, any> = {
+      assignedToLevel: 'L0',
+      assignToLevel: 'L1',
+      category: 'cat-1',
+      subject: 'Subject',
+      description: 'Description',
+      statusId: 'status-1',
+    };
+
+    mockUseWatch.mockImplementation(({ name }: { name: string }) => watchValues[name]);
+    const permissions = require('../../../utils/permissions');
+    permissions.checkFieldAccess.mockReturnValue(true);
+  });
+
+  it('fetches initial data on mount', async () => {
+    setupUseApiMocks();
+    render(<TicketDetails {...baseProps} />);
+
+    await waitFor(() => {
+      expect(mockGetAllLevels).toHaveBeenCalled();
+      expect(mockGetCategories).toHaveBeenCalled();
+      expect(mockGetPriorities).toHaveBeenCalled();
+      expect(mockGetSeverities).toHaveBeenCalled();
+    });
+  });
+
+  it('loads dependent data when values change', async () => {
+    setupUseApiMocks();
+    render(<TicketDetails {...baseProps} />);
+
+    await waitFor(() => {
+      expect(mockGetAllUsersByLevel).toHaveBeenCalledWith('L1');
+      expect(mockGetSubCategories).toHaveBeenCalledWith('cat-1');
+      expect(mockGetNextStatuses).toHaveBeenCalledWith('status-1');
+    });
+  });
+
+  it('propagates attachment changes through callbacks', async () => {
+    setupUseApiMocks();
+    render(<TicketDetails {...baseProps} />);
+
+    await waitFor(() => {
+      expect(FileUploadMock).toHaveBeenCalled();
+    });
+    const uploadProps = FileUploadMock.mock.calls[0][0];
+    uploadProps.onFilesChange([new File(['data'], 'file.txt')]);
+
+    expect(baseProps.setAttachments).toHaveBeenCalled();
+    expect(baseProps.setValue).toHaveBeenCalledWith('attachments', expect.any(Array));
+  });
+});


### PR DESCRIPTION
## Summary
- add tests covering the LinkToMasterTicketModal interactions and API integrations
- add tests for RequestDetails view toggles and SuccessfulModal actions
- add TicketDetails tests covering API fetches and attachment handling

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e61d65b5c883328156c2be40282ef1