### PR TITLE
Fix status list parsing for status history display

### DIFF
--- a/ui/src/utils/Utils.ts
+++ b/ui/src/utils/Utils.ts
@@ -92,7 +92,10 @@ export async function getStatuses(): Promise<any[]> {
     return stored;
   }
   const res = await getStatusListFromApi();
-  const list = res.data.body.data;
+  const rawPayload = res?.data ?? res;
+  const body = rawPayload?.body ?? rawPayload;
+  const payload = body && typeof body === "object" && "data" in body ? body.data : body;
+  const list = Array.isArray(payload) ? payload : [];
   statusCache = list;
   setStatusList(list);
   return list;


### PR DESCRIPTION
## Summary
- update the status list helper to handle API response shapes consistently so status names resolve correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6491232b88332ae8aee37715dfc26