### PR TITLE
Update FCI assignment flow and add assign-back action

### DIFF
--- a/ui/src/components/AllTickets/TicketCard.tsx
+++ b/ui/src/components/AllTickets/TicketCard.tsx
@@ -136,7 +136,7 @@ const TicketCard: React.FC<TicketCardProps> = ({ ticket, priorityConfig, onClick
     const statusColor = getStatusColorById(ticket.statusId || '') || undefined;
     const truncatedStatus = displayStatusName.length > 12 ? `${displayStatusName.slice(0, 12)}...` : displayStatusName;
     const resumeAction = recordActions.find(a => a.action === 'Resume');
-    const showSubmit = resumeAction && (statusName === 'On Hold (Pending with Requester)' || statusName === 'On Hold (Pending with Regional Nodal Officer)');
+    const showSubmit = resumeAction && (statusName === 'On Hold (Pending with Requester)' || statusName === 'On Hold (Pending with FCI)');
 
     return (
         <Card

--- a/ui/src/components/AllTickets/__tests__/AdvancedAssignmentOptionsDialog.test.tsx
+++ b/ui/src/components/AllTickets/__tests__/AdvancedAssignmentOptionsDialog.test.tsx
@@ -64,7 +64,7 @@ describe('AdvancedAssignmentOptionsDialog', () => {
         ticketId: 'INC-1',
         requestorId: 'user-1',
         canRequester: false,
-        canRno: false,
+        canAssignToFci: false,
         levels: [
             { levelId: 'L1', levelName: 'Level 1' },
             { levelId: 'L2', levelName: 'Level 2' },
@@ -72,9 +72,6 @@ describe('AdvancedAssignmentOptionsDialog', () => {
         users: [
             { userId: '1', username: 'john', name: 'John Doe', roles: '3', levels: ['L1'] },
             { userId: '2', username: 'mary', name: 'Mary Jane', roles: '9', levels: ['L2'] },
-        ],
-        rnoUsers: [
-            { userId: 'r1', username: 'rno', name: 'Rno User', roles: '16', levels: [] },
         ],
         updateTicketApiHandler: jest.fn(() => Promise.resolve()),
         searchCurrentTicketsPaginatedApi: jest.fn(),
@@ -96,13 +93,13 @@ describe('AdvancedAssignmentOptionsDialog', () => {
             <AdvancedAssignmentOptionsDialog
                 {...defaultProps}
                 canRequester
-                canRno
+                canAssignToFci
             />
         );
 
         expect(screen.getByText('Assign User')).toBeInTheDocument();
         expect(screen.getByText('Requester')).toBeInTheDocument();
-        expect(screen.getByText('Regional Nodal Officer')).toBeInTheDocument();
+        expect(screen.getByText('Assign to FCI')).toBeInTheDocument();
     });
 
     it('assigns selected user and refreshes tickets', async () => {
@@ -161,30 +158,28 @@ describe('AdvancedAssignmentOptionsDialog', () => {
         expect(defaultProps.onClose).toHaveBeenCalled();
     });
 
-    it('assigns to regional nodal officer when RNO tab used', async () => {
+    it('assigns to FCI when dedicated tab used', async () => {
         render(
             <AdvancedAssignmentOptionsDialog
                 {...defaultProps}
-                canRno
+                canAssignToFci
             />
         );
 
-        fireEvent.click(screen.getByText('Regional Nodal Officer'));
-        fireEvent.click(screen.getByText('Rno User'));
+        fireEvent.click(screen.getByText('Assign to FCI'));
         await waitFor(() => {
-            expect(mockRemarkComponent).toHaveBeenCalledWith(expect.objectContaining({ actionName: 'Assign' }));
+            expect(mockRemarkComponent).toHaveBeenCalledWith(expect.objectContaining({ actionName: 'Assign to FCI' }));
         });
-        const rnoCall = mockRemarkComponent.mock.calls.filter(([props]) => props.actionName === 'Assign').pop();
-        expect(rnoCall).toBeDefined();
-        const rnoProps = rnoCall![0];
-        rnoProps.onSubmit('test remark');
+        const fciCall = mockRemarkComponent.mock.calls.find(([props]) => props.actionName === 'Assign to FCI');
+        expect(fciCall).toBeDefined();
+        const fciProps = fciCall![0];
+        fciProps.onSubmit('test remark');
 
         await waitFor(() => {
             expect(defaultProps.updateTicketApiHandler).toHaveBeenCalled();
         });
 
         expect(mockUpdateTicket).toHaveBeenCalledWith('INC-1', expect.objectContaining({
-            assignedTo: 'rno',
             status: { statusId: '5' },
         }));
         expect(defaultProps.searchCurrentTicketsPaginatedApi).toHaveBeenCalledWith('INC-1');

--- a/ui/src/components/UI/IconButton/CustomIconButton.tsx
+++ b/ui/src/components/UI/IconButton/CustomIconButton.tsx
@@ -45,6 +45,7 @@ import RunningWithErrorsIcon from '@mui/icons-material/RunningWithErrors';
 import GradingIcon from '@mui/icons-material/Grading';
 import RateReviewIcon from '@mui/icons-material/RateReview';
 import { PauseCircleOutline, NorthEast, Moving, PersonAddAlt } from '@mui/icons-material';
+import UndoIcon from '@mui/icons-material/Undo';
 import WorkOutlineIcon from '@mui/icons-material/WorkOutline';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import LinkOffIcon from '@mui/icons-material/LinkOff';
@@ -102,6 +103,7 @@ const iconMap = {
     workOutline: WorkOutlineIcon,
     visibility: VisibilityIcon,
     linkOff: LinkOffIcon,
+    undo: UndoIcon,
 };
 
 // Valid keys for the icon map


### PR DESCRIPTION
## Summary
- replace the RNO advanced assignment tab with a dedicated "Assign to FCI" status action that only updates the ticket status
- stop fetching RNO users in the assignee dropdown and wire the new advanced dialog prop
- surface an Assign Back icon for On Hold (Pending with FCI) tickets and reuse it across the table along with the supporting undo icon and tests

## Testing
- CI=true npm test -- --runTestsByPath src/components/AllTickets/__tests__/AdvancedAssignmentOptionsDialog.test.tsx src/components/AllTickets/__tests__/AssigneeDropdown.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e647d1ed6883329f42bd7fb3f65589