### PR TITLE
Show actual usernames in recommended severity labels

### DIFF
--- a/ui/src/components/TicketView/TicketView.tsx
+++ b/ui/src/components/TicketView/TicketView.tsx
@@ -610,21 +610,12 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
       .catch(() => setHasFeedback(false));
   };
 
-  const youText = t('You');
   const pendingApprovalText = t('Pending Approval');
   const recommendedSeverityBy = ticket?.severityRecommendedBy;
-  const recommendedSeverityByText = recommendedSeverityBy
-    ? recommendedSeverityBy === currentUsername
-      ? youText
-      : recommendedSeverityBy
-    : ' - ';
+  const recommendedSeverityByText = recommendedSeverityBy || ' - ';
   const recommendedSeverityStatus = ticket?.recommendedSeverityStatus;
   const severityApprovedBy = ticket?.severityApprovedBy;
-  const severityApprovedByText = severityApprovedBy
-    ? severityApprovedBy === currentUsername
-      ? youText
-      : severityApprovedBy
-    : ' - ';
+  const severityApprovedByText = severityApprovedBy || ' - ';
   const recommendedSeverityApprovalText = recommendedSeverityStatus === 'APPROVED' && severityApprovedByText
     ? t('Approved by {{name}}', { name: severityApprovedByText })
     : pendingApprovalText;


### PR DESCRIPTION
## Summary
- ensure the recommended severity display uses the stored usernames instead of substituting "You"
- keep the approval message consistent by reusing the dynamic usernames for approvers

## Testing
- CI=true npm test -- TicketView

------
https://chatgpt.com/codex/tasks/task_e_68e64f0effa883328cc477c4dc18adb2