### PR TITLE
Show ticket resolution date in feedback workflows

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/dto/TicketFeedbackResponse.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/TicketFeedbackResponse.java
@@ -10,5 +10,6 @@ public record TicketFeedbackResponse(
         Integer timeliness,
         String comments,
         LocalDateTime submittedAt,
-        String submittedBy
+        String submittedBy,
+        LocalDateTime dateOfResolution
 ) {}

--- a/api/src/main/java/com/ticketingSystem/api/service/TicketFeedbackService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/TicketFeedbackService.java
@@ -90,7 +90,7 @@ public class TicketFeedbackService {
                 statusMasterRepository.findById(closedId).ifPresent(ticket::setStatus);
             }
             ticketRepository.save(ticket);
-            return toResponse(ticketId, saved);
+            return toResponse(ticket, saved);
         } catch (Exception ex) {
             throw new FeedbackSubmissionException(ticketId, ex);
         }
@@ -104,13 +104,14 @@ public class TicketFeedbackService {
         }
         TicketFeedback feedback = feedbackRepository.findByTicketId(ticketId)
                 .orElseThrow(() -> new FeedbackNotFoundException(ticketId));
-        return toResponse(ticketId, feedback);
+        return toResponse(ticket, feedback);
     }
 
-    private TicketFeedbackResponse toResponse(String ticketId, TicketFeedback feedback) {
-        return new TicketFeedbackResponse(ticketId, feedback.getOverallSatisfaction(),
+    private TicketFeedbackResponse toResponse(Ticket ticket, TicketFeedback feedback) {
+        return new TicketFeedbackResponse(ticket.getId(), feedback.getOverallSatisfaction(),
                 feedback.getResolutionEffectiveness(), feedback.getCommunicationSupport(),
-                feedback.getTimeliness(), feedback.getComments(), feedback.getSubmittedAt(), feedback.getSubmittedBy());
+                feedback.getTimeliness(), feedback.getComments(), feedback.getSubmittedAt(),
+                feedback.getSubmittedBy(), ticket.getResolvedAt());
     }
 
     private boolean isTicketOwner(String ticketUserId, String currentUserId) {

--- a/ui/src/services/FeedbackService.ts
+++ b/ui/src/services/FeedbackService.ts
@@ -10,6 +10,23 @@ export type SubmitFeedbackRequest = {
   comments?: string;
 };
 
+export type FeedbackFormResponse = {
+  ticketId: string;
+  dateOfResolution: string | null;
+};
+
+export type TicketFeedbackResponse = {
+  ticketId: string;
+  overallSatisfaction: number;
+  resolutionEffectiveness: number;
+  communicationSupport: number;
+  timeliness: number;
+  comments?: string | null;
+  submittedAt: string;
+  submittedBy: string;
+  dateOfResolution: string | null;
+};
+
 export function getFeedbackForm(ticketId: string) {
   return apiClient.get(`${BASE_URL}/tickets/${ticketId}/feedback/form`);
 }


### PR DESCRIPTION
## Summary
- include the ticket resolution timestamp in `TicketFeedbackResponse` so provided feedback can expose it
- load feedback form metadata in the customer feedback UI to populate and show the resolution date in both submission and view modes
- update feedback-related unit tests to cover the new data flow

## Testing
- CI=true npm test -- FeedbackModal --watchAll=false
- CI=true npm test -- CustomerSatisfactionForm --watchAll=false
- ./gradlew test --console=plain *(fails: Java 17 toolchain is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e64ea06f48833285df7e3cd7e5ec1c