### PR TITLE
Add recursive CustomMetricCard and integrate into SupportDashboard key metrics

### DIFF
--- a/ui/src/components/Dashboard/CustomMetricCard.tsx
+++ b/ui/src/components/Dashboard/CustomMetricCard.tsx
@@ -104,36 +104,36 @@ const CustomMetricCard = ({
   const visibleChildren = (children ?? []).filter((child) => child?.show !== false);
 
   return (
-    <Box sx={{ display: "flex", flexDirection: "column", gap: 1, width: "100%" }}>
-      <Card
-        className="h-100"
-        sx={{
-          borderRadius: 2,
-          border: `1px solid ${theme.palette.divider}`,
-          backgroundColor: resolveThemeColor(theme, backgroundColor, "background.paper"),
-          boxShadow: level === 0 ? theme.shadows[1] : "none",
-        }}
-      >
-        <CardContent className="py-3">
+    <Card
+      className="h-100"
+      sx={{
+        borderRadius: 2,
+        border: `1px solid ${theme.palette.divider}`,
+        backgroundColor: resolveThemeColor(theme, backgroundColor, "background.paper"),
+        boxShadow: level === 0 ? theme.shadows[1] : "none",
+      }}
+    >
+      <CardContent className="py-3" sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+        <Box>
           <MetricText config={title} fallback={defaultTextConfig.title} variant="subtitle2" className="fw-semibold text-uppercase mb-1" />
           <MetricText config={metricValue} fallback={defaultTextConfig.metricValue} variant="h5" className="fw-bold" />
           <MetricText config={subtitle} fallback={defaultTextConfig.subtitle} variant="body2" className="mt-1" />
-        </CardContent>
-      </Card>
-
-      {visibleChildren.length ? (
-        <Box className="d-flex flex-wrap" sx={{ gap: 1, alignItems: "stretch" }}>
-          {visibleChildren.map((child, index) => {
-            const leafCount = getLeafCount(child);
-            return (
-              <Box key={`${index}-${child?.title?.text ?? "metric-child"}`} sx={{ flex: `${leafCount} 1 0`, minWidth: 220 }}>
-                <CustomMetricCard {...child} level={level + 1} />
-              </Box>
-            );
-          })}
         </Box>
-      ) : null}
-    </Box>
+
+        {visibleChildren.length ? (
+          <Box className="d-flex flex-wrap" sx={{ gap: 1, alignItems: "stretch" }}>
+            {visibleChildren.map((child, index) => {
+              const leafCount = getLeafCount(child);
+              return (
+                <Box key={`${index}-${child?.title?.text ?? "metric-child"}`} sx={{ flex: `${leafCount} 1 0`, minWidth: 220 }}>
+                  <CustomMetricCard {...child} level={level + 1} />
+                </Box>
+              );
+            })}
+          </Box>
+        ) : null}
+      </CardContent>
+    </Card>
   );
 };
 

--- a/ui/src/components/Dashboard/CustomMetricCard.tsx
+++ b/ui/src/components/Dashboard/CustomMetricCard.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+import { Box, Card, CardContent, Typography } from "@mui/material";
+import { Theme, useTheme } from "@mui/material/styles";
+import { useTranslation } from "react-i18next";
+
+export interface MetricCardTextConfig {
+  attributes?: Record<string, unknown> | null;
+  text?: string | number | null;
+  textSize?: number | string | null;
+  textColor?: string | null;
+}
+
+export interface MetricCardData {
+  title?: MetricCardTextConfig | null;
+  subtitle?: MetricCardTextConfig | null;
+  metricValue?: MetricCardTextConfig | null;
+  backgroundColor?: string | null;
+  children?: MetricCardData[] | null;
+  show?: boolean | null;
+}
+
+interface CustomMetricCardProps extends MetricCardData {
+  level?: number;
+}
+
+const defaultTextConfig = {
+  title: {
+    text: "",
+    textSize: 12,
+    textColor: "text.secondary",
+  },
+  subtitle: {
+    text: "",
+    textSize: 12,
+    textColor: "text.secondary",
+  },
+  metricValue: {
+    text: "0",
+    textSize: 24,
+    textColor: "text.primary",
+  },
+};
+
+const resolveThemeColor = (theme: Theme, color?: string | null, fallback = "text.primary") => {
+  const key = color || fallback;
+
+  if (key.includes(".")) {
+    const [group, shade] = key.split(".");
+    const paletteGroup = (theme.palette as any)[group];
+    if (paletteGroup && paletteGroup[shade]) return paletteGroup[shade];
+  }
+
+  const textPalette = (theme.palette as any).text;
+  if (textPalette && textPalette[key]) return textPalette[key];
+
+  return key;
+};
+
+const getLeafCount = (node?: MetricCardData | null): number => {
+  if (!node?.children?.length) return 1;
+  return node.children.reduce((sum, child) => sum + getLeafCount(child), 0);
+};
+
+const MetricText: React.FC<{
+  config: MetricCardTextConfig | null | undefined;
+  fallback: MetricCardTextConfig;
+  variant: "subtitle2" | "body2" | "h5";
+  className?: string;
+}> = ({ config, fallback, variant, className }) => {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const merged = { ...fallback, ...(config ?? {}) };
+
+  return (
+    <Typography
+      variant={variant}
+      className={className}
+      sx={{
+        fontSize: merged.textSize || fallback.textSize,
+        color: resolveThemeColor(theme, merged.textColor, fallback.textColor),
+      }}
+      {...((merged.attributes ?? {}) as object)}
+    >
+      {merged.text == null || merged.text === "" ? "" : t(String(merged.text), { defaultValue: String(merged.text) })}
+    </Typography>
+  );
+};
+
+const CustomMetricCard = ({
+  title,
+  subtitle,
+  metricValue,
+  backgroundColor,
+  children,
+  show,
+  level = 0,
+}: CustomMetricCardProps) => {
+  const theme = useTheme();
+
+  if (show === false) {
+    return null;
+  }
+
+  const visibleChildren = (children ?? []).filter((child) => child?.show !== false);
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 1, width: "100%" }}>
+      <Card
+        className="h-100"
+        sx={{
+          borderRadius: 2,
+          border: `1px solid ${theme.palette.divider}`,
+          backgroundColor: resolveThemeColor(theme, backgroundColor, "background.paper"),
+          boxShadow: level === 0 ? theme.shadows[1] : "none",
+        }}
+      >
+        <CardContent className="py-3">
+          <MetricText config={title} fallback={defaultTextConfig.title} variant="subtitle2" className="fw-semibold text-uppercase mb-1" />
+          <MetricText config={metricValue} fallback={defaultTextConfig.metricValue} variant="h5" className="fw-bold" />
+          <MetricText config={subtitle} fallback={defaultTextConfig.subtitle} variant="body2" className="mt-1" />
+        </CardContent>
+      </Card>
+
+      {visibleChildren.length ? (
+        <Box className="d-flex flex-wrap" sx={{ gap: 1, alignItems: "stretch" }}>
+          {visibleChildren.map((child, index) => {
+            const leafCount = getLeafCount(child);
+            return (
+              <Box key={`${index}-${child?.title?.text ?? "metric-child"}`} sx={{ flex: `${leafCount} 1 0`, minWidth: 220 }}>
+                <CustomMetricCard {...child} level={level + 1} />
+              </Box>
+            );
+          })}
+        </Box>
+      ) : null}
+    </Box>
+  );
+};
+
+export default CustomMetricCard;

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -326,7 +326,22 @@
       "ticketsPerMonth": "Tickets Created Per Month",
       "tickets": "Tickets",
       "overallTickets": "Overall Tickets",
-      "helpdeskOverview": "Anna Darpan Helpdesk Overview"
+      "helpdeskOverview": "Anna Darpan Helpdesk Overview",
+      "totalTicketsRaised": "Total Tickets Raised",
+      "loggedInUser": "Logged in user",
+      "unacknowledged": "Unacknowledged",
+      "acknowledged": "Acknowledged",
+      "open": "Open",
+      "reOpened": "Re-opened",
+      "assigned": "Assigned",
+      "pending": "Pending",
+      "withRequester": "With Requester",
+      "withFci": "With FCI",
+      "withVendor": "With Vendor",
+      "resolved": "Resolved",
+      "pendingForFeedback": "Pending for Feedback",
+      "feedbackSubmitted": "Feedback Submitted",
+      "closed": "Closed"
     }
   },
   "global": {

--- a/ui/src/locales/hi/translation.json
+++ b/ui/src/locales/hi/translation.json
@@ -318,7 +318,22 @@
       "ticketsPerMonth": "प्रति माह बनाए गए टिकट",
       "tickets": "टिकट",
       "overallTickets": "कुल टिकट",
-      "helpdeskOverview": "अन्ना दर्पण हेल्पडेस्क अवलोकन"
+      "helpdeskOverview": "अन्ना दर्पण हेल्पडेस्क अवलोकन",
+      "totalTicketsRaised": "कुल उठाए गए टिकट",
+      "loggedInUser": "लॉग-इन उपयोगकर्ता",
+      "unacknowledged": "अस्वीकृत",
+      "acknowledged": "स्वीकृत",
+      "open": "खुला",
+      "reOpened": "पुनः खोला गया",
+      "assigned": "असाइन किया गया",
+      "pending": "लंबित",
+      "withRequester": "अनुरोधकर्ता के साथ",
+      "withFci": "एफसीआई के साथ",
+      "withVendor": "विक्रेता के साथ",
+      "resolved": "समाधान किया गया",
+      "pendingForFeedback": "प्रतिक्रिया हेतु लंबित",
+      "feedbackSubmitted": "प्रतिक्रिया सबमिट की गई",
+      "closed": "बंद"
     }
   },
   "global": {


### PR DESCRIPTION
### Motivation

- Provide a reusable metric card component to display hierarchical ticket metrics (matching the sunburst grouping) with per-card visibility controlled by permissions. 
- Make metric presentation theme-aware, translatable, and robust to nullable/absent values so dashboard key metrics can be composed from the existing summary payload.

### Description

- Added a new component `CustomMetricCard` that accepts nullable props for `title`, `subtitle`, `metricValue`, `backgroundColor`, `children`, and `show`, supports text objects (`attributes`, `text`, `textSize`, `textColor`) with defaults, resolves theme palette tokens, and renders recursively for nested children (`ui/src/components/Dashboard/CustomMetricCard.tsx`).
- Integrated the metric card into `SupportDashboard` and built a hierarchical `ticketMetricsCardData` object (Unacknowledged / Acknowledged → deeper children) derived from the same status counts used by the sunburst chart, with top-level visibility gated by the permission path `dashboard.keyMetrics.totalTicketsRaisedCard` (`ui/src/pages/SupportDashboard.tsx`).
- Implemented proportional child width allocation based on subtree leaf count so sibling cards expand according to their nested content, and added border, radius and background styling that uses theme tokens for dark/light themes.
- Added English and Hindi translation keys for all new metric labels used by the component in `ui/src/locales/en/translation.json` and `ui/src/locales/hi/translation.json`.

### Testing

- Ran JSON validation on translations with `python -m json.tool ui/src/locales/en/translation.json` and `python -m json.tool ui/src/locales/hi/translation.json`, and both checks passed.
- Attempted to build the UI with `cd ui && npm run -s build`, which failed in this environment due to missing `react-scripts`.
- Attempted dependency installation with `cd ui && npm ci`, which failed due to a dependency resolution conflict (`i18next@25.x` peer-optional `typescript@^5` vs project `typescript@4.9.5`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2eeedd5f48332ba62635b313c867a)