### PR TITLE
Show disabled Sub Module/Region/District filters on All Tickets

### DIFF
--- a/ui/src/components/AllTickets/TicketsList.tsx
+++ b/ui/src/components/AllTickets/TicketsList.tsx
@@ -648,15 +648,14 @@ const TicketsList: React.FC<TicketsListProps> = ({
                     />
 
                     {/* SUBCATEGORY DROPDOWN FILTER */}
-                    {selectedCategory !== "All"
-                        ? <DropdownController
-                            label="Sub Module"
-                            value={selectedSubCategory}
-                            className="col-3 ps-1"
-                            onChange={handleSubCategoryChange}
-                            options={subCategoryOptions}
-                        />
-                        : <div className="d-flex col-3"></div>}
+                    <DropdownController
+                        label="Sub Module"
+                        value={selectedSubCategory}
+                        className="col-3 ps-1"
+                        onChange={handleSubCategoryChange}
+                        options={subCategoryOptions}
+                        disabled={selectedCategory === "All"}
+                    />
 
                     <DropdownController
                         label="Zone"
@@ -666,25 +665,23 @@ const TicketsList: React.FC<TicketsListProps> = ({
                         options={zoneOptions}
                     />
 
-                    {selectedZone !== "All"
-                        ? <DropdownController
-                            label="Region"
-                            value={selectedRegion}
-                            className="col-3 px-1"
-                            onChange={handleRegionChange}
-                            options={regionOptions}
-                        />
-                        : <div className="d-flex col-3"></div>}
+                    <DropdownController
+                        label="Region"
+                        value={selectedRegion}
+                        className="col-3 px-1"
+                        onChange={handleRegionChange}
+                        options={regionOptions}
+                        disabled={selectedZone === "All"}
+                    />
 
-                    {selectedRegion !== "All"
-                        ? <DropdownController
-                            label="District"
-                            value={selectedDistrict}
-                            className="col-3 px-1"
-                            onChange={handleDistrictChange}
-                            options={districtOptions}
-                        />
-                        : <div className="d-flex col-3"></div>}
+                    <DropdownController
+                        label="District"
+                        value={selectedDistrict}
+                        className="col-3 px-1"
+                        onChange={handleDistrictChange}
+                        options={districtOptions}
+                        disabled={selectedRegion === "All"}
+                    />
 
                     <DropdownController
                         label="Issue Type"


### PR DESCRIPTION
### Motivation
- Improve UX by always showing the location and submodule filter controls so the filter row layout is stable and discoverable. 
- Preserve existing filtering logic by preventing interaction when a higher-level selection makes the control inapplicable.

### Description
- Replaced conditional rendering of the Sub Module, Region, and District filters in `ui/src/components/AllTickets/TicketsList.tsx` with always-rendered `DropdownController` components. 
- Added `disabled` props that retain previous visibility logic: Sub Module disabled when `selectedCategory === "All"`, Region disabled when `selectedZone === "All"`, and District disabled when `selectedRegion === "All"`.
- Removed placeholder empty column `div`s that were previously rendered when those filters were hidden, while leaving `value`, `onChange`, and `options` wiring unchanged.

### Testing
- Attempted to build the UI with `npm run build` in `ui/`, and the build failed due to a missing module: `Module not found: Can't resolve 'react-i18next'`.
- Attempted `npm install` in `ui/` to fix dependencies, which failed due to a dependency resolution conflict between `i18next` and the project's `typescript` version (peer requirement for TypeScript `^5`).
- No frontend unit tests were run in this environment because dependency resolution and build issues prevented a successful build or test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a35c9df06483328b00b6f5da61306d)