### PR TITLE
Add Division master, history, and UI dropdown for tickets

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/controller/DivisionController.java
+++ b/api/src/main/java/com/ticketingSystem/api/controller/DivisionController.java
@@ -1,0 +1,39 @@
+package com.ticketingSystem.api.controller;
+
+import com.ticketingSystem.api.dto.DivisionDto;
+import com.ticketingSystem.api.models.DivisionMaster;
+import com.ticketingSystem.api.service.DivisionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/divisions")
+@CrossOrigin(origins = "http://localhost:3000")
+@RequiredArgsConstructor
+public class DivisionController {
+    private final DivisionService divisionService;
+
+    @GetMapping
+    public ResponseEntity<List<DivisionDto>> getDivisions() {
+        List<DivisionDto> divisions = divisionService.getAllActive().stream()
+                .map(this::toDto)
+                .toList();
+        return ResponseEntity.ok(divisions);
+    }
+
+    private DivisionDto toDto(DivisionMaster division) {
+        DivisionDto dto = new DivisionDto();
+        dto.setDivisionId(division.getDivisionId());
+        dto.setDivisionName(division.getDivisionName());
+        dto.setDivisionCode(division.getDivisionCode());
+        dto.setDescription(division.getDescription());
+        dto.setIsActive(division.getIsActive());
+        return dto;
+    }
+}

--- a/api/src/main/java/com/ticketingSystem/api/dto/DivisionDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/DivisionDto.java
@@ -1,0 +1,14 @@
+package com.ticketingSystem.api.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DivisionDto {
+    private String divisionId;
+    private String divisionName;
+    private String divisionCode;
+    private String description;
+    private String isActive;
+}

--- a/api/src/main/java/com/ticketingSystem/api/dto/TicketDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/TicketDto.java
@@ -41,6 +41,8 @@ public class TicketDto {
     private String issueTypeLabel;
     private String priority;
     private String priorityId;
+    private String division;
+    private String divisionName;
     private String severity;
     private String severityId;
     private String severityLabel;

--- a/api/src/main/java/com/ticketingSystem/api/mapper/DtoMapper.java
+++ b/api/src/main/java/com/ticketingSystem/api/mapper/DtoMapper.java
@@ -123,6 +123,7 @@ public class DtoMapper {
         }
         dto.setPriority(ticket.getPriority());
         dto.setPriorityId(ticket.getPriority());
+        dto.setDivision(ticket.getDivision());
         dto.setSeverity(ticket.getSeverity());
         dto.setSeverityId(ticket.getSeverity());
         dto.setSeverityLabel(ticket.getSeverity());

--- a/api/src/main/java/com/ticketingSystem/api/models/DivisionHistory.java
+++ b/api/src/main/java/com/ticketingSystem/api/models/DivisionHistory.java
@@ -1,0 +1,37 @@
+package com.ticketingSystem.api.models;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "division_history")
+@Getter
+@Setter
+public class DivisionHistory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "division_history_id")
+    private String id;
+
+    @ManyToOne
+    @JoinColumn(name = "ticket_id", referencedColumnName = "ticket_id")
+    private Ticket ticket;
+
+    @Column(name = "updated_by")
+    private String updatedBy;
+
+    @Column(name = "previous_division")
+    private String previousDivision;
+
+    @Column(name = "current_division")
+    private String currentDivision;
+
+    @Column(name = "timestamp")
+    private LocalDateTime timestamp;
+
+    @Column(name = "remark")
+    private String remark;
+}

--- a/api/src/main/java/com/ticketingSystem/api/models/DivisionMaster.java
+++ b/api/src/main/java/com/ticketingSystem/api/models/DivisionMaster.java
@@ -1,0 +1,44 @@
+package com.ticketingSystem.api.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "division_master")
+@Getter
+@Setter
+public class DivisionMaster {
+
+    @Id
+    @Column(name = "division_id")
+    private String divisionId;
+
+    @Column(name = "division_name")
+    private String divisionName;
+
+    @Column(name = "division_code")
+    private String divisionCode;
+
+    private String description;
+
+    @Column(name = "created_on")
+    private LocalDateTime createdOn;
+
+    @Column(name = "created_by")
+    private String createdBy;
+
+    @Column(name = "updated_on")
+    private LocalDateTime updatedOn;
+
+    @Column(name = "updated_by")
+    private String updatedBy;
+
+    @Column(name = "is_active")
+    private String isActive;
+}

--- a/api/src/main/java/com/ticketingSystem/api/models/Ticket.java
+++ b/api/src/main/java/com/ticketingSystem/api/models/Ticket.java
@@ -65,6 +65,8 @@ public class Ticket {
     @JoinColumn(name = "issue_type_id", referencedColumnName = "issue_type_id", insertable = false, updatable = false)
     private IssueType issueType;
     private String priority;
+    @Column(name = "division")
+    private String division;
     private String severity;
     @Column(name = "recommended_severity")
     private String recommendedSeverity;

--- a/api/src/main/java/com/ticketingSystem/api/repository/DivisionHistoryRepository.java
+++ b/api/src/main/java/com/ticketingSystem/api/repository/DivisionHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.ticketingSystem.api.repository;
+
+import com.ticketingSystem.api.models.DivisionHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DivisionHistoryRepository extends JpaRepository<DivisionHistory, String> {
+}

--- a/api/src/main/java/com/ticketingSystem/api/repository/DivisionMasterRepository.java
+++ b/api/src/main/java/com/ticketingSystem/api/repository/DivisionMasterRepository.java
@@ -1,0 +1,10 @@
+package com.ticketingSystem.api.repository;
+
+import com.ticketingSystem.api.models.DivisionMaster;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DivisionMasterRepository extends JpaRepository<DivisionMaster, String> {
+    List<DivisionMaster> findByIsActive(String isActive);
+}

--- a/api/src/main/java/com/ticketingSystem/api/service/DivisionHistoryService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/DivisionHistoryService.java
@@ -1,0 +1,31 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.exception.TicketNotFoundException;
+import com.ticketingSystem.api.models.DivisionHistory;
+import com.ticketingSystem.api.models.Ticket;
+import com.ticketingSystem.api.repository.DivisionHistoryRepository;
+import com.ticketingSystem.api.repository.TicketRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class DivisionHistoryService {
+    private final DivisionHistoryRepository divisionHistoryRepository;
+    private final TicketRepository ticketRepository;
+
+    public DivisionHistory addHistory(String ticketId, String updatedBy, String previousDivision, String currentDivision, String remark) {
+        Ticket ticket = ticketRepository.findById(ticketId)
+                .orElseThrow(() -> new TicketNotFoundException(ticketId));
+        DivisionHistory history = new DivisionHistory();
+        history.setTicket(ticket);
+        history.setUpdatedBy(updatedBy);
+        history.setPreviousDivision(previousDivision);
+        history.setCurrentDivision(currentDivision);
+        history.setRemark(remark);
+        history.setTimestamp(LocalDateTime.now());
+        return divisionHistoryRepository.save(history);
+    }
+}

--- a/api/src/main/java/com/ticketingSystem/api/service/DivisionService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/DivisionService.java
@@ -1,0 +1,20 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.models.DivisionMaster;
+import com.ticketingSystem.api.repository.DivisionMasterRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DivisionService {
+    private static final String ACTIVE_FLAG = "1";
+
+    private final DivisionMasterRepository divisionMasterRepository;
+
+    public List<DivisionMaster> getAllActive() {
+        return divisionMasterRepository.findByIsActive(ACTIVE_FLAG);
+    }
+}

--- a/api/src/main/java/com/ticketingSystem/api/service/TicketService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/TicketService.java
@@ -23,6 +23,7 @@ import com.ticketingSystem.api.repository.RecommendedSeverityFlowRepository;
 import com.ticketingSystem.api.repository.RoleRepository;
 import com.ticketingSystem.api.repository.RegionMasterRepository;
 import com.ticketingSystem.api.repository.DistrictMasterRepository;
+import com.ticketingSystem.api.repository.DivisionMasterRepository;
 import com.ticketingSystem.api.enums.Mode;
 import com.ticketingSystem.api.enums.TicketStatus;
 import com.ticketingSystem.api.enums.FeedbackStatus;
@@ -88,6 +89,8 @@ public class TicketService {
     private final RoleRepository roleRepository;
     private final RegionMasterRepository regionMasterRepository;
     private final DistrictMasterRepository districtMasterRepository;
+    private final DivisionMasterRepository divisionMasterRepository;
+    private final DivisionHistoryService divisionHistoryService;
     private final TicketSlaService ticketSlaService;
     private final RecommendedSeverityFlowRepository recommendedSeverityFlowRepository;
     private final TicketIdGenerator ticketIdGenerator;
@@ -117,6 +120,12 @@ public class TicketService {
                     .ifPresent(issueType -> dto.setIssueTypeLabel(issueType.getIssueTypeLabel()));
         }
         if (ticket.getCreatedBy() != null) dto.setCreatedBy(ticket.getCreatedBy());
+
+        if (ticket.getDivision() != null) {
+            dto.setDivision(ticket.getDivision());
+            divisionMasterRepository.findById(ticket.getDivision())
+                    .ifPresent(division -> dto.setDivisionName(division.getDivisionName()));
+        }
 
         // priority info
         if (ticket.getPriority() != null) {
@@ -353,6 +362,10 @@ public class TicketService {
         boolean sla = workflowService.getSlaFlagByStatusAndIssueType(openId, saved.getIssueTypeId());
 
         List<StatusHistory> histories = new ArrayList<>();
+
+        if (saved.getDivision() != null && !saved.getDivision().isBlank()) {
+            divisionHistoryService.addHistory(saved.getId(), saved.getUpdatedBy(), null, saved.getDivision(), "New");
+        }
 
         // ADDING TICKET IN STATUS HISTORY
         histories.add(statusHistoryService.addHistory(saved.getId(), saved.getUpdatedBy(), null, openId, sla, "New"));
@@ -657,6 +670,7 @@ public class TicketService {
         String previousRecommendedSeverity = existing.getRecommendedSeverity();
         String previousRecommendedBy = existing.getSeverityRecommendedBy();
         String previousAssignedTo = existing.getAssignedTo();
+        String previousDivision = existing.getDivision();
         TicketStatus previousStatus = existing.getTicketStatus();
         Status previousStatusEntity = existing.getStatus();
         String previousStatusId = existing.getStatus() != null ? existing.getStatus().getStatusId()
@@ -711,6 +725,7 @@ public class TicketService {
         }
         if (updated.getIssueTypeId() != null) existing.setIssueTypeId(updated.getIssueTypeId());
         if (updated.getPriority() != null) existing.setPriority(updated.getPriority());
+        if (updated.getDivision() != null) existing.setDivision(updated.getDivision());
         if (updated.getSeverity() != null) existing.setSeverity(updated.getSeverity());
         if (updated.getRecommendedSeverity() != null) existing.setRecommendedSeverity(updated.getRecommendedSeverity());
         if (updated.getImpact() != null) existing.setImpact(updated.getImpact());
@@ -768,6 +783,9 @@ public class TicketService {
         existing.setLastModified(LocalDateTime.now());
         Ticket saved = ticketRepository.save(existing);
         String updatedBy = updated.getUpdatedBy() != null ? updated.getUpdatedBy() : existing.getUpdatedBy();
+        if (updated.getDivision() != null && !Objects.equals(previousDivision, saved.getDivision())) {
+            divisionHistoryService.addHistory(id, updatedBy, previousDivision, saved.getDivision(), remark);
+        }
         if (assignmentChanged) {
             assignmentHistoryService.addHistory(id,
                     updated.getAssignedBy() != null ? updated.getAssignedBy() : updatedBy,

--- a/db/queries/add_division_master_and_history.sql
+++ b/db/queries/add_division_master_and_history.sql
@@ -1,0 +1,51 @@
+-- 1) Division master table
+CREATE TABLE IF NOT EXISTS division_master (
+    division_id VARCHAR(20) PRIMARY KEY,
+    division_name VARCHAR(255) NOT NULL,
+    division_code VARCHAR(50),
+    description VARCHAR(500),
+    created_on TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_by VARCHAR(100),
+    updated_on TIMESTAMP NULL,
+    updated_by VARCHAR(100),
+    is_active CHAR(1) DEFAULT '1'
+);
+
+-- Seed active divisions
+INSERT INTO division_master (division_id, division_name, division_code, description, created_by, is_active)
+VALUES
+('DIV-001', 'Procurement Division', 'PROC', 'Procurement Division', 'SYSTEM', '1'),
+('DIV-002', 'Storage Division', 'STRG', 'Storage Division', 'SYSTEM', '1'),
+('DIV-003', 'Movement Division', 'MOVE', 'Movement Division', 'SYSTEM', '1'),
+('DIV-004', 'Quality Division', 'QUAL', 'Quality Division', 'SYSTEM', '1'),
+('DIV-005', 'Stocks/PV Division', 'STPV', 'Stocks/PV Division', 'SYSTEM', '1'),
+('DIV-006', 'Sales Division', 'SALE', 'Sales Division', 'SYSTEM', '1'),
+('DIV-007', 'Import & Export Division', 'IMEX', 'Import & Export Division', 'SYSTEM', '1'),
+('DIV-008', 'IT Division', 'IT', 'IT Division', 'SYSTEM', '1'),
+('DIV-009', 'General/House Keeping Division', 'GENHK', 'General/House Keeping Division', 'SYSTEM', '1'),
+('DIV-010', 'Contract Division', 'CONT', 'Contract Division', 'SYSTEM', '1'),
+('DIV-011', 'IRL Division', 'IRL', 'IRL Division', 'SYSTEM', '1'),
+('DIV-012', 'Engineering & Maintenance (Civil & Mechanical)', 'ENMCM', 'Engineering & Maintenance (Civil & Mechanical)', 'SYSTEM', '1')
+ON CONFLICT (division_id) DO NOTHING;
+
+-- 2) Add division column to tickets
+ALTER TABLE tickets
+    ADD COLUMN IF NOT EXISTS division VARCHAR(20);
+
+-- Optional FK for data integrity
+ALTER TABLE tickets
+    ADD CONSTRAINT fk_tickets_division
+    FOREIGN KEY (division)
+    REFERENCES division_master(division_id);
+
+-- 3) Division history table
+CREATE TABLE IF NOT EXISTS division_history (
+    division_history_id VARCHAR(36) PRIMARY KEY,
+    ticket_id VARCHAR(255) NOT NULL,
+    updated_by VARCHAR(100),
+    previous_division VARCHAR(20),
+    current_division VARCHAR(20),
+    timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    remark VARCHAR(255),
+    CONSTRAINT fk_division_history_ticket FOREIGN KEY (ticket_id) REFERENCES tickets(ticket_id)
+);

--- a/ui/src/components/RaiseTicket/TicketDetails.tsx
+++ b/ui/src/components/RaiseTicket/TicketDetails.tsx
@@ -16,6 +16,7 @@ import { checkFieldAccess } from "../../utils/permissions";
 import { getPriorities } from "../../services/PriorityService";
 import { getSeverities } from "../../services/SeverityService";
 import { getIssueTypes } from "../../services/IssueTypeService";
+import { getDivisions } from "../../services/DivisionService";
 import InfoIcon from "../UI/Icons/InfoIcon";
 import { IssueTypeInfo, PriorityInfo, SeverityInfo } from "../../types";
 import FileUpload from "../UI/FileUpload";
@@ -47,6 +48,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
     const { data: priorityList, apiHandler: getPriorityApiHandler } = useApi<any>();
     const { data: severityList, apiHandler: getSeverityApiHandler } = useApi<any>();
     const { data: issueTypeList, apiHandler: getIssueTypeApiHandler } = useApi<any>();
+    const { data: divisionList, apiHandler: getDivisionApiHandler } = useApi<any>();
 
     // USESTATE INITIALIZATIONS
     const [assignFurther, setAssignFurther] = useState<boolean>(false);
@@ -69,6 +71,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
     const priorityOptions: DropdownOption[] = Array.isArray(priorityList) ? priorityList.map((p: PriorityInfo) => ({ label: p.level, value: p.id })) : [];
     const severityOptions: DropdownOption[] = Array.isArray(severityList) ? severityList.map((s: SeverityInfo) => ({ label: s.level, value: s.level })) : [];
     const issueTypeOptions: DropdownOption[] = getDropdownOptions(issueTypeList, 'issueTypeLabel', 'issueTypeId');
+    const divisionOptions: DropdownOption[] = getDropdownOptions(divisionList, 'divisionName', 'divisionId');
 
     const priorityContent = Array.isArray(priorityList) ? (
         <div>
@@ -104,6 +107,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
     let showCategory = checkFieldAccess('ticketDetails', 'category');
     let showSubCategory = checkFieldAccess('ticketDetails', 'subCategory');
     let showIssueType = checkFieldAccess('ticketDetails', 'issueType');
+    let showDivision = checkFieldAccess('ticketDetails', 'division');
     let showPriority = checkFieldAccess('ticketDetails', 'priority');
     let showSeverityFields = checkFieldAccess('ticketDetails', 'severity');
     let showSeverity = checkFieldAccess('ticketDetails', 'severity');
@@ -145,6 +149,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
         getPriorityApiHandler(() => getPriorities())
         getSeverityApiHandler(() => getSeverities())
         getIssueTypeApiHandler(() => getIssueTypes())
+        getDivisionApiHandler(() => getDivisions())
     }, [])
 
     useEffect(() => {
@@ -160,6 +165,7 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
             register('assignedBy', { value: getCurrentUserDetails()?.username || 'john.doe' });
             register('updatedBy', { value: getCurrentUserDetails()?.username || 'john.doe' });
             register('attachments');
+            register('division');
         }
     }, [register]);
 
@@ -219,6 +225,20 @@ const TicketDetails: React.FC<TicketDetailsProps> = ({ register, control, setVal
                             disabled={disableAll || !category}
                             rules={{ required: 'Please select Sub Module' }}
                         />
+                    </div>
+                )}
+                {showDivision && (
+                    <div className="col-md-6">
+                        <GenericDropdownController
+                            name="division"
+                            control={control}
+                            label="Division"
+                            options={divisionOptions}
+                            className="form-select"
+                            disabled={disableAll}
+                            rules={{ required: 'Please select Division' }}
+                        />
+                        <small className="text-muted">Select the Division to whom this Issue Pertains for easy Tracking</small>
                     </div>
                 )}
                 {showIssueType && (

--- a/ui/src/components/TicketView/TicketView.tsx
+++ b/ui/src/components/TicketView/TicketView.tsx
@@ -9,6 +9,7 @@ import { getCurrentUserDetails } from '../../config/config';
 import { getPriorities } from '../../services/PriorityService';
 import { getSeverities } from '../../services/SeverityService';
 import { getIssueTypes } from '../../services/IssueTypeService';
+import { getDivisions } from '../../services/DivisionService';
 import InfoIcon from '../UI/Icons/InfoIcon';
 import GenericButton from '../UI/Button';
 import { PriorityInfo, SeverityInfo, TicketSla, TicketStatusWorkflow, RootCauseAnalysis } from '../../types';
@@ -129,10 +130,12 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
   const [severity, setSeverity] = useState('');
   const [recommendedSeverity, setRecommendedSeverity] = useState('');
   const [issueTypeId, setIssueTypeId] = useState('');
+  const [divisionId, setDivisionId] = useState('');
   const [priorityOptions, setPriorityOptions] = useState<string[]>([]);
   const [priorityDetails, setPriorityDetails] = useState<PriorityInfo[]>([]);
   const [severityList, setSeverityList] = useState<SeverityInfo[]>([]);
   const [issueTypeOptions, setIssueTypeOptions] = useState<DropdownOption[]>([]);
+  const [divisionOptions, setDivisionOptions] = useState<DropdownOption[]>([]);
   const [categoryOptions, setCategoryOptions] = useState<DropdownOption[]>([]);
   const [subCategoryOptions, setSubCategoryOptions] = useState<DropdownOption[]>([]);
   const [selectedCategoryId, setSelectedCategoryId] = useState('');
@@ -412,6 +415,8 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
   const allowSubcategoryEdit = checkAccessMaster(['ticketView', 'subcategory', 'allowEdit'])
   const allowSeverityEdit = checkAccessMaster(['ticketView', 'severity', 'allowEdit'])
   const showIssueType = checkAccessMaster(['ticketView', 'issueType'])
+  const showDivision = checkAccessMaster(['ticketView', 'division'])
+  const allowDivisionEdit = checkAccessMaster(['ticketView', 'division', 'allowEdit'])
   const showSla = checkAccessMaster(['ticketView', 'sla'])
   const showComments = checkAccessMaster(['ticketView', 'comments'])
 
@@ -478,6 +483,10 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
         const issueTypeData = Array.isArray(res?.data) ? res.data : [];
         setIssueTypeOptions(getDropdownOptions(issueTypeData, 'issueTypeLabel', 'issueTypeId'));
       });
+      getDivisions().then(res => {
+        const divisionData = Array.isArray(res?.data) ? res.data : [];
+        setDivisionOptions(getDropdownOptions(divisionData, 'divisionName', 'divisionId'));
+      });
       getCategories()
         .then(res => {
           const rawPayload = res?.data ?? res;
@@ -532,6 +541,7 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
       setSeverity(ticket.severity || '');
       setRecommendedSeverity(ticket.recommendedSeverity || '');
       setIssueTypeId(ticket.issueTypeId || '');
+      setDivisionId(ticket.division || '');
       setSelectedCategoryId('');
       setSelectedSubCategoryId('');
       setSubCategoryOptions([]);
@@ -613,6 +623,9 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
     if (issueTypeId) {
       payload.issueTypeId = issueTypeId;
     }
+    if (divisionId) {
+      payload.division = divisionId;
+    }
     if (selectedCategoryId) {
       payload.category = selectedCategoryId;
     }
@@ -675,6 +688,7 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
       setSeverity(ticket.severity || '');
       setRecommendedSeverity(ticket.recommendedSeverity || '');
       setIssueTypeId(ticket.issueTypeId || '');
+      setDivisionId(ticket.division || '');
     }
   };
 
@@ -1221,6 +1235,15 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
 
         {/* PRIORITY, SEVERITY */}
         <div className="col-7 mt-4" style={{ minWidth: 'max-content' }}>
+          {showDivision && <Box sx={{ display: 'flex', gap: 1, alignItems: 'baseline' }}>
+            <Typography color="text.secondary">{t('Division')}</Typography>
+            {renderSelect(divisionId, setDivisionId, divisionOptions, {
+              displayValue: ticket?.divisionName || ticket?.division,
+              translate: false,
+              disabled: !divisionOptions.length,
+              editing: allowDivisionEdit && editing,
+            })}
+          </Box>}
           {showIssueType && (
             <Box sx={{ display: 'flex', gap: 1, alignItems: 'baseline' }}>
               <Typography color="text.secondary">{t('Issue Type')}</Typography>

--- a/ui/src/pages/RaiseTicket.tsx
+++ b/ui/src/pages/RaiseTicket.tsx
@@ -128,6 +128,7 @@ const RaiseTicket: React.FC<any> = () => {
         resetField('category');
         resetField('subCategory');
         resetField('issueTypeId');
+        resetField('division');
         resetField('priority');
         resetField('severity');
         resetField('impact');

--- a/ui/src/services/DivisionService.ts
+++ b/ui/src/services/DivisionService.ts
@@ -1,0 +1,20 @@
+import axios, { AxiosResponse } from 'axios';
+import { BASE_URL } from './api';
+import { DivisionInfo } from '../types';
+
+const normalizeDivisionData = (data: any): DivisionInfo[] => {
+    if (Array.isArray(data)) {
+        return data as DivisionInfo[];
+    }
+    if (Array.isArray(data?.body?.data)) {
+        return data.body.data as DivisionInfo[];
+    }
+    return [];
+};
+
+export function getDivisions() {
+    return axios.get(`${BASE_URL}/divisions`).then((res: AxiosResponse<any>) => ({
+        ...res,
+        data: normalizeDivisionData(res.data),
+    }) as AxiosResponse<DivisionInfo[]>);
+}

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -53,6 +53,8 @@ export interface Ticket {
     subCategory: string;
     issueTypeId?: string;
     issueTypeLabel?: string;
+    division?: string;
+    divisionName?: string;
     priority: string;
     priorityId?: string;
     isMaster: boolean;
@@ -159,4 +161,13 @@ export interface PermissionNode {
         name?: string;
     };
     children?: { [key: string]: PermissionNode } | null;
+}
+
+
+export interface DivisionInfo {
+    divisionId: string;
+    divisionName: string;
+    divisionCode?: string;
+    description?: string;
+    isActive?: string;
 }


### PR DESCRIPTION
### Motivation
- Provide a mandatory `Division` field on the Raise Ticket form and add view/edit support on View Ticket so tickets can be tracked by division. 
- Persist divisions in a dedicated master table and maintain change history similar to existing `status_history` tracking.
- Expose an API to return active divisions for the UI and wire ticket create/update flows to record division history.

### Description
- Database: added `db/queries/add_division_master_and_history.sql` which creates `division_master` (seeded `DIV-001`..`DIV-012`), alters `tickets` to add `division`, and creates `division_history`.
- Backend model/API: added `DivisionMaster` and `DivisionHistory` entities, `DivisionDto`, `DivisionMasterRepository`, `DivisionHistoryRepository`, `DivisionService`, `DivisionHistoryService`, and `DivisionController` with a `GET /divisions` endpoint that returns active divisions.
- Ticket integration: added `division` field to `Ticket` and `TicketDto`, updated `DtoMapper` to populate `division`/`divisionName`, and updated `TicketService` to record a `division_history` row on ticket creation (if division provided) and when `division` changes on ticket update.
- UI: added `ui/src/services/DivisionService.ts` and `DivisionInfo` type, added a mandatory `Division` dropdown to the Raise Ticket form (with the helper text "Select the Division to whom this Issue Pertains for easy Tracking"), wired the dropdown options to `GET /divisions` via `useApi` and `getDropdownOptions`, registered `division` in the form payload, and added Division display/edit and permission-gated edit behavior in TicketView so updates send `division` in the update payload.

### Testing
- Ran `./gradlew compileJava` for backend compile verification, which failed in this environment with `Unsupported class file major version 69` (local Java/Gradle incompatibility), so compile could not be validated here (failed).
- Ran frontend build `npm run build`, which failed in this environment due to missing dependency resolution (`Can't resolve 'react-i18next'`), so the UI build could not be validated here (failed).
- Attempted a browser screenshot of the running UI with Playwright, but the local dev server was not reachable (`ERR_EMPTY_RESPONSE`), so end-to-end rendering could not be validated (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3f4f5c49483329f7d147d78fe4bb9)