### PR TITLE
Add Division column to exports and Division History tab/view

### DIFF
--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -64,6 +64,8 @@ export interface TicketRow {
     zoneCode?: string;
     districtName?: string;
     regionName?: string;
+    divisionName?: string;
+    divisionId?: string;
     rcaStatus?: 'NOT_APPLICABLE' | 'PENDING' | 'SUBMITTED';
 }
 
@@ -419,6 +421,11 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
                 getValue: (record: TicketRow) => record.assignedToName || record.assignedTo || '-',
             },
             {
+                key: 'division',
+                label: t('Division'),
+                getValue: (record: TicketRow) => record.divisionName || record.divisionId || '-',
+            },
+            {
                 key: 'status',
                 label: t('Status'),
                 getValue: (record: TicketRow) => getStatusNameById(record.statusId || '') || record.statusLabel || '-',
@@ -452,6 +459,7 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
             { key: t('Region'), value: filters.regionLabel },
             { key: t('District'), value: filters.districtLabel },
             { key: t('Issue Type'), value: filters.issueTypeLabel || issueTypeFilterLabel },
+            { key: t('Division'), value: filters.divisionLabel },
             { key: t('Assignee'), value: filters.assignedToLabel },
             { key: t('Status'), value: filters.statusLabel },
         ].filter((entry) => Boolean(entry.value));

--- a/ui/src/components/DivisionHistory/index.tsx
+++ b/ui/src/components/DivisionHistory/index.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import GenericTable from '../UI/GenericTable';
+import ViewToggle from '../UI/ViewToggle';
+import { useApi } from '../../hooks/useApi';
+import { getDivisionHistory } from '../../services/DivisionHistoryService';
+import { Timeline, TimelineItem, TimelineSeparator, TimelineDot, TimelineConnector, TimelineContent } from '@mui/lab';
+import { Paper } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import HistoryReportDownloadMenu, { HistoryReportColumn } from '../History/HistoryReportDownloadMenu';
+
+interface HistoryEntry {
+    id: string;
+    previousDivision?: string;
+    currentDivision?: string;
+    divisionName?: string;
+    updatedBy?: string;
+    timestamp: string;
+    remark?: string;
+}
+
+interface DivisionHistoryProps {
+    ticketId: string;
+}
+
+const resolveDivisionName = (entry: HistoryEntry, key: 'current' | 'previous') => {
+    if (key === 'current') {
+        return entry.currentDivision || entry.divisionName || '-';
+    }
+    return entry.previousDivision || '-';
+};
+
+const DivisionHistory: React.FC<DivisionHistoryProps> = ({ ticketId }) => {
+    const { data, apiHandler } = useApi<any>();
+    const [view, setView] = useState<'table' | 'timeline'>('table');
+    const { t } = useTranslation();
+
+    useEffect(() => {
+        apiHandler(() => getDivisionHistory(ticketId));
+    }, [apiHandler, ticketId]);
+
+    const history = useMemo(() => (Array.isArray(data)
+        ? [...data].sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+        : []), [data]);
+
+    const columns = [
+        { title: t('Previous Division'), dataIndex: 'previousDivision', key: 'previousDivision', render: (_: string, record: HistoryEntry) => resolveDivisionName(record, 'previous') },
+        { title: t('Current Division'), dataIndex: 'currentDivision', key: 'currentDivision', render: (_: string, record: HistoryEntry) => resolveDivisionName(record, 'current') },
+        { title: t('Updated By'), dataIndex: 'updatedBy', key: 'updatedBy', render: (v: string) => v || '-' },
+        {
+            title: t('Updated On'),
+            dataIndex: 'timestamp',
+            key: 'timestamp',
+            render: (v: string) => new Date(v).toLocaleString(),
+        },
+        { title: t('Remark'), dataIndex: 'remark', key: 'remark', render: (v: string) => v || '-' },
+    ];
+
+    const reportColumns: HistoryReportColumn<HistoryEntry>[] = [
+        { key: 'previousDivision', header: t('Previous Division'), getValue: (row) => resolveDivisionName(row, 'previous') },
+        { key: 'currentDivision', header: t('Current Division'), getValue: (row) => resolveDivisionName(row, 'current') },
+        { key: 'updatedBy', header: t('Updated By'), getValue: (row) => row.updatedBy || '-' },
+        { key: 'timestamp', header: t('Updated On'), getValue: (row) => row.timestamp ? new Date(row.timestamp).toLocaleString() : '-' },
+        { key: 'remark', header: t('Remark'), getValue: (row) => row.remark || '-' },
+    ];
+
+    return (
+        <div>
+            <div className="d-flex justify-content-end align-items-center gap-2 mb-2">
+                <HistoryReportDownloadMenu
+                    title={`Ticket ${ticketId} - ${t('Division History')}`}
+                    fileBaseName={`${ticketId}-division-history`}
+                    rows={history}
+                    columns={reportColumns}
+                />
+                <ViewToggle
+                    value={view}
+                    onChange={setView}
+                    options={[
+                        { icon: 'table', value: 'table' },
+                        { icon: 'timeline', value: 'timeline' }
+                    ]}
+                />
+            </div>
+            {view === 'table' ? (
+                <GenericTable
+                    dataSource={history}
+                    columns={columns as any}
+                    rowKey="id"
+                    pagination={false}
+                    rowClassName={(_, idx) => (idx === 0 ? 'latest-row' : '')}
+                />
+            ) : (
+                <Timeline>
+                    {history.map((h, idx) => (
+                        <TimelineItem key={h.id}>
+                            <TimelineSeparator>
+                                <TimelineDot sx={{ bgcolor: idx === 0 ? 'warning.light' : undefined }} />
+                                {idx < history.length - 1 && <TimelineConnector />}
+                            </TimelineSeparator>
+                            <TimelineContent>
+                                <Paper elevation={2} sx={{ p: 1 }}>
+                                    <strong>{resolveDivisionName(h, 'current')}</strong>
+                                    <div style={{ fontSize: 12 }}>
+                                        {new Date(h.timestamp).toLocaleString()} - {h.updatedBy || '-'}
+                                    </div>
+                                    {h.remark && <div style={{ fontSize: 12 }}>{h.remark}</div>}
+                                </Paper>
+                            </TimelineContent>
+                        </TimelineItem>
+                    ))}
+                </Timeline>
+            )}
+        </div>
+    );
+};
+
+export default DivisionHistory;

--- a/ui/src/components/TicketView/HistorySidebar.tsx
+++ b/ui/src/components/TicketView/HistorySidebar.tsx
@@ -12,10 +12,10 @@ interface HistorySidebarProps {
 }
 
 const HistorySidebar: React.FC<HistorySidebarProps> = ({ ticketId, open, setOpen }) => {
-    const [tab, setTab] = useState<'status' | 'assignment'>('status');
+    const [tab, setTab] = useState<'status' | 'assignment' | 'division'>('status');
     const { t } = useTranslation();
 
-    const handleOpen = (value: 'status' | 'assignment') => {
+    const handleOpen = (value: 'status' | 'assignment' | 'division') => {
         setTab(value);
         setOpen(true);
     };
@@ -25,7 +25,7 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ ticketId, open, setOpen
     return (
         <>
             {!open && (
-                <div style={{ position: 'fixed', right: -40, top: '40%', zIndex: 1300, display: 'flex', flexDirection: 'column', gap: 115 }}>
+                <div style={{ position: 'fixed', right: -40, top: '40%', zIndex: 1300, display: 'flex', flexDirection: 'column', gap: 72 }}>
                     <Button
                         variant="contained"
                         size="small"
@@ -41,6 +41,14 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ ticketId, open, setOpen
                         sx={{ transform: 'rotate(-90deg)' }}
                     >
                         {t('Assignment History')}
+                    </Button>
+                    <Button
+                        variant="contained"
+                        size="small"
+                        onClick={() => handleOpen('division')}
+                        sx={{ transform: 'rotate(-90deg)' }}
+                    >
+                        {t('Division History')}
                     </Button>
                 </div>
             )}
@@ -60,7 +68,7 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ ticketId, open, setOpen
                     <IconButton onClick={handleClose} sx={{ position: 'absolute', left: -40, top: 8 }}>
                         <ChevronLeftIcon />
                     </IconButton>
-                    <Histories ticketId={ticketId} currentTab={tab} onTabChange={(k) => setTab(k as 'status' | 'assignment')} />
+                    <Histories ticketId={ticketId} currentTab={tab} onTabChange={(k) => setTab(k as 'status' | 'assignment' | 'division')} />
                 </Box>
             </Drawer>
         </>

--- a/ui/src/components/TicketView/__tests__/HistorySidebar.test.tsx
+++ b/ui/src/components/TicketView/__tests__/HistorySidebar.test.tsx
@@ -24,6 +24,7 @@ describe('HistorySidebar', () => {
 
     const statusButton = screen.getByRole('button', { name: 'Status History' });
     const assignmentButton = screen.getByRole('button', { name: 'Assignment History' });
+    const divisionButton = screen.getByRole('button', { name: 'Division History' });
 
     fireEvent.click(assignmentButton);
     expect(setOpen).toHaveBeenCalledWith(true);
@@ -34,6 +35,10 @@ describe('HistorySidebar', () => {
     fireEvent.click(statusButton);
     const lastStatusCall = historiesMock.mock.calls[historiesMock.mock.calls.length - 1];
     expect(lastStatusCall?.[0].currentTab).toBe('status');
+
+    fireEvent.click(divisionButton);
+    const lastDivisionCall = historiesMock.mock.calls[historiesMock.mock.calls.length - 1];
+    expect(lastDivisionCall?.[0].currentTab).toBe('division');
   });
 
   it('renders drawer content when open and handles tab change and close', async () => {
@@ -51,6 +56,13 @@ describe('HistorySidebar', () => {
 
     const nextCall = historiesMock.mock.calls[historiesMock.mock.calls.length - 1];
     expect(nextCall?.[0].currentTab).toBe('assignment');
+
+    await act(async () => {
+      props.onTabChange?.('division');
+    });
+
+    const divisionCall = historiesMock.mock.calls[historiesMock.mock.calls.length - 1];
+    expect(divisionCall?.[0].currentTab).toBe('division');
 
     const closeButton = screen.getByTestId('ChevronRightIcon').closest('button');
     expect(closeButton).not.toBeNull();

--- a/ui/src/components/__tests__/componentsExports.test.tsx
+++ b/ui/src/components/__tests__/componentsExports.test.tsx
@@ -33,6 +33,7 @@ import Header from '../Layout/Header';
 import Sidebar from '../Layout/Sidebar';
 import UserMenu from '../Layout/UserMenu';
 import AssignmentHistory from '../AssignmentHistory';
+import DivisionHistory from '../DivisionHistory';
 import ChildTicketsTable from '../Ticket/ChildTicketsTable';
 
 jest.mock('jwt-decode', () => ({
@@ -114,6 +115,7 @@ describe('component module exports', () => {
     expect(Sidebar).toBeTruthy();
     expect(UserMenu).toBeTruthy();
     expect(AssignmentHistory).toBeTruthy();
+    expect(DivisionHistory).toBeTruthy();
     expect(ChildTicketsTable).toBeTruthy();
   });
 });

--- a/ui/src/pages/Histories.tsx
+++ b/ui/src/pages/Histories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import StatusHistory from '../components/StatusHistory';
 import AssignmentHistory from '../components/AssignmentHistory';
+import DivisionHistory from '../components/DivisionHistory';
 import CustomTabsComponent from '../components/UI/CustomTabsComponent';
 import { useTranslation } from 'react-i18next';
 
@@ -16,6 +17,7 @@ const Histories: React.FC<HistoriesProps> = ({ ticketId, currentTab, onTabChange
     const tabs = [
         { key: 'status', tabTitle: t('Status History'), tabComponent: <StatusHistory ticketId={ticketId} /> },
         { key: 'assignment', tabTitle: t('Assignment History'), tabComponent: <AssignmentHistory ticketId={ticketId} /> },
+        { key: 'division', tabTitle: t('Division History'), tabComponent: <DivisionHistory ticketId={ticketId} /> },
     ];
 
     return (

--- a/ui/src/pages/__tests__/Histories.test.tsx
+++ b/ui/src/pages/__tests__/Histories.test.tsx
@@ -22,12 +22,18 @@ jest.mock('../../components/AssignmentHistory', () => ({
   default: ({ ticketId }: { ticketId: string }) => <div>Assignment {ticketId}</div>,
 }));
 
+jest.mock('../../components/DivisionHistory', () => ({
+  __esModule: true,
+  default: ({ ticketId }: { ticketId: string }) => <div>Division {ticketId}</div>,
+}));
+
 describe('Histories', () => {
-  it('renders tabs with status and assignment history', () => {
+  it('renders tabs with status, assignment and division history', () => {
     render(<Histories ticketId="T-1" currentTab="status" onTabChange={jest.fn()} />);
 
-    expect(tabsProps[0].tabs).toHaveLength(2);
+    expect(tabsProps[0].tabs).toHaveLength(3);
     expect(tabsProps[0].tabs[0].tabTitle).toBe('Status History');
     expect(tabsProps[0].tabs[1].tabTitle).toBe('Assignment History');
+    expect(tabsProps[0].tabs[2].tabTitle).toBe('Division History');
   });
 });

--- a/ui/src/services/DivisionHistoryService.ts
+++ b/ui/src/services/DivisionHistoryService.ts
@@ -1,0 +1,6 @@
+import axios from 'axios';
+import { BASE_URL } from './api';
+
+export function getDivisionHistory(ticketId: string) {
+    return axios.get(`${BASE_URL}/division-history/${ticketId}`);
+}

--- a/ui/src/services/__tests__/services.test.ts
+++ b/ui/src/services/__tests__/services.test.ts
@@ -342,6 +342,15 @@ describe("StakeholderService", () => {
   });
 });
 
+
+describe("DivisionHistoryService", () => {
+  it("retrieves ticket division history", async () => {
+    const service = await import("../DivisionHistoryService");
+    await service.getDivisionHistory("123");
+    expect(axiosMock.get).toHaveBeenCalledWith(expect.stringContaining("/division-history/123"));
+  });
+});
+
 describe("StatusHistoryService", () => {
   it("retrieves ticket status history", async () => {
     const service = await import("../StatusHistoryService");


### PR DESCRIPTION
### Motivation
- A new `division` field was added and must be included in ticket exports and the histories UI, matching existing status and assignment history functionality.

### Description
- Added a `DivisionHistory` component that mirrors `StatusHistory`/`AssignmentHistory` with table/timeline views, download menu and `useApi`-backed data loading via `getDivisionHistory`.
- Created `ui/src/services/DivisionHistoryService.ts` with `getDivisionHistory(ticketId)` and used it from the new history component via the `useApi` hook.
- Wired the new component into the UI by adding a `Division History` tab in `Histories` and a launcher button/tab state in `HistorySidebar` (supports `'division'` tab state).
- Extended ticket exports/reporting by adding a `Division` export column and including the selected division in the download filter summary in `TicketsTable`, and updated related tests and component exports to include `DivisionHistory`.

### Testing
- Ran `npm test` for the history UI tests and `DivisionHistoryService` test and they passed: `src/pages/__tests__/Histories.test.tsx` ✅, `src/components/TicketView/__tests__/HistorySidebar.test.tsx` ✅, and `src/services/__tests__/services.test.ts` (DivisionHistoryService spec) ✅.
- Attempted a broader test/start run: `npm test` including all suites initially surfaced unrelated environment issues (missing test dependency `xlsx` in the Jest environment) and `npm start` crashed in this environment due to Node OOM, both of which are unrelated to the division history changes and did not affect the focused tests above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5ab073f1c8332a7975423635b4335)