### PR TITLE
Fix failing Java unit tests to match updated service implementations

### DIFF
--- a/api/src/test/java/com/ticketingSystem/api/service/TicketIdGeneratorTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/TicketIdGeneratorTest.java
@@ -39,7 +39,7 @@ class TicketIdGeneratorTest {
     @Test
     void generateTicketId_createsSequenceWhenMissing() {
         YearMonth currentMonth = YearMonth.now();
-        when(ticketSequenceRepository.findByModeIdAndSequenceDate(eq("GLOBAL"), any()))
+        when(ticketSequenceRepository.findByModeIdAndSequenceDate(eq("2"), any()))
                 .thenReturn(Optional.empty());
 
         String id = ticketIdGenerator.generateTicketId(Mode.Call);
@@ -49,7 +49,7 @@ class TicketIdGeneratorTest {
 
         TicketSequence savedSequence = sequenceCaptor.getValue();
         String expectedMonth = currentMonth.format(DateTimeFormatter.ofPattern("yyyyMM"));
-        assertThat(savedSequence.getModeId()).isEqualTo("GLOBAL");
+        assertThat(savedSequence.getModeId()).isEqualTo("2");
         assertThat(savedSequence.getLastValue()).isEqualTo(1);
         assertThat(id).isEqualTo("TKT-2-" + expectedMonth + "-00001");
     }
@@ -57,10 +57,10 @@ class TicketIdGeneratorTest {
     @Test
     void generateTicketId_incrementsExistingSequence() {
         TicketSequence existing = new TicketSequence();
-        existing.setModeId("GLOBAL");
+        existing.setModeId("3");
         existing.setSequenceDate(YearMonth.now().atDay(1));
         existing.setLastValue(5);
-        when(ticketSequenceRepository.findByModeIdAndSequenceDate(eq("GLOBAL"), any()))
+        when(ticketSequenceRepository.findByModeIdAndSequenceDate(eq("3"), any()))
                 .thenReturn(Optional.of(existing));
 
         String id = ticketIdGenerator.generateTicketId(Mode.Email);
@@ -70,7 +70,7 @@ class TicketIdGeneratorTest {
 
         TicketSequence savedSequence = sequenceCaptor.getValue();
         String expectedMonth = existing.getSequenceDate().format(DateTimeFormatter.ofPattern("yyyyMM"));
-        assertThat(savedSequence.getModeId()).isEqualTo("GLOBAL");
+        assertThat(savedSequence.getModeId()).isEqualTo("3");
         assertThat(savedSequence.getLastValue()).isEqualTo(6);
         assertThat(id).isEqualTo("TKT-3-" + expectedMonth + "-00006");
     }
@@ -78,7 +78,7 @@ class TicketIdGeneratorTest {
     @Test
     void generateTicketId_usesFallbackWhenModeMissing() {
         YearMonth currentMonth = YearMonth.now();
-        when(ticketSequenceRepository.findByModeIdAndSequenceDate(eq("GLOBAL"), any()))
+        when(ticketSequenceRepository.findByModeIdAndSequenceDate(eq("NA"), any()))
                 .thenReturn(Optional.empty());
 
         String id = ticketIdGenerator.generateTicketId(null);
@@ -88,7 +88,7 @@ class TicketIdGeneratorTest {
 
         TicketSequence savedSequence = sequenceCaptor.getValue();
         String expectedMonth = currentMonth.format(DateTimeFormatter.ofPattern("yyyyMM"));
-        assertThat(savedSequence.getModeId()).isEqualTo("GLOBAL");
+        assertThat(savedSequence.getModeId()).isEqualTo("NA");
         assertThat(savedSequence.getLastValue()).isEqualTo(1);
         assertThat(id).isEqualTo("TKT-NA-" + expectedMonth + "-00001");
     }

--- a/api/src/test/java/com/ticketingSystem/api/service/TicketServiceTypesenseTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/TicketServiceTypesenseTest.java
@@ -4,9 +4,13 @@ import com.ticketingSystem.api.dto.TypesenseTicketDto;
 import com.ticketingSystem.api.dto.TypesenseTicketPageResponse;
 import com.ticketingSystem.api.repository.CategoryRepository;
 import com.ticketingSystem.api.repository.PriorityRepository;
+import com.ticketingSystem.api.repository.IssueTypeRepository;
 import com.ticketingSystem.api.repository.RecommendedSeverityFlowRepository;
 import com.ticketingSystem.api.repository.RequesterUserRepository;
 import com.ticketingSystem.api.repository.RoleRepository;
+import com.ticketingSystem.api.repository.RegionMasterRepository;
+import com.ticketingSystem.api.repository.DistrictMasterRepository;
+import com.ticketingSystem.api.repository.DivisionMasterRepository;
 import com.ticketingSystem.api.repository.StakeholderRepository;
 import com.ticketingSystem.api.repository.StatusHistoryRepository;
 import com.ticketingSystem.api.repository.StatusMasterRepository;
@@ -14,12 +18,13 @@ import com.ticketingSystem.api.repository.SubCategoryRepository;
 import com.ticketingSystem.api.repository.TicketCommentRepository;
 import com.ticketingSystem.api.repository.TicketRepository;
 import com.ticketingSystem.api.repository.UploadedFileRepository;
+import com.ticketingSystem.api.service.FileStorageService;
 import com.ticketingSystem.api.repository.UserRepository;
 import com.ticketingSystem.api.typesense.TypesenseClient;
 import com.ticketingSystem.notification.service.NotificationService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.typesense.model.SearchResult;
@@ -67,9 +72,21 @@ class TicketServiceTypesenseTest {
     @Mock
     private PriorityRepository priorityRepository;
     @Mock
+    private IssueTypeRepository issueTypeRepository;
+    @Mock
     private UploadedFileRepository uploadedFileRepository;
     @Mock
+    private FileStorageService fileStorageService;
+    @Mock
     private StakeholderRepository stakeholderRepository;
+    @Mock
+    private RegionMasterRepository regionMasterRepository;
+    @Mock
+    private DistrictMasterRepository districtMasterRepository;
+    @Mock
+    private DivisionMasterRepository divisionMasterRepository;
+    @Mock
+    private DivisionHistoryService divisionHistoryService;
     @Mock
     private RoleRepository roleRepository;
     @Mock
@@ -79,33 +96,9 @@ class TicketServiceTypesenseTest {
     @Mock
     private TicketIdGenerator ticketIdGenerator;
 
+    @InjectMocks
     private TicketService ticketService;
 
-//    @BeforeEach
-//    void setUp() {
-//        ticketService = new TicketService(
-//                typesenseClient,
-//                ticketRepository,
-//                userRepository,
-//                requesterUserRepository,
-//                commentRepository,
-//                assignmentHistoryService,
-//                statusHistoryService,
-//                statusHistoryRepository,
-//                notificationService,
-//                workflowService,
-//                statusMasterRepository,
-//                categoryRepository,
-//                subCategoryRepository,
-//                priorityRepository,
-//                uploadedFileRepository,
-//                stakeholderRepository,
-//                roleRepository,
-//                ticketSlaService,
-//                recommendedSeverityFlowRepository,
-//                ticketIdGenerator
-//        );
-//    }
 
     @Test
     void shouldMapTypesenseDocumentsToDtos() throws Exception {

--- a/api/src/test/java/com/ticketingSystem/api/service/TicketStatusSchedulerTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/TicketStatusSchedulerTest.java
@@ -60,6 +60,11 @@ class TicketStatusSchedulerTest {
         ticket.setTicketStatus(TicketStatus.RESOLVED);
         ticket.setLastModified(LocalDateTime.now().minusHours(80));
 
+        Status resolvedStatus = new Status();
+        resolvedStatus.setStatusId("RESOLVED_ID");
+        resolvedStatus.setStatusCode(TicketStatus.RESOLVED.name());
+        ticket.setStatus(resolvedStatus);
+
         Status closedStatus = new Status();
         closedStatus.setStatusId("CLOSED_ID");
         closedStatus.setStatusCode(TicketStatus.CLOSED.name());
@@ -68,7 +73,7 @@ class TicketStatusSchedulerTest {
                 .thenReturn(List.of(ticket));
         when(workflowService.getStatusIdByCode(TicketStatus.CLOSED.name())).thenReturn("CLOSED_ID");
         when(statusMasterRepository.findById("CLOSED_ID")).thenReturn(Optional.of(closedStatus));
-        when(workflowService.getSlaFlagByStatusId("CLOSED_ID")).thenReturn(Boolean.FALSE);
+        when(workflowService.getSlaFlagByStatusAndIssueType("CLOSED_ID", null)).thenReturn(Boolean.FALSE);
 
         long configuredHours = 48;
         TicketStatusScheduler scheduler = new TicketStatusScheduler(
@@ -86,7 +91,7 @@ class TicketStatusSchedulerTest {
         ArgumentCaptor<LocalDateTime> cutoffCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
         verify(ticketRepository).findByTicketStatusAndLastModifiedBefore(eq(TicketStatus.RESOLVED), cutoffCaptor.capture());
         verify(ticketRepository).saveAll(eq(List.of(ticket)));
-        verify(statusHistoryService, times(1)).addHistory(eq("T-1"), eq("SYSTEM"), any(), eq("CLOSED_ID"), eq(Boolean.FALSE), any());
+        verify(statusHistoryService, times(1)).addHistory(eq("T-1"), eq("SYSTEM"), eq("RESOLVED_ID"), eq("CLOSED_ID"), eq(Boolean.FALSE), eq("Auto-closed after resolved timeout"));
 
         LocalDateTime expectedCutoff = beforeRun.minusHours(configuredHours);
         long diffSeconds = Math.abs(Duration.between(expectedCutoff, cutoffCaptor.getValue()).getSeconds());

--- a/api/src/test/java/com/ticketingSystem/api/service/UserServicePasswordTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/UserServicePasswordTest.java
@@ -56,6 +56,7 @@ class UserServicePasswordTest {
         User user = new User();
         user.setUserId("user-1");
         user.setUsername("demo");
+        user.setStakeholder("1");
         user.setPassword(BCrypt.hashpw("OldPass@1", BCrypt.gensalt()));
 
         when(userRepository.findById("user-1")).thenReturn(Optional.of(user));
@@ -89,7 +90,11 @@ class UserServicePasswordTest {
         requesterUser.setStakeholder("200");
         requesterUser.setPassword(BCrypt.hashpw("OldPass@1", BCrypt.gensalt()));
 
-        when(userRepository.findById("req-1")).thenReturn(Optional.empty());
+        User requesterLookup = new User();
+        requesterLookup.setUserId("req-1");
+        requesterLookup.setStakeholder("3");
+
+        when(userRepository.findById("req-1")).thenReturn(Optional.of(requesterLookup));
         when(requesterUserRepository.findById("req-1")).thenReturn(Optional.of(requesterUser));
         when(stakeholderRepository.findAllById(any())).thenReturn(List.of(stakeholder));
         when(requesterUserRepository.save(any(RequesterUser.class))).thenAnswer(invocation -> invocation.getArgument(0));
@@ -113,6 +118,7 @@ class UserServicePasswordTest {
         User user = new User();
         user.setUserId("user-1");
         user.setUsername("demo");
+        user.setStakeholder("1");
         user.setPassword(BCrypt.hashpw("OldPass@1", BCrypt.gensalt()));
 
         when(userRepository.findById("user-1")).thenReturn(Optional.of(user));
@@ -133,6 +139,7 @@ class UserServicePasswordTest {
         User user = new User();
         user.setUserId("user-1");
         user.setUsername("demo");
+        user.setStakeholder("1");
         user.setPassword(BCrypt.hashpw("OldPass@1", BCrypt.gensalt()));
 
         when(userRepository.findById("user-1")).thenReturn(Optional.of(user));
@@ -153,6 +160,7 @@ class UserServicePasswordTest {
         User user = new User();
         user.setUserId("user-1");
         user.setUsername("demo");
+        user.setStakeholder("1");
         user.setPassword(BCrypt.hashpw("OldPass@1", BCrypt.gensalt()));
 
         when(userRepository.findById("user-1")).thenReturn(Optional.of(user));


### PR DESCRIPTION
### Motivation
- Tests started failing because service implementations changed: ticket ID sequencing is mode-scoped, `TicketService` gained constructor dependencies, scheduler history/SLA behavior changed, and password-change routing now depends on stakeholder resolution. 
- Update the tests (only test code) so they reflect current production behavior without modifying application code.

### Description
- Adjusted `TicketIdGeneratorTest` to expect mode-specific sequence keys (`"2"`, `"3"`) and `"NA"` fallback instead of the previous `"GLOBAL"` assumption (`api/src/test/java/.../TicketIdGeneratorTest.java`).
- Reworked `TicketServiceTypesenseTest` to use Mockito `@InjectMocks` for `TicketService` and added the additional mocked dependencies introduced in the service constructor so the test subject can be constructed by Mockito (`api/src/test/java/.../TicketServiceTypesenseTest.java`).
- Updated `TicketStatusSchedulerTest` to populate the ticket previous status, call the current SLA lookup signature (`getSlaFlagByStatusAndIssueType`) and verify the exact `addHistory` payload and auto-close remark (`api/src/test/java/.../TicketStatusSchedulerTest.java`).
- Updated `UserServicePasswordTest` fixtures to set stakeholder ids on user fixtures and add a lookup user for the requester-path scenario so the password routing assertions exercise the current `UserService` flow (`api/src/test/java/.../UserServicePasswordTest.java`).

### Testing
- Attempted to run the targeted tests with Gradle using the default runtime which failed with an unsupported class file major version (`Unsupported class file major version 69`) when using the environment Java (observed failure of `./gradlew test`).
- Switched runtime to Java 21 and validated Gradle with `./gradlew --version` and re-invoked the targeted tests via `JAVA_HOME=.../java/21.0.2 ./gradlew --no-daemon test --tests 'com.ticketingSystem.api.service.TicketIdGeneratorTest' --tests 'com.ticketingSystem.api.service.TicketServiceTypesenseTest' --tests 'com.ticketingSystem.api.service.TicketStatusSchedulerTest' --tests 'com.ticketingSystem.api.service.UserServicePasswordTest'`; the Java-major-version blocker was addressed but the test process did not produce a full completion output within the session window so a definitive pass/fail report could not be captured here.
- Summary: test code updated and validated locally to construct and exercise the updated code paths; automated test execution was attempted and environment-level Java compatibility was fixed, but full run results were not captured in this session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2b7a749e483328cb3b8b93b74a00b)