### PR TITLE
Fix failing UserService and NotificationService unit tests

### DIFF
--- a/api/src/test/java/com/ticketingSystem/api/service/UserServicePasswordTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/UserServicePasswordTest.java
@@ -82,6 +82,7 @@ class UserServicePasswordTest {
 
         Stakeholder stakeholder = new Stakeholder();
         stakeholder.setId(200);
+        stakeholder.setDescription("Requester Stakeholder");
         stakeholder.setStakeholderGroup(stakeholderGroup);
 
         RequesterUser requesterUser = new RequesterUser();
@@ -92,7 +93,7 @@ class UserServicePasswordTest {
 
         User requesterLookup = new User();
         requesterLookup.setUserId("req-1");
-        requesterLookup.setStakeholder("3");
+        requesterLookup.setStakeholder("200");
 
         when(userRepository.findById("req-1")).thenReturn(Optional.of(requesterLookup));
         when(requesterUserRepository.findById("req-1")).thenReturn(Optional.of(requesterUser));

--- a/api/src/test/java/com/ticketingSystem/notification/service/NotificationServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/notification/service/NotificationServiceTest.java
@@ -43,6 +43,9 @@ class NotificationServiceTest {
         when(notificationMasterRepository.findByCodeAndIsActiveTrue("TICKET_CREATED"))
                 .thenReturn(Optional.of(notificationMaster));
 
+        notificationRuntimeToggleService = mock(NotificationRuntimeToggleService.class);
+        when(notificationRuntimeToggleService.isNotificationEnabled()).thenReturn(true);
+
         notificationService = new NotificationService(List.of(notifier), properties, notificationRuntimeToggleService, notificationMasterRepository);
     }
 


### PR DESCRIPTION
### Motivation
- Two unit tests were failing with NPEs due to incomplete test fixtures: the requester stakeholder mapping produced a null description during stakeholder name resolution and `NotificationServiceTest` injected a null `NotificationRuntimeToggleService` dependency.

### Description
- Updated `UserServicePasswordTest` to set a non-null stakeholder description and align the `requesterLookup` stakeholder id with the mocked `Stakeholder` (`200`) so stakeholder name/group resolution follows the intended requester path.
- Updated `NotificationServiceTest` to mock `NotificationRuntimeToggleService` and stub `isNotificationEnabled()` to return `true` so `sendNotification(...)` executes without a null dependency.
- Changes are test-only and limited to `api/src/test/java/com/ticketingSystem/api/service/UserServicePasswordTest.java` and `api/src/test/java/com/ticketingSystem/notification/service/NotificationServiceTest.java`.

### Testing
- Attempted to run the targeted tests with `./gradlew test --tests 'com.ticketingSystem.api.service.UserServicePasswordTest.changePasswordRoutesToRequesterRepositoryWhenStakeholderGroupIsThree' --tests 'com.ticketingSystem.notification.service.NotificationServiceTest.shouldIncludeSupportEmailWhenSendingNotification'`, but the build failed in this environment with a Gradle/JDK compatibility error: `Unsupported class file major version 69` so the tests could not be executed here.
- Changes were committed locally; they are small test-fixture fixes and should allow the tests to pass in a CI/dev environment with compatible JDK/Gradle versions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2cd2bc7d08332b7c9733717076dd3)