### PR TITLE
Add comprehensive JUnit coverage for multiple backend services

### DIFF
--- a/api/src/test/java/com/ticketingSystem/api/service/AssignmentHistoryServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/AssignmentHistoryServiceTest.java
@@ -1,0 +1,78 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.exception.TicketNotFoundException;
+import com.ticketingSystem.api.models.AssignmentHistory;
+import com.ticketingSystem.api.models.Ticket;
+import com.ticketingSystem.api.repository.AssignmentHistoryRepository;
+import com.ticketingSystem.api.repository.TicketRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AssignmentHistoryServiceTest {
+
+    @Mock
+    private AssignmentHistoryRepository historyRepository;
+    @Mock
+    private TicketRepository ticketRepository;
+
+    @InjectMocks
+    private AssignmentHistoryService service;
+
+    @Test
+    void addHistoryShouldPersistMappedFields() {
+        Ticket ticket = new Ticket();
+        ticket.setId("T-1");
+        when(ticketRepository.findById("T-1")).thenReturn(Optional.of(ticket));
+
+        AssignmentHistory saved = new AssignmentHistory();
+        when(historyRepository.save(org.mockito.ArgumentMatchers.any(AssignmentHistory.class))).thenReturn(saved);
+
+        AssignmentHistory result = service.addHistory("T-1", "alice", "bob", "L1", "Investigating");
+
+        ArgumentCaptor<AssignmentHistory> captor = ArgumentCaptor.forClass(AssignmentHistory.class);
+        verify(historyRepository).save(captor.capture());
+        AssignmentHistory persisted = captor.getValue();
+
+        assertThat(persisted.getTicket()).isEqualTo(ticket);
+        assertThat(persisted.getAssignedBy()).isEqualTo("alice");
+        assertThat(persisted.getAssignedTo()).isEqualTo("bob");
+        assertThat(persisted.getLevelId()).isEqualTo("L1");
+        assertThat(persisted.getRemark()).isEqualTo("Investigating");
+        // Timestamp should always be generated server-side for traceability.
+        assertThat(persisted.getTimestamp()).isNotNull();
+        assertThat(result).isEqualTo(saved);
+    }
+
+    @Test
+    void addHistoryShouldThrowWhenTicketMissing() {
+        when(ticketRepository.findById("MISSING")).thenReturn(Optional.empty());
+
+        assertThrows(TicketNotFoundException.class,
+                () -> service.addHistory("MISSING", "a", "b", "L2", "remark"));
+    }
+
+    @Test
+    void getHistoryForTicketShouldReturnChronologicalEntries() {
+        Ticket ticket = new Ticket();
+        when(ticketRepository.findById("T-2")).thenReturn(Optional.of(ticket));
+        List<AssignmentHistory> history = List.of(new AssignmentHistory(), new AssignmentHistory());
+        when(historyRepository.findByTicketOrderByTimestampAsc(ticket)).thenReturn(history);
+
+        List<AssignmentHistory> result = service.getHistoryForTicket("T-2");
+
+        assertThat(result).containsExactlyElementsOf(history);
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/AuthServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/AuthServiceTest.java
@@ -1,0 +1,94 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.dto.AuthenticatedUser;
+import com.ticketingSystem.api.models.RequesterUser;
+import com.ticketingSystem.api.models.User;
+import com.ticketingSystem.api.repository.RequesterUserRepository;
+import com.ticketingSystem.api.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCrypt;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private RequesterUserRepository requesterUserRepository;
+
+    @InjectMocks
+    private AuthService service;
+
+    @Test
+    void authenticateShouldUseUserRepositoryForInternalPortalAndValidateBcrypt() {
+        User user = new User();
+        user.setUsername("admin");
+        user.setPassword(BCrypt.hashpw("secret", BCrypt.gensalt()));
+        when(userRepository.findByUsername("admin")).thenReturn(Optional.of(user));
+
+        Optional<AuthenticatedUser> result = service.authenticate("admin", "secret", "internal");
+
+        assertThat(result).isPresent();
+        verify(userRepository).findByUsername("admin");
+        verifyNoInteractions(requesterUserRepository);
+    }
+
+    @Test
+    void authenticateShouldRejectOverlongBcryptPasswordInput() {
+        User user = new User();
+        user.setPassword(BCrypt.hashpw("short", BCrypt.gensalt()));
+        when(userRepository.findByUsername("admin")).thenReturn(Optional.of(user));
+
+        String overlong = "é".repeat(40); // UTF-8 bytes > 72 and should fail safely.
+        assertThat(overlong.getBytes(StandardCharsets.UTF_8).length).isGreaterThan(72);
+
+        Optional<AuthenticatedUser> result = service.authenticate("admin", overlong, null);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void authenticateShouldSupportRequesterPortalAliases() {
+        RequesterUser requester = new RequesterUser();
+        requester.setUsername("req-user");
+        requester.setPassword("plain-pass");
+        when(requesterUserRepository.findByUsername("req-user")).thenReturn(Optional.of(requester));
+
+        Optional<AuthenticatedUser> result = service.authenticate("req-user", "plain-pass", " requestor ");
+
+        assertThat(result).isPresent();
+        verify(requesterUserRepository).findByUsername("req-user");
+        verifyNoInteractions(userRepository);
+    }
+
+    @Test
+    void authenticateShouldAllowHashToHashComparisonForMigratedData() {
+        String hash = BCrypt.hashpw("secret", BCrypt.gensalt());
+        User user = new User();
+        user.setPassword(hash);
+        when(userRepository.findByUsername("admin")).thenReturn(Optional.of(user));
+
+        Optional<AuthenticatedUser> result = service.authenticate("admin", hash, null);
+
+        assertThat(result).isPresent();
+    }
+
+    @Test
+    void findUserByUsernameShouldReturnEmptyWhenMissing() {
+        when(userRepository.findByUsername("ghost")).thenReturn(Optional.empty());
+
+        assertThat(service.findUserByUsername("ghost", null)).isEmpty();
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/CalendarSyncServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/CalendarSyncServiceTest.java
@@ -1,0 +1,100 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.config.CalendarUiProperties;
+import com.ticketingSystem.calendar.facade.ExternalCalendarFacade;
+import com.ticketingSystem.calendar.repository.HolidayRepository;
+import com.ticketingSystem.calendar.util.TimeUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.Year;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CalendarSyncServiceTest {
+
+    @Mock
+    private HolidayRepository holidayRepository;
+    @Mock
+    private ExternalCalendarFacade externalCalendarFacade;
+
+    private CalendarUiProperties properties;
+
+    @InjectMocks
+    private CalendarSyncService service;
+
+    @BeforeEach
+    void setUp() {
+        properties = new CalendarUiProperties();
+        properties.setEnsureOnDemand(true);
+        properties.setProviderCode("nager");
+        properties.setRegion("IN-WB");
+        service = new CalendarSyncService(holidayRepository, externalCalendarFacade, properties);
+    }
+
+    @Test
+    void ensureRangeShouldDoNothingWhenOnDemandSyncDisabled() {
+        properties.setEnsureOnDemand(false);
+
+        service.ensureRange(LocalDate.of(2024, 1, 1), LocalDate.of(2026, 12, 31));
+
+        verifyNoHolidayLookupOrSync();
+    }
+
+    @Test
+    void ensureRangeShouldTraverseAllYearsInWindow() {
+        when(holidayRepository.existsByDateBetweenAndRegion(any(), any(), eq("IN-WB"))).thenReturn(true);
+
+        service.ensureRange(LocalDate.of(2024, 12, 20), LocalDate.of(2026, 1, 10));
+
+        verify(holidayRepository).existsByDateBetweenAndRegion(LocalDate.of(2024, 1, 1), LocalDate.of(2024, 366), "IN-WB");
+        verify(holidayRepository).existsByDateBetweenAndRegion(LocalDate.of(2025, 1, 1), LocalDate.of(2025, 365), "IN-WB");
+        verify(holidayRepository).existsByDateBetweenAndRegion(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 365), "IN-WB");
+        verify(externalCalendarFacade, never()).sync(any(), any(), any());
+    }
+
+    @Test
+    void ensureYearShouldTriggerSyncWhenNoCacheExists() {
+        when(holidayRepository.existsByDateBetweenAndRegion(any(), any(), eq("IN-WB"))).thenReturn(false);
+
+        service.ensureYear(Year.of(2025));
+
+        verify(externalCalendarFacade).sync("nager", Year.of(2025), "IN-WB");
+    }
+
+    @Test
+    void ensureYearShouldUseDefaultProviderAndRegionWhenBlank() {
+        properties.setProviderCode(" ");
+        properties.setRegion(null);
+        when(holidayRepository.existsByDateBetweenAndRegion(any(), any(), eq(TimeUtils.DEFAULT_REGION))).thenReturn(false);
+
+        service.ensureYear(Year.of(2024));
+
+        verify(externalCalendarFacade).sync("nager", Year.of(2024), TimeUtils.DEFAULT_REGION);
+    }
+
+    @Test
+    void syncYearShouldSwallowProviderFailures() {
+        when(externalCalendarFacade.sync(any(), any(), any())).thenThrow(new RuntimeException("upstream unavailable"));
+
+        service.syncYear(Year.of(2027));
+
+        // Method should not propagate provider failures because sync is best-effort.
+        verify(externalCalendarFacade).sync("nager", Year.of(2027), "IN-WB");
+    }
+
+    private void verifyNoHolidayLookupOrSync() {
+        verify(holidayRepository, never()).existsByDateBetweenAndRegion(any(), any(), any());
+        verify(externalCalendarFacade, never()).sync(any(), any(), any());
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/CalendarUiServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/CalendarUiServiceTest.java
@@ -1,0 +1,49 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.dto.CalendarViewResponse;
+import com.ticketingSystem.calendar.dto.CalendarConfigDto;
+import com.ticketingSystem.calendar.dto.FullCalendarEventDto;
+import com.ticketingSystem.calendar.service.CalendarQueryService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CalendarUiServiceTest {
+
+    @Mock
+    private CalendarQueryService calendarQueryService;
+    @Mock
+    private CalendarSyncService calendarSyncService;
+
+    @InjectMocks
+    private CalendarUiService service;
+
+    @Test
+    void loadCalendarShouldSyncThenReturnConfigAndEvents() {
+        LocalDate from = LocalDate.of(2025, 1, 1);
+        LocalDate to = LocalDate.of(2025, 1, 31);
+        CalendarConfigDto config = new CalendarConfigDto();
+        List<FullCalendarEventDto> events = List.of(new FullCalendarEventDto());
+        when(calendarQueryService.getCalendarConfig(from, to)).thenReturn(config);
+        when(calendarQueryService.listEvents(from, to)).thenReturn(events);
+
+        CalendarViewResponse response = service.loadCalendar(from, to);
+
+        // We first ensure cache freshness, then execute the read queries.
+        verify(calendarSyncService).ensureRange(from, to);
+        verify(calendarQueryService).getCalendarConfig(from, to);
+        verify(calendarQueryService).listEvents(from, to);
+        assertThat(response.config()).isEqualTo(config);
+        assertThat(response.events()).containsExactlyElementsOf(events);
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/CategoryServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/CategoryServiceTest.java
@@ -1,0 +1,99 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.dto.CategoryDto;
+import com.ticketingSystem.api.models.Category;
+import com.ticketingSystem.api.repository.CategoryRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryServiceTest {
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @InjectMocks
+    private CategoryService service;
+
+    @Test
+    void getAllCategoriesShouldMapEntitiesToDtos() {
+        Category category = new Category();
+        category.setCategoryId("c1");
+        category.setCategory("Infrastructure");
+        category.setIsActive("Y");
+        when(categoryRepository.findAll()).thenReturn(List.of(category));
+
+        List<CategoryDto> result = service.getAllCategories();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCategoryId()).isEqualTo("c1");
+        assertThat(result.get(0).getCategory()).isEqualTo("Infrastructure");
+    }
+
+    @Test
+    void saveCategoryShouldPopulateDefaultsAndAuditFields() {
+        Category category = new Category();
+        category.setCategory("Electrical");
+        when(categoryRepository.save(category)).thenReturn(category);
+
+        service.saveCategory(category);
+
+        assertThat(category.getTimestamp()).isNotNull();
+        assertThat(category.getLastUpdated()).isNotNull();
+        assertThat(category.getIsActive()).isEqualTo("Y");
+    }
+
+    @Test
+    void updateCategoryShouldOnlyOverwriteNullableFieldsWhenProvided() {
+        Category existing = new Category();
+        existing.setCategory("Old");
+        existing.setUpdatedBy("u1");
+        existing.setIsActive("Y");
+        Category update = new Category();
+        update.setCategory("New");
+        // null values here should preserve existing optional values.
+        update.setUpdatedBy(null);
+        update.setIsActive(null);
+
+        when(categoryRepository.findById("1")).thenReturn(Optional.of(existing));
+        when(categoryRepository.save(existing)).thenReturn(existing);
+
+        Optional<Category> result = service.updateCategory("1", update);
+
+        assertThat(result).contains(existing);
+        assertThat(existing.getCategory()).isEqualTo("New");
+        assertThat(existing.getUpdatedBy()).isEqualTo("u1");
+        assertThat(existing.getIsActive()).isEqualTo("Y");
+    }
+
+    @Test
+    void updateCategoryShouldReturnEmptyWhenMissing() {
+        when(categoryRepository.findById("404")).thenReturn(Optional.empty());
+
+        assertThat(service.updateCategory("404", new Category())).isEmpty();
+    }
+
+    @Test
+    void deleteMethodsShouldDelegateToRepository() {
+        service.deleteCategory("one");
+        verify(categoryRepository).deleteById("one");
+
+        List<String> ids = List.of("a", "b");
+        service.deleteCategories(ids);
+
+        ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
+        verify(categoryRepository).deleteAllById(captor.capture());
+        assertThat(captor.getValue()).containsExactly("a", "b");
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/ClientCredentialSeederTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/ClientCredentialSeederTest.java
@@ -1,0 +1,58 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.config.MobileClientProperties;
+import com.ticketingSystem.api.models.ClientCredential;
+import com.ticketingSystem.api.repository.ClientCredentialRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ClientCredentialSeederTest {
+
+    @Mock
+    private ClientCredentialService clientCredentialService;
+    @Mock
+    private ClientCredentialRepository clientCredentialRepository;
+
+    private MobileClientProperties properties;
+    private ClientCredentialSeeder seeder;
+
+    @BeforeEach
+    void setUp() {
+        properties = new MobileClientProperties();
+        properties.setId("mobile-client");
+        properties.setSecret("mobile-secret");
+        properties.setDescription("Parent app");
+        seeder = new ClientCredentialSeeder(properties, clientCredentialService, clientCredentialRepository);
+    }
+
+    @Test
+    void ensureMobileClientCredentialShouldSkipCreationWhenExistingCredentialFound() {
+        when(clientCredentialRepository.findByClientIdAndRevokedAtIsNull("mobile-client"))
+                .thenReturn(Optional.of(new ClientCredential()));
+
+        seeder.ensureMobileClientCredential();
+
+        verify(clientCredentialService, never()).registerClient("mobile-client", "mobile-secret", "Parent app");
+    }
+
+    @Test
+    void ensureMobileClientCredentialShouldCreateMissingCredential() {
+        when(clientCredentialRepository.findByClientIdAndRevokedAtIsNull("mobile-client"))
+                .thenReturn(Optional.empty());
+
+        seeder.ensureMobileClientCredential();
+
+        // Seeder should bootstrap expected mobile credentials exactly once when absent.
+        verify(clientCredentialService).registerClient("mobile-client", "mobile-secret", "Parent app");
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/ClientCredentialServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/ClientCredentialServiceTest.java
@@ -1,0 +1,97 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.models.ClientCredential;
+import com.ticketingSystem.api.models.ClientToken;
+import com.ticketingSystem.api.repository.ClientCredentialRepository;
+import com.ticketingSystem.api.repository.ClientTokenRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCrypt;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ClientCredentialServiceTest {
+
+    @Mock
+    private ClientCredentialRepository clientCredentialRepository;
+    @Mock
+    private ClientTokenRepository clientTokenRepository;
+
+    @InjectMocks
+    private ClientCredentialService service;
+
+    @Test
+    void registerClientShouldPersistHashedSecretAndMetadata() {
+        when(clientCredentialRepository.save(any(ClientCredential.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ClientCredential credential = service.registerClient("client-a", "raw-secret", "description");
+
+        assertThat(credential.getClientId()).isEqualTo("client-a");
+        assertThat(credential.getDescription()).isEqualTo("description");
+        assertThat(credential.getCreatedAt()).isNotNull();
+        assertThat(BCrypt.checkpw("raw-secret", credential.getClientSecretHash())).isTrue();
+    }
+
+    @Test
+    void authenticateAndValidateShouldRespectBcryptSecretComparison() {
+        ClientCredential credential = new ClientCredential();
+        credential.setClientSecretHash(BCrypt.hashpw("secret", BCrypt.gensalt()));
+        when(clientCredentialRepository.findByClientIdAndRevokedAtIsNull("client"))
+                .thenReturn(Optional.of(credential));
+
+        assertThat(service.authenticate("client", "secret")).contains(credential);
+        assertThat(service.authenticate("client", "wrong")).isEmpty();
+        assertThat(service.validateClientSecret("client", "secret")).isTrue();
+        assertThat(service.validateClientSecret("client", "wrong")).isFalse();
+    }
+
+    @Test
+    void recordAccessTokenShouldPersistFieldsAndIssuedAt() {
+        ClientCredential credential = new ClientCredential();
+        when(clientTokenRepository.save(any(ClientToken.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        LocalDateTime accessExpiry = LocalDateTime.now().plusMinutes(30);
+        ClientToken token = service.recordAccessToken(credential, "access-hash", accessExpiry, "refresh-hash", null);
+
+        assertThat(token.getClientCredential()).isEqualTo(credential);
+        assertThat(token.getAccessTokenHash()).isEqualTo("access-hash");
+        assertThat(token.getRefreshTokenHash()).isEqualTo("refresh-hash");
+        assertThat(token.getAccessTokenExpiresAt()).isEqualTo(accessExpiry);
+        assertThat(token.getIssuedAt()).isNotNull();
+    }
+
+    @Test
+    void findAndRevokeMethodsShouldDelegateToRepositories() {
+        ClientCredential credential = new ClientCredential();
+        ClientToken token = new ClientToken();
+        when(clientTokenRepository.findActiveByAccessTokenHash(any(), any())).thenReturn(Optional.of(token));
+        when(clientTokenRepository.findActiveByRefreshTokenHash(any(), any())).thenReturn(Optional.of(token));
+
+        assertThat(service.findActiveToken("a")).contains(token);
+        assertThat(service.findActiveRefreshToken("r")).contains(token);
+
+        service.revokeCredential(credential);
+        service.revokeToken(token);
+
+        ArgumentCaptor<ClientCredential> credentialCaptor = ArgumentCaptor.forClass(ClientCredential.class);
+        verify(clientCredentialRepository).save(credentialCaptor.capture());
+        assertThat(credentialCaptor.getValue().getRevokedAt()).isNotNull();
+
+        ArgumentCaptor<ClientToken> tokenCaptor = ArgumentCaptor.forClass(ClientToken.class);
+        verify(clientTokenRepository).save(tokenCaptor.capture());
+        assertThat(tokenCaptor.getValue().getRevokedAt()).isNotNull();
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/ClientTokenServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/ClientTokenServiceTest.java
@@ -1,0 +1,113 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.config.ClientTokenProperties;
+import com.ticketingSystem.api.config.JwtProperties;
+import com.ticketingSystem.api.models.ClientCredential;
+import com.ticketingSystem.api.models.ClientToken;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ClientTokenServiceTest {
+
+    @Mock
+    private ClientCredentialService clientCredentialService;
+
+    private ClientTokenProperties tokenProperties;
+    private JwtProperties jwtProperties;
+    private ClientTokenService service;
+
+    @BeforeEach
+    void setUp() {
+        tokenProperties = new ClientTokenProperties();
+        tokenProperties.setAccessExpirationMinutes(5L);
+
+        jwtProperties = new JwtProperties();
+        jwtProperties.setSecret("12345678901234567890123456789012");
+
+        service = new ClientTokenService(clientCredentialService, tokenProperties, jwtProperties);
+    }
+
+    @Test
+    void issueAccessTokenShouldPersistHashedTokenAndReturnPublicPayload() {
+        ClientCredential credential = new ClientCredential();
+        credential.setClientId("mobile-app");
+
+        ClientTokenService.IssuedClientToken issued = service.issueAccessToken(credential);
+
+        assertThat(issued.clientId()).isEqualTo("mobile-app");
+        assertThat(issued.expiresInMinutes()).isEqualTo(5L);
+        assertThat(issued.accessToken()).isNotBlank();
+
+        ArgumentCaptor<String> hashCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<LocalDateTime> expiryCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        verify(clientCredentialService).recordAccessToken(eq(credential), hashCaptor.capture(), expiryCaptor.capture(), eq(null), eq(null));
+        // Persisted hash should never equal raw JWT token.
+        assertThat(hashCaptor.getValue()).isNotEqualTo(issued.accessToken());
+        assertThat(expiryCaptor.getValue()).isAfter(LocalDateTime.now().minusMinutes(1));
+    }
+
+    @Test
+    void findActiveTokenShouldHashRawTokenBeforeLookup() {
+        when(clientCredentialService.findActiveToken(any())).thenReturn(Optional.of(new ClientToken()));
+
+        Optional<ClientToken> result = service.findActiveToken("raw-token");
+
+        assertThat(result).isPresent();
+        verify(clientCredentialService).findActiveToken("34d328009b123fbbb0dc93f18b3e6de1ecf7b1a5783c33dff7ffe1926f09e943");
+    }
+
+    @Test
+    void verifyAccessTokenShouldReturnValidAndExpiredStates() throws InterruptedException {
+        ClientCredential credential = new ClientCredential();
+        credential.setClientId("c-1");
+
+        String validToken = service.issueAccessToken(credential).accessToken();
+        ClientTokenService.TokenVerificationResult validResult = service.verifyAccessToken(validToken);
+        assertThat(validResult.valid()).isTrue();
+        assertThat(validResult.expired()).isFalse();
+        assertThat(validResult.payload().clientId()).isEqualTo("c-1");
+
+        tokenProperties.setAccessExpirationMinutes(0L);
+        ClientTokenService shortLivedService = new ClientTokenService(clientCredentialService, tokenProperties, jwtProperties);
+        String expiredToken = shortLivedService.issueAccessToken(credential).accessToken();
+        Thread.sleep(1100); // ensure token crosses expiration second boundary
+
+        ClientTokenService.TokenVerificationResult expiredResult = shortLivedService.verifyAccessToken(expiredToken);
+        assertThat(expiredResult.valid()).isFalse();
+        assertThat(expiredResult.expired()).isTrue();
+        assertThat(expiredResult.payload()).isNotNull();
+    }
+
+    @Test
+    void verifyAccessTokenShouldReturnInvalidForMalformedToken() {
+        ClientTokenService.TokenVerificationResult result = service.verifyAccessToken("definitely-not-a-jwt");
+
+        assertThat(result.valid()).isFalse();
+        assertThat(result.expired()).isFalse();
+        assertThat(result.payload()).isNull();
+    }
+
+    @Test
+    void issueAccessTokenShouldFailWhenSecretMissing() {
+        jwtProperties.setSecret(" ");
+        ClientTokenService invalidService = new ClientTokenService(clientCredentialService, tokenProperties, jwtProperties);
+
+        assertThrows(IllegalStateException.class,
+                () -> invalidService.issueAccessToken(new ClientCredential()));
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/DistrictMasterServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/DistrictMasterServiceTest.java
@@ -1,0 +1,44 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.models.DistrictMaster;
+import com.ticketingSystem.api.repository.DistrictMasterRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DistrictMasterServiceTest {
+
+    @Mock
+    private DistrictMasterRepository repository;
+
+    @InjectMocks
+    private DistrictMasterService service;
+
+    @Test
+    void getAllShouldReturnRepositoryResults() {
+        List<DistrictMaster> districts = List.of(new DistrictMaster(), new DistrictMaster());
+        when(repository.findAll()).thenReturn(districts);
+
+        assertThat(service.getAll()).containsExactlyElementsOf(districts);
+    }
+
+    @Test
+    void getByHrmsRegCodeShouldDelegateSortedLookup() {
+        List<DistrictMaster> districts = List.of(new DistrictMaster());
+        when(repository.findByHrmsRegCodeOrderByDistrictNameAsc("REG-1")).thenReturn(districts);
+
+        List<DistrictMaster> result = service.getByHrmsRegCode("REG-1");
+
+        verify(repository).findByHrmsRegCodeOrderByDistrictNameAsc("REG-1");
+        assertThat(result).containsExactlyElementsOf(districts);
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/DivisionHistoryServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/DivisionHistoryServiceTest.java
@@ -1,0 +1,62 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.exception.TicketNotFoundException;
+import com.ticketingSystem.api.models.DivisionHistory;
+import com.ticketingSystem.api.models.Ticket;
+import com.ticketingSystem.api.repository.DivisionHistoryRepository;
+import com.ticketingSystem.api.repository.TicketRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DivisionHistoryServiceTest {
+
+    @Mock
+    private DivisionHistoryRepository divisionHistoryRepository;
+    @Mock
+    private TicketRepository ticketRepository;
+
+    @InjectMocks
+    private DivisionHistoryService service;
+
+    @Test
+    void addHistoryShouldPersistAuditRecord() {
+        Ticket ticket = new Ticket();
+        when(ticketRepository.findById("T-1")).thenReturn(Optional.of(ticket));
+        when(divisionHistoryRepository.save(any(DivisionHistory.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        DivisionHistory saved = service.addHistory("T-1", "editor", "A", "B", "Escalated");
+
+        assertThat(saved.getTicket()).isEqualTo(ticket);
+        assertThat(saved.getUpdatedBy()).isEqualTo("editor");
+        assertThat(saved.getPreviousDivision()).isEqualTo("A");
+        assertThat(saved.getCurrentDivision()).isEqualTo("B");
+        assertThat(saved.getRemark()).isEqualTo("Escalated");
+        assertThat(saved.getTimestamp()).isNotNull();
+
+        ArgumentCaptor<DivisionHistory> captor = ArgumentCaptor.forClass(DivisionHistory.class);
+        verify(divisionHistoryRepository).save(captor.capture());
+        assertThat(captor.getValue().getTimestamp()).isNotNull();
+    }
+
+    @Test
+    void addHistoryShouldThrowWhenTicketNotFound() {
+        when(ticketRepository.findById("404")).thenReturn(Optional.empty());
+
+        assertThrows(TicketNotFoundException.class,
+                () -> service.addHistory("404", "u", "x", "y", "remark"));
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/DivisionServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/DivisionServiceTest.java
@@ -1,0 +1,36 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.models.DivisionMaster;
+import com.ticketingSystem.api.repository.DivisionMasterRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DivisionServiceTest {
+
+    @Mock
+    private DivisionMasterRepository divisionMasterRepository;
+
+    @InjectMocks
+    private DivisionService service;
+
+    @Test
+    void getAllActiveShouldOnlyRequestActiveFlagValue() {
+        List<DivisionMaster> active = List.of(new DivisionMaster());
+        when(divisionMasterRepository.findByIsActive("1")).thenReturn(active);
+
+        List<DivisionMaster> result = service.getAllActive();
+
+        verify(divisionMasterRepository).findByIsActive("1");
+        assertThat(result).containsExactlyElementsOf(active);
+    }
+}


### PR DESCRIPTION
### Motivation
- Improve unit test coverage for core service-layer logic and guardrails to reduce regressions and document intended behavior. 
- Capture edge cases around authentication (bcrypt, migrated hashes, oversized inputs), token issuance/verification, on-demand calendar syncing, and history/audit record creation.
- Validate repository delegation and defaulting/validation logic in CRUD and seeder code.

### Description
- Added 11 new JUnit/Mockito test classes exercising service behaviour for `AssignmentHistoryService`, `AuthService`, `CalendarSyncService`, `CalendarUiService`, `CategoryService`, `ClientCredentialSeeder`, `ClientCredentialService`, `ClientTokenService`, `DistrictMasterService`, `DivisionHistoryService`, and `DivisionService`, each covering happy paths and relevant edge cases. 
- Covered authentication flows including requester vs internal portal selection, bcrypt verification, hash-vs-hash comparison for migrated passwords, and rejection of overlong UTF-8 password inputs. 
- Covered client credential and token flows including secret hashing on registration, token recording, lookup by hashed token, JWT generation and verification (valid, expired, malformed), and the missing-JWT-secret failure case. 
- Covered calendar sync semantics including on-demand toggling, multi-year traversal, provider/region fallbacks, and robustness to provider failures, plus the UI flow that ensures sync before query and composes the response. 

### Testing
- Added the new test classes under `api/src/test/java/com/ticketingSystem/api/service` and validated assertions and mocks locally in the repository. 
- Attempted to run a focused Gradle test run for the new suites; the build failed to initialize due to an environment JDK/Gradle compatibility issue (`Unsupported class file major version 69`) so tests were not executed in this environment. 
- Performed an automated SHA-256 computation to assert the expected token-hash used by `ClientTokenService` lookup logic and updated the tests to assert against that computed value.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3db5d9bc8833289e2a2776e9744b0)