### PR TITLE
Fix CalendarUiServiceTest to construct record DTOs with required args

### DIFF
--- a/api/src/test/java/com/ticketingSystem/api/service/CalendarUiServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/CalendarUiServiceTest.java
@@ -1,6 +1,7 @@
 package com.ticketingSystem.api.service;
 
 import com.ticketingSystem.api.dto.CalendarViewResponse;
+import com.ticketingSystem.calendar.dto.BusinessHoursDto;
 import com.ticketingSystem.calendar.dto.CalendarConfigDto;
 import com.ticketingSystem.calendar.dto.FullCalendarEventDto;
 import com.ticketingSystem.calendar.service.CalendarQueryService;
@@ -32,8 +33,19 @@ class CalendarUiServiceTest {
     void loadCalendarShouldSyncThenReturnConfigAndEvents() {
         LocalDate from = LocalDate.of(2025, 1, 1);
         LocalDate to = LocalDate.of(2025, 1, 31);
-        CalendarConfigDto config = new CalendarConfigDto();
-        List<FullCalendarEventDto> events = List.of(new FullCalendarEventDto());
+        BusinessHoursDto defaultHours = new BusinessHoursDto(540, 1020, new Integer[]{1, 2, 3, 4, 5});
+        CalendarConfigDto config = new CalendarConfigDto("UTC", defaultHours, List.of());
+        List<FullCalendarEventDto> events = List.of(
+                new FullCalendarEventDto(
+                        "evt-1",
+                        "Incident triage",
+                        "2025-01-15T09:00:00Z",
+                        "2025-01-15T10:00:00Z",
+                        false,
+                        "#1f77b4",
+                        "#ffffff"
+                )
+        );
         when(calendarQueryService.getCalendarConfig(from, to)).thenReturn(config);
         when(calendarQueryService.listEvents(from, to)).thenReturn(events);
 


### PR DESCRIPTION
### Motivation

- Tests failed to compile because Java records `CalendarConfigDto` and `FullCalendarEventDto` were being instantiated with no-arg constructors while their canonical constructors require specific fields, so the test needed to be updated to construct records with required arguments.

### Description

- Added an import for `BusinessHoursDto` and created a `BusinessHoursDto` test fixture using `new BusinessHoursDto(540, 1020, new Integer[]{1, 2, 3, 4, 5})`.
- Replaced the no-arg `CalendarConfigDto` instantiation with `new CalendarConfigDto("UTC", defaultHours, List.of())`.
- Replaced the no-arg `FullCalendarEventDto` with a fully populated record instance using `new FullCalendarEventDto("evt-1", "Incident triage", "2025-01-15T09:00:00Z", "2025-01-15T10:00:00Z", false, "#1f77b4", "#ffffff")`.

### Testing

- Ran the single test via `cd api && ./gradlew test --tests com.ticketingSystem.api.service.CalendarUiServiceTest`, which could not complete in this environment due to a Gradle/JDK compatibility error `Unsupported class file major version 69` and thus did not report test pass/fail for the logic changes.
- The change is limited to test fixtures/instantiation and resolves the compile errors caused by incorrect record construction in the test code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3ebd472748332a17445a0a20527da)