### PR TITLE
Add comprehensive JUnit tests for backend service layer

### DIFF
--- a/api/src/test/java/com/ticketingSystem/api/service/DocumentServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/DocumentServiceTest.java
@@ -1,0 +1,86 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.exception.ResourceNotFoundException;
+import com.ticketingSystem.api.models.Document;
+import com.ticketingSystem.api.repository.DocumentRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DocumentServiceTest {
+
+    @Mock
+    private DocumentRepository documentRepository;
+
+    @InjectMocks
+    private DocumentService service;
+
+    @Test
+    void getDocumentsShouldReturnOnlyNonDeletedDocumentsFromRepository() {
+        Document d = new Document();
+        d.setId("doc-1");
+        when(documentRepository.findByIsDeletedFalse()).thenReturn(List.of(d));
+
+        assertThat(service.getDocuments()).containsExactly(d);
+    }
+
+    @Test
+    void addDocumentShouldPersistProvidedDocument() {
+        Document doc = new Document();
+        doc.setTitle("FAQ");
+        when(documentRepository.save(doc)).thenReturn(doc);
+
+        assertThat(service.addDocument(doc)).isSameAs(doc);
+        verify(documentRepository).save(doc);
+    }
+
+    @Test
+    void updateDocumentShouldCopyEditableFieldsAndSave() {
+        Document existing = new Document();
+        existing.setId("doc-1");
+        existing.setTitle("Old");
+
+        Document update = new Document();
+        update.setTitle("New title");
+        update.setDescription("Updated description");
+        update.setType("pdf");
+        update.setAttachmentPath("ticket/1/new.pdf");
+
+        when(documentRepository.findById("doc-1")).thenReturn(Optional.of(existing));
+        when(documentRepository.save(existing)).thenReturn(existing);
+
+        Document result = service.updateDocument("doc-1", update);
+
+        assertThat(result.getTitle()).isEqualTo("New title");
+        assertThat(result.getDescription()).isEqualTo("Updated description");
+        assertThat(result.getType()).isEqualTo("pdf");
+        assertThat(result.getAttachmentPath()).isEqualTo("ticket/1/new.pdf");
+    }
+
+    @Test
+    void updateDocumentShouldThrowWhenDocumentIsMissing() {
+        when(documentRepository.findById("missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.updateDocument("missing", new Document()))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void softDeleteDocumentShouldThrowWhenDocumentIsMissing() {
+        when(documentRepository.findById("missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.softDeleteDocument("missing"))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/ExternalClientAuthServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/ExternalClientAuthServiceTest.java
@@ -1,0 +1,57 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.dto.ClientCredentialRequest;
+import com.ticketingSystem.api.dto.ClientTokenResponse;
+import com.ticketingSystem.api.models.ClientCredential;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ExternalClientAuthServiceTest {
+
+    @Mock
+    private ClientCredentialService clientCredentialService;
+    @Mock
+    private ClientTokenService clientTokenService;
+
+    @InjectMocks
+    private ExternalClientAuthService service;
+
+    @Test
+    void exchangeCredentialsShouldReturnEmptyWhenAuthenticationFails() {
+        ClientCredentialRequest request = new ClientCredentialRequest();
+        request.setClientId("client");
+        request.setClientSecret("wrong");
+        when(clientCredentialService.authenticate("client", "wrong")).thenReturn(Optional.empty());
+
+        assertThat(service.exchangeCredentials(request)).isEmpty();
+    }
+
+    @Test
+    void exchangeCredentialsShouldIssueTokenWhenAuthenticationSucceeds() {
+        ClientCredentialRequest request = new ClientCredentialRequest();
+        request.setClientId("client");
+        request.setClientSecret("secret");
+        ClientCredential credential = new ClientCredential();
+        when(clientCredentialService.authenticate("client", "secret")).thenReturn(Optional.of(credential));
+        when(clientTokenService.issueAccessToken(credential))
+                .thenReturn(new ClientTokenService.IssuedClientToken("jwt", 15L, "client"));
+
+        Optional<ClientTokenResponse> result = service.exchangeCredentials(request);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().accessToken()).isEqualTo("jwt");
+        assertThat(result.get().expiresInMinutes()).isEqualTo(15L);
+        assertThat(result.get().clientId()).isEqualTo("client");
+        verify(clientTokenService).issueAccessToken(credential);
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/ExternalSsoTokenServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/ExternalSsoTokenServiceTest.java
@@ -1,0 +1,78 @@
+package com.ticketingSystem.api.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ticketingSystem.api.dto.ExternalSsoTokenResponse;
+import com.ticketingSystem.api.models.SsoLoginPayload;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ExternalSsoTokenServiceTest {
+
+    private ExternalSsoTokenService service;
+    private RestTemplate restTemplate;
+
+    @BeforeEach
+    void setUp() {
+        service = new ExternalSsoTokenService("https://sso.example/token", "shared-secret", new ObjectMapper());
+        restTemplate = mock(RestTemplate.class);
+        // Replace the internally-created RestTemplate with a mock to unit test network behavior.
+        ReflectionTestUtils.setField(service, "restTemplate", restTemplate);
+    }
+
+    @Test
+    void requestTokenShouldReturnBodyForSuccessful2xxResponse() {
+        ExternalSsoTokenResponse body = new ExternalSsoTokenResponse();
+        body.setAccessToken("abc");
+        when(restTemplate.postForEntity(eq("https://sso.example/token"), any(HttpEntity.class), eq(ExternalSsoTokenResponse.class)))
+                .thenReturn(new ResponseEntity<>(body, HttpStatus.OK));
+
+        Optional<ExternalSsoTokenResponse> result = service.requestToken(payload());
+
+        assertThat(result).contains(body);
+
+        ArgumentCaptor<HttpEntity> requestCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate).postForEntity(eq("https://sso.example/token"), requestCaptor.capture(), eq(ExternalSsoTokenResponse.class));
+        String serializedBody = requestCaptor.getValue().getBody().toString();
+        assertThat(serializedBody).contains("user1", "client-1", "auth-123", "shared-secret");
+    }
+
+    @Test
+    void requestTokenShouldReturnEmptyForNon2xxResponse() {
+        when(restTemplate.postForEntity(eq("https://sso.example/token"), any(HttpEntity.class), eq(ExternalSsoTokenResponse.class)))
+                .thenReturn(new ResponseEntity<>(new ExternalSsoTokenResponse(), HttpStatus.BAD_REQUEST));
+
+        assertThat(service.requestToken(payload())).isEmpty();
+    }
+
+    @Test
+    void requestTokenShouldReturnEmptyWhenRestClientThrows() {
+        when(restTemplate.postForEntity(eq("https://sso.example/token"), any(HttpEntity.class), eq(ExternalSsoTokenResponse.class)))
+                .thenThrow(new RestClientException("downstream unavailable"));
+
+        assertThat(service.requestToken(payload())).isEmpty();
+    }
+
+    private SsoLoginPayload payload() {
+        return SsoLoginPayload.builder()
+                .username("user1")
+                .clientId("client-1")
+                .authCode("auth-123")
+                .build();
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/FaqServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/FaqServiceTest.java
@@ -1,0 +1,100 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.dto.FaqDto;
+import com.ticketingSystem.api.exception.ResourceNotFoundException;
+import com.ticketingSystem.api.models.Faq;
+import com.ticketingSystem.api.repository.FaqRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FaqServiceTest {
+
+    @Mock
+    private FaqRepository faqRepository;
+
+    @InjectMocks
+    private FaqService service;
+
+    @Test
+    void getAllFaqsShouldMapEntitiesToDtos() {
+        Faq faq = new Faq();
+        faq.setId("f1");
+        faq.setQuestionEn("How?");
+        when(faqRepository.findAll()).thenReturn(List.of(faq));
+
+        List<FaqDto> result = service.getAllFaqs();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo("f1");
+        assertThat(result.get(0).getQuestionEn()).isEqualTo("How?");
+    }
+
+    @Test
+    void getFaqShouldThrowWhenEntityNotFound() {
+        when(faqRepository.findById("missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getFaq("missing"))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    @Test
+    void createFaqShouldCopyFieldsAndReturnDto() {
+        FaqDto dto = baseDto();
+        when(faqRepository.save(any(Faq.class))).thenAnswer(invocation -> {
+            Faq entity = invocation.getArgument(0);
+            entity.setId("new-id");
+            return entity;
+        });
+
+        FaqDto saved = service.createFaq(dto);
+
+        assertThat(saved.getId()).isEqualTo("new-id");
+        assertThat(saved.getQuestionHi()).isEqualTo(dto.getQuestionHi());
+        assertThat(saved.getAnswerEn()).isEqualTo(dto.getAnswerEn());
+    }
+
+    @Test
+    void updateFaqShouldUpdateMutableFieldsOnExistingEntity() {
+        Faq existing = new Faq();
+        existing.setId("f1");
+        existing.setQuestionEn("Old");
+        when(faqRepository.findById("f1")).thenReturn(Optional.of(existing));
+        when(faqRepository.save(existing)).thenReturn(existing);
+
+        FaqDto update = baseDto();
+        update.setQuestionEn("New question");
+
+        FaqDto result = service.updateFaq("f1", update);
+
+        assertThat(result.getQuestionEn()).isEqualTo("New question");
+        verify(faqRepository).save(existing);
+    }
+
+    private FaqDto baseDto() {
+        FaqDto dto = new FaqDto();
+        dto.setQuestionEn("Q en");
+        dto.setQuestionHi("Q hi");
+        dto.setAnswerEn("A en");
+        dto.setAnswerHi("A hi");
+        dto.setKeywords("k1,k2");
+        dto.setCreatedBy("creator");
+        dto.setCreatedOn(LocalDateTime.now());
+        dto.setUpdatedBy("upd");
+        dto.setUpdatedOn(LocalDateTime.now());
+        return dto;
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/FileStorageServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/FileStorageServiceTest.java
@@ -1,0 +1,136 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.config.OciProperties;
+import com.ticketingSystem.api.exception.TicketNotFoundException;
+import com.ticketingSystem.api.models.Ticket;
+import com.ticketingSystem.api.models.UploadedFile;
+import com.ticketingSystem.api.repository.TicketRepository;
+import com.ticketingSystem.api.repository.UploadedFileRepository;
+import com.ticketingSystem.api.service.feignClients.OciFeignClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FileStorageServiceTest {
+
+    @Mock
+    private UploadedFileRepository uploadedFileRepository;
+    @Mock
+    private TicketRepository ticketRepository;
+    @Mock
+    private OciObjectStorageService ociObjectStorageService;
+    @Mock
+    private OciFeignClient ociFeignClient;
+
+    @Spy
+    @InjectMocks
+    private FileStorageService service;
+
+    private OciProperties ociProperties;
+
+    @BeforeEach
+    void setUp() {
+        ociProperties = new OciProperties();
+        ReflectionTestUtils.setField(ociProperties, "bucketObject", "/attachments/");
+        ReflectionTestUtils.setField(service, "ociProperties", ociProperties);
+    }
+
+    @Test
+    void saveShouldPersistMetadataUploadBytesAndReturnRelativePath() throws Exception {
+        Ticket ticket = new Ticket();
+        when(ticketRepository.findById("T1")).thenReturn(Optional.of(ticket));
+        when(uploadedFileRepository.save(any(UploadedFile.class))).thenAnswer(invocation -> {
+            UploadedFile uf = invocation.getArgument(0);
+            if (uf.getId() == null) {
+                uf.setId("file-123");
+            }
+            return uf;
+        });
+        doReturn("ticket/attachments/T1/file-123_test.pdf").when(service)
+                .uploadFile(eq("attachments/T1/file-123_test.pdf"), any(byte[].class));
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "test.pdf",
+                "application/pdf",
+                "hello".getBytes(StandardCharsets.UTF_8)
+        );
+
+        String path = service.save(file, "T1", "user-a");
+
+        assertThat(path).isEqualTo("attachments/T1/file-123_test.pdf");
+
+        ArgumentCaptor<UploadedFile> captor = ArgumentCaptor.forClass(UploadedFile.class);
+        verify(uploadedFileRepository, times(2)).save(captor.capture());
+        assertThat(captor.getAllValues().get(1).getRelativePath()).isEqualTo("attachments/T1/file-123_test.pdf");
+    }
+
+    @Test
+    void saveShouldDeleteMetadataWhenUploadFails() throws Exception {
+        Ticket ticket = new Ticket();
+        when(ticketRepository.findById("T1")).thenReturn(Optional.of(ticket));
+        UploadedFile saved = new UploadedFile();
+        saved.setId("file-1");
+        when(uploadedFileRepository.save(any(UploadedFile.class))).thenReturn(saved);
+        doThrow(new RuntimeException("oci fail")).when(service)
+                .uploadFile(eq("attachments/T1/file-1_image.png"), any(byte[].class));
+
+        MockMultipartFile file = new MockMultipartFile("file", "image.png", "image/png", new byte[]{1, 2});
+
+        assertThatThrownBy(() -> service.save(file, "T1", "u1"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("oci fail");
+
+        verify(uploadedFileRepository).delete(saved);
+    }
+
+    @Test
+    void saveShouldThrowWhenTicketIsMissing() {
+        when(ticketRepository.findById("missing")).thenReturn(Optional.empty());
+        MockMultipartFile file = new MockMultipartFile("file", "a.txt", "text/plain", new byte[]{1});
+
+        assertThatThrownBy(() -> service.save(file, "missing", "u"))
+                .isInstanceOf(TicketNotFoundException.class);
+    }
+
+    @Test
+    void privateObjectKeyHelpersShouldNormalizeValuesForEdgeInputs() throws Exception {
+        Method normalizeObjectKey = FileStorageService.class.getDeclaredMethod("normalizeObjectKey", String.class);
+        Method ensureTicketPrefix = FileStorageService.class.getDeclaredMethod("ensureTicketPrefix", String.class);
+        Method buildObjectName = FileStorageService.class.getDeclaredMethod("buildObjectName", String.class, String.class);
+        normalizeObjectKey.setAccessible(true);
+        ensureTicketPrefix.setAccessible(true);
+        buildObjectName.setAccessible(true);
+
+        String normalized = (String) normalizeObjectKey.invoke(service, "https://host/n/ns/b/bucket/o/path/file.png");
+        assertThat(normalized).isEqualTo("path/file.png");
+
+        String prefixed = (String) ensureTicketPrefix.invoke(service, "path/file.png");
+        assertThat(prefixed).isEqualTo("ticket/path/file.png");
+
+        String objectName = (String) buildObjectName.invoke(service, "\\nested//path/", "ignored");
+        assertThat(objectName).isEqualTo("ticket/nested/path");
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/HeadquarterMasterServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/HeadquarterMasterServiceTest.java
@@ -1,0 +1,33 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.models.HeadquarterMaster;
+import com.ticketingSystem.api.repository.HeadquarterMasterRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HeadquarterMasterServiceTest {
+
+    @Mock
+    private HeadquarterMasterRepository repository;
+
+    @InjectMocks
+    private HeadquarterMasterService service;
+
+    @Test
+    void getAllShouldDelegateToRepository() {
+        HeadquarterMaster one = new HeadquarterMaster();
+        one.setHeadquarterCode("H1");
+        when(repository.findAll()).thenReturn(List.of(one));
+
+        assertThat(service.getAll()).containsExactly(one);
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/IssueTypeServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/IssueTypeServiceTest.java
@@ -1,0 +1,58 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.models.IssueType;
+import com.ticketingSystem.api.repository.IssueTypeRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IssueTypeServiceTest {
+
+    @Mock
+    private IssueTypeRepository repository;
+
+    @InjectMocks
+    private IssueTypeService service;
+
+    @Test
+    void getAllActiveShouldQueryWithExpectedActiveFlag() {
+        when(repository.findByIsActive("1")).thenReturn(List.of(new IssueType()));
+
+        assertThat(service.getAllActive()).hasSize(1);
+    }
+
+    @Test
+    void isSlaEnabledForIssueTypeShouldReturnFalseForBlankId() {
+        assertThat(service.isSlaEnabledForIssueType(" ")).isFalse();
+        assertThat(service.isSlaEnabledForIssueType(null)).isFalse();
+    }
+
+    @Test
+    void isSlaEnabledForIssueTypeShouldReturnFalseWhenTypeMissingOrFlagNull() {
+        IssueType noFlag = new IssueType();
+        noFlag.setSlaFlag(null);
+        when(repository.findById("x")).thenReturn(Optional.of(noFlag));
+        when(repository.findById("missing")).thenReturn(Optional.empty());
+
+        assertThat(service.isSlaEnabledForIssueType("x")).isFalse();
+        assertThat(service.isSlaEnabledForIssueType("missing")).isFalse();
+    }
+
+    @Test
+    void isSlaEnabledForIssueTypeShouldReturnTrueWhenSlaFlagIsTrue() {
+        IssueType issueType = new IssueType();
+        issueType.setSlaFlag(true);
+        when(repository.findById("i1")).thenReturn(Optional.of(issueType));
+
+        assertThat(service.isSlaEnabledForIssueType("i1")).isTrue();
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/JwtTokenServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/JwtTokenServiceTest.java
@@ -1,0 +1,100 @@
+package com.ticketingSystem.api.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ticketingSystem.api.config.JwtProperties;
+import com.ticketingSystem.api.dto.LoginPayload;
+import com.ticketingSystem.api.enums.ClientType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JwtTokenServiceTest {
+
+    private JwtProperties jwtProperties;
+    private JwtTokenService service;
+
+    @BeforeEach
+    void setUp() {
+        jwtProperties = new JwtProperties();
+        jwtProperties.setSecret("12345678901234567890123456789012"); // >= 32 bytes for HS256
+        jwtProperties.setExpirationMinutes(5);
+        jwtProperties.setRefreshExpirationMinutes(60);
+        service = new JwtTokenService(jwtProperties, new ObjectMapper());
+    }
+
+    @Test
+    void accessTokenRoundTripShouldPreserveClaims() {
+        LoginPayload payload = payload();
+
+        String token = service.generateAccessToken(payload);
+
+        JwtTokenService.TokenVerificationResult verification = service.verifyAccessToken(token);
+        assertThat(verification.valid()).isTrue();
+        assertThat(verification.expired()).isFalse();
+        assertThat(verification.payload().getUsername()).isEqualTo("admin");
+        assertThat(verification.payload().getRoles()).containsExactly("ROLE_ADMIN");
+        assertThat(verification.payload().getAllowedStatusActionIds()).containsExactly("A1", "A2");
+    }
+
+    @Test
+    void refreshTokenShouldNotBeAcceptedAsAccessToken() {
+        String refreshToken = service.generateRefreshToken(payload());
+
+        assertThat(service.parseAccessToken(refreshToken)).isEmpty();
+        assertThat(service.verifyAccessToken(refreshToken).valid()).isFalse();
+        assertThat(service.parseRefreshToken(refreshToken)).isPresent();
+    }
+
+    @Test
+    void regenerateAccessTokenShouldSucceedForValidAccessTokenAndFailForRefreshToken() {
+        String accessToken = service.generateAccessToken(payload());
+        String refreshToken = service.generateRefreshToken(payload());
+
+        assertThat(service.regenerateAccessToken(accessToken)).isPresent();
+        assertThat(service.regenerateAccessToken(refreshToken)).isEmpty();
+    }
+
+    @Test
+    void parseShouldReturnEmptyForTamperedToken() {
+        String token = service.generateAccessToken(payload());
+        String tampered = token + "corrupt";
+
+        assertThat(service.parseAccessToken(tampered)).isEmpty();
+        assertThat(service.verifyAccessToken(tampered).valid()).isFalse();
+    }
+
+    @Test
+    void generateShouldFailFastWhenSecretMissing() {
+        JwtProperties badProps = new JwtProperties();
+        badProps.setSecret(" ");
+        JwtTokenService badService = new JwtTokenService(badProps, new ObjectMapper());
+
+        assertThatThrownBy(() -> badService.generateAccessToken(payload()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("security.jwt.secret");
+    }
+
+    private LoginPayload payload() {
+        return LoginPayload.builder()
+                .userId("u1")
+                .username("admin")
+                .name("Admin")
+                .firstName("A")
+                .lastName("B")
+                .roles(List.of("ROLE_ADMIN"))
+                .levels(List.of("L1"))
+                .allowedStatusActionIds(Set.of("A1", "A2"))
+                .officeType("HQ")
+                .officeCode("001")
+                .zoneCode("Z")
+                .regionCode("R")
+                .districtCode("D")
+                .clientType(ClientType.EXTERNAL)
+                .build();
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/LevelServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/LevelServiceTest.java
@@ -1,0 +1,102 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.dto.LevelDto;
+import com.ticketingSystem.api.dto.UserDto;
+import com.ticketingSystem.api.models.Level;
+import com.ticketingSystem.api.models.Stakeholder;
+import com.ticketingSystem.api.models.User;
+import com.ticketingSystem.api.models.UserLevel;
+import com.ticketingSystem.api.repository.LevelRepository;
+import com.ticketingSystem.api.repository.StakeholderRepository;
+import com.ticketingSystem.api.repository.UserLevelRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LevelServiceTest {
+
+    @Mock
+    private LevelRepository levelRepository;
+    @Mock
+    private UserLevelRepository userLevelRepository;
+    @Mock
+    private StakeholderRepository stakeholderRepository;
+
+    @InjectMocks
+    private LevelService service;
+
+    @Test
+    void getAllLevelsShouldMapEntityFields() {
+        Level level = new Level();
+        level.setLevelId("L1");
+        level.setLevelName("District");
+        when(levelRepository.findAll()).thenReturn(List.of(level));
+
+        List<LevelDto> result = service.getAllLevels();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getLevelId()).isEqualTo("L1");
+        assertThat(result.get(0).getLevelName()).isEqualTo("District");
+    }
+
+    @Test
+    void getUsersByLevelShouldReturnEmptyWhenNoAssignments() {
+        when(userLevelRepository.findByLevelIdsContaining("L1")).thenReturn(List.of());
+
+        assertThat(service.getUsersByLevel("L1")).isEmpty();
+    }
+
+    @Test
+    void getUsersByLevelShouldResolveStakeholderDescriptionAndHandleInvalidStakeholderId() {
+        User user = new User();
+        user.setUserId("u1");
+        user.setUsername("user");
+        user.setStakeholder("12");
+
+        Stakeholder stakeholder = new Stakeholder();
+        stakeholder.setId(12);
+        stakeholder.setDescription("Support Team");
+        when(stakeholderRepository.findById(12)).thenReturn(Optional.of(stakeholder));
+
+        UserLevel ul = new UserLevel();
+        ul.setUser(user);
+
+        User second = new User();
+        second.setUserId("u2");
+        second.setStakeholder("NOT_NUMERIC");
+        UserLevel ul2 = new UserLevel();
+        ul2.setUser(second);
+
+        when(userLevelRepository.findByLevelIdsContaining("L1")).thenReturn(List.of(ul, ul2));
+
+        Optional<Set<UserDto>> result = service.getUsersByLevel("L1");
+
+        assertThat(result).isPresent();
+        assertThat(result.get()).hasSize(2);
+        assertThat(result.get()).anyMatch(dto -> "Support Team".equals(dto.getStakeholder()));
+        assertThat(result.get()).anyMatch(dto -> "NOT_NUMERIC".equals(dto.getStakeholder()));
+    }
+
+    @Test
+    void getLevelListByUserIdShouldHandleNullAndDelimitedValues() {
+        when(userLevelRepository.findByUserId("missing")).thenReturn(null);
+
+        assertThat(service.getLevelListByUserId("missing")).isEmpty();
+
+        UserLevel userLevel = new UserLevel();
+        userLevel.setLevelIds("L1|L2|L3");
+        when(userLevelRepository.findByUserId("u1")).thenReturn(userLevel);
+
+        assertThat(service.getLevelListByUserId("u1")).containsExactly("L1", "L2", "L3");
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/LoggingServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/LoggingServiceTest.java
@@ -1,0 +1,16 @@
+package com.ticketingSystem.api.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class LoggingServiceTest {
+
+    @Test
+    void performSampleTaskShouldHandleInternalExceptionAndNotPropagate() {
+        LoggingService service = new LoggingService();
+
+        // The method intentionally throws and catches an exception to demonstrate error logging.
+        assertThatCode(service::performSampleTask).doesNotThrowAnyException();
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/MobileClientAuthServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/MobileClientAuthServiceTest.java
@@ -1,0 +1,59 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.config.MobileClientProperties;
+import com.ticketingSystem.api.dto.ClientTokenResponse;
+import com.ticketingSystem.api.models.ClientCredential;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MobileClientAuthServiceTest {
+
+    @Mock
+    private ClientCredentialService clientCredentialService;
+    @Mock
+    private ClientTokenService clientTokenService;
+
+    private MobileClientProperties properties;
+
+    @InjectMocks
+    private MobileClientAuthService service;
+
+    @BeforeEach
+    void setUp() {
+        properties = new MobileClientProperties();
+        properties.setId("mobile-client");
+        service = new MobileClientAuthService(clientCredentialService, clientTokenService, properties);
+    }
+
+    @Test
+    void issueMobileClientTokenShouldReturnEmptyWhenNoActiveCredential() {
+        when(clientCredentialService.findActiveByClientId("mobile-client")).thenReturn(Optional.empty());
+
+        assertThat(service.issueMobileClientToken()).isEmpty();
+    }
+
+    @Test
+    void issueMobileClientTokenShouldIssueTokenForActiveCredential() {
+        ClientCredential credential = new ClientCredential();
+        when(clientCredentialService.findActiveByClientId("mobile-client")).thenReturn(Optional.of(credential));
+        when(clientTokenService.issueAccessToken(credential))
+                .thenReturn(new ClientTokenService.IssuedClientToken("jwt", 30L, "mobile-client"));
+
+        Optional<ClientTokenResponse> result = service.issueMobileClientToken();
+
+        assertThat(result).isPresent();
+        assertThat(result.get().accessToken()).isEqualTo("jwt");
+        assertThat(result.get().expiresInMinutes()).isEqualTo(30L);
+        assertThat(result.get().clientId()).isEqualTo("mobile-client");
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/OciObjectStorageServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/OciObjectStorageServiceTest.java
@@ -1,0 +1,26 @@
+package com.ticketingSystem.api.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class OciObjectStorageServiceTest {
+
+    private final OciObjectStorageService service = new OciObjectStorageService();
+
+    @Test
+    void uploadShouldReturnObjectKeyWithoutAttemptingRealOciUpload() throws Exception {
+        MockMultipartFile file = new MockMultipartFile("f", "name.txt", "text/plain", "x".getBytes());
+
+        assertThat(service.upload(file, "ticket/path/name.txt")).isEqualTo("ticket/path/name.txt");
+    }
+
+    @Test
+    void deleteShouldNoOpForNullOrBlankAndNotThrowForNormalKey() {
+        assertThatCode(() -> service.delete(null)).doesNotThrowAnyException();
+        assertThatCode(() -> service.delete("   ")).doesNotThrowAnyException();
+        assertThatCode(() -> service.delete("ticket/path/file.txt")).doesNotThrowAnyException();
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/OciUploadServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/OciUploadServiceTest.java
@@ -1,0 +1,22 @@
+package com.ticketingSystem.api.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.aryEq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class OciUploadServiceTest {
+
+    @Test
+    void interfaceContractCanBeMockedAndInvokedByCollaborators() throws Exception {
+        OciUploadService uploadService = mock(OciUploadService.class);
+
+        uploadService.uploadFile("ticket/path.txt", new byte[]{1, 2});
+        uploadService.createPreauthenticatedRequest("ticket/path.txt", "ObjectRead", "download_1", "2030-01-01T00:00:00Z");
+
+        // This verifies invocation signatures expected by service collaborators.
+        verify(uploadService).uploadFile("ticket/path.txt", aryEq(new byte[]{1, 2}));
+        verify(uploadService).createPreauthenticatedRequest("ticket/path.txt", "ObjectRead", "download_1", "2030-01-01T00:00:00Z");
+    }
+}

--- a/api/src/test/java/com/ticketingSystem/api/service/PageMasterServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/PageMasterServiceTest.java
@@ -1,0 +1,66 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.dto.PageMasterDto;
+import com.ticketingSystem.api.models.PageMaster;
+import com.ticketingSystem.api.repository.PageMasterRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PageMasterServiceTest {
+
+    @Mock
+    private PageMasterRepository pageMasterRepository;
+
+    @InjectMocks
+    private PageMasterService service;
+
+    @Test
+    void getAllPagesShouldMapRepositoryResults() {
+        PageMaster page = new PageMaster();
+        page.setPageId(1L);
+        page.setPageName("Dashboard");
+        when(pageMasterRepository.findAll()).thenReturn(List.of(page));
+
+        List<PageMasterDto> result = service.getAllPages();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getPageId()).isEqualTo(1L);
+        assertThat(result.get(0).getPageName()).isEqualTo("Dashboard");
+    }
+
+    @Test
+    void getActiveMethodsShouldOnlyUseMatchingRepositoryQueries() {
+        PageMaster active = new PageMaster();
+        active.setPageId(2L);
+        active.setPageName("Tickets");
+
+        when(pageMasterRepository.findByIsActiveTrue()).thenReturn(List.of(active));
+        when(pageMasterRepository.findByIsActiveTrueAndIsOnSidebarTrue()).thenReturn(List.of(active));
+
+        assertThat(service.getActivePages()).extracting(PageMasterDto::getPageId).containsExactly(2L);
+        assertThat(service.getActiveSidebarPages()).extracting(PageMasterDto::getPageName).containsExactly("Tickets");
+    }
+
+    @Test
+    void getPageByIdShouldReturnMappedDtoOrEmpty() {
+        PageMaster page = new PageMaster();
+        page.setPageId(7L);
+        page.setPageCode("REPORTS");
+        when(pageMasterRepository.findById(7L)).thenReturn(Optional.of(page));
+        when(pageMasterRepository.findById(8L)).thenReturn(Optional.empty());
+
+        assertThat(service.getPageById(7L)).isPresent();
+        assertThat(service.getPageById(7L).get().getPageCode()).isEqualTo("REPORTS");
+        assertThat(service.getPageById(8L)).isEmpty();
+    }
+}


### PR DESCRIPTION
### Motivation
- Improve unit test coverage for core service classes and protect critical behaviors (auth, file storage, JWT, OCI integration helpers). 
- Capture realistic edge cases and failure modes such as missing resources, downstream SSO failures, upload rollbacks, token tampering, and malformed inputs. 
- Provide a clear, mock-driven test harness so future refactors have stronger regression protection.

### Description
- Added 14 new test classes under `api/src/test/java/com/ticketingSystem/api/service` covering `DocumentService`, `FaqService`, `IssueTypeService`, `LevelService`, `HeadquarterMasterService`, `PageMasterService`, `JwtTokenService`, `ExternalSsoTokenService`, `ExternalClientAuthService`, `MobileClientAuthService`, `FileStorageService`, `OciObjectStorageService`, `OciUploadService`, and `LoggingService` that exercise happy paths, error handling and edge cases. 
- `ExternalSsoTokenServiceTest` replaces the internal `RestTemplate` with a mock via `ReflectionTestUtils` and verifies request payload and handling for 2xx, non-2xx and exception scenarios. 
- `FileStorageServiceTest` uses a `@Spy` on the service to intercept `uploadFile` calls, verifies metadata persistence + rollback (delete) on upload failure, and invokes private helpers (`normalizeObjectKey`, `ensureTicketPrefix`, `buildObjectName`) via reflection for path-normalization edge cases. 
- `JwtTokenServiceTest` verifies access/refresh token semantics, regeneration, tamper detection, and secret validation; `OciUploadServiceTest` asserts the collaborator interface contract (byte-array matcher via `aryEq`).

### Testing
- Added and locally committed the new test sources (14 files) and attempted to run the targeted Gradle test command: `cd api && ./gradlew test --tests 'com.ticketingSystem.api.service.DocumentServiceTest' --tests 'com.ticketingSystem.api.service.ExternalClientAuthServiceTest' --tests 'com.ticketingSystem.api.service.ExternalSsoTokenServiceTest' --tests 'com.ticketingSystem.api.service.FaqServiceTest' --tests 'com.ticketingSystem.api.service.FileStorageServiceTest' --tests 'com.ticketingSystem.api.service.HeadquarterMasterServiceTest' --tests 'com.ticketingSystem.api.service.IssueTypeServiceTest' --tests 'com.ticketingSystem.api.service.JwtTokenServiceTest' --tests 'com.ticketingSystem.api.service.LevelServiceTest' --tests 'com.ticketingSystem.api.service.LoggingServiceTest' --tests 'com.ticketingSystem.api.service.MobileClientAuthServiceTest' --tests 'com.ticketingSystem.api.service.OciObjectStorageServiceTest' --tests 'com.ticketingSystem.api.service.OciUploadServiceTest' --tests 'com.ticketingSystem.api.service.PageMasterServiceTest'`. 
- The build/test run could not complete in this environment due to a JVM/Gradle incompatibility error (`Unsupported class file major version 69`), so automated execution did not finish; the tests themselves are included and ready to run in a compatible Java/Gradle environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3e48d2678833291c11a6747366b47)