### PR TITLE
Fix TicketDetails tests: stabilize `useApi` mock and add missing service mocks

### DIFF
--- a/ui/src/components/RaiseTicket/__tests__/TicketDetails.test.tsx
+++ b/ui/src/components/RaiseTicket/__tests__/TicketDetails.test.tsx
@@ -59,6 +59,19 @@ jest.mock('../../../services/SeverityService', () => ({
   getSeverities: (...args: any[]) => mockGetSeverities(...args),
 }));
 
+
+const mockGetIssueTypes = jest.fn(() => Promise.resolve([]));
+
+jest.mock('../../../services/IssueTypeService', () => ({
+  getIssueTypes: (...args: any[]) => mockGetIssueTypes(...args),
+}));
+
+const mockGetDivisions = jest.fn(() => Promise.resolve([]));
+
+jest.mock('../../../services/DivisionService', () => ({
+  getDivisions: (...args: any[]) => mockGetDivisions(...args),
+}));
+
 jest.mock('../../UI/Dropdown/GenericDropdownController', () => ({
   __esModule: true,
   default: ({ name, label, options, disabled }: any) => (
@@ -129,14 +142,24 @@ describe('TicketDetails', () => {
       return { data, pending: false, error: null, apiHandler: handler };
     };
 
-    mockUseApi
-      .mockReturnValueOnce(makeReturn([]))
-      .mockReturnValueOnce(makeReturn([]))
-      .mockReturnValueOnce(makeReturn([{ category: 'Hardware', categoryId: 'cat-1' }]))
-      .mockReturnValueOnce(makeReturn([{ subCategory: 'Laptop', subCategoryId: 'sub-1', severityId: 'sev-1' }]))
-      .mockReturnValueOnce(makeReturn([]))
-      .mockReturnValueOnce(makeReturn([{ id: 'p1', level: 'High', description: 'High impact' }]))
-      .mockReturnValueOnce(makeReturn([{ id: 's1', level: 'Critical', description: 'Critical issue' }]));
+    const useApiReturns = [
+      makeReturn([]),
+      makeReturn([]),
+      makeReturn([{ category: 'Hardware', categoryId: 'cat-1' }]),
+      makeReturn([{ subCategory: 'Laptop', subCategoryId: 'sub-1', severityId: 'sev-1' }]),
+      makeReturn([]),
+      makeReturn([{ id: 'p1', level: 'High', description: 'High impact' }]),
+      makeReturn([{ id: 's1', level: 'Critical', description: 'Critical issue' }]),
+      makeReturn([]),
+      makeReturn([]),
+    ];
+
+    let callCount = 0;
+    mockUseApi.mockImplementation(() => {
+      const value = useApiReturns[callCount % useApiReturns.length];
+      callCount += 1;
+      return value;
+    });
 
     return handlers;
   };


### PR DESCRIPTION
### Motivation
- Tests for `TicketDetails` were failing because repeated `useApi()` hook calls exhausted a `mockReturnValueOnce` chain and some services called `axios` during mount because they were not mocked.

### Description
- Replace chained `mockReturnValueOnce` stubs with a cyclic `mockImplementation` that serves a reusable array of `useApi` return values to avoid `undefined` destructuring on re-renders.
- Add explicit Jest mocks for `IssueTypeService.getIssueTypes` and `DivisionService.getDivisions` to prevent real `axios` calls during component mount effects.
- Expand the `useApi` return list to cover additional hook invocations observed during rendering so handlers remain defined across effects.
- Change is localized to the test file `ui/src/components/RaiseTicket/__tests__/TicketDetails.test.tsx` and preserves existing assertions and test logic.

### Testing
- Ran `cd ui && npm test -- --runTestsByPath src/components/RaiseTicket/__tests__/TicketDetails.test.tsx --watch=false` and all tests in that file passed.
- Test results: `3 passed, 0 failed` for the `TicketDetails` suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3fbc1476083328b530cee465d673a)