### PR TITLE
Fix TicketView unit tests by hardening async/service handling

### DIFF
--- a/ui/src/components/TicketView/TicketView.tsx
+++ b/ui/src/components/TicketView/TicketView.tsx
@@ -189,7 +189,8 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
   const isRno = roleList.includes('4');
 
   const latestStatusRemark = Array.isArray(data)
-    ? [...data]?.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())[0].remark
+    ? ([...data]
+      .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())[0]?.remark ?? '')
     : ""
 
   const handleLinkToMasterTicketModalClose = useCallback(() => {
@@ -495,14 +496,22 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
         const severityData = Array.isArray(res?.data) ? res.data : [];
         setSeverityList(severityData);
       });
-      getIssueTypes().then(res => {
-        const issueTypeData = Array.isArray(res?.data) ? res.data : [];
-        setIssueTypeOptions(getDropdownOptions(issueTypeData, 'issueTypeLabel', 'issueTypeId'));
-      });
-      getDivisions().then(res => {
-        const divisionData = Array.isArray(res?.data) ? res.data : [];
-        setDivisionOptions(getDropdownOptions(divisionData, 'divisionName', 'divisionId'));
-      });
+      Promise.resolve(getIssueTypes())
+        .then(res => {
+          const issueTypeData = Array.isArray(res?.data) ? res.data : [];
+          setIssueTypeOptions(getDropdownOptions(issueTypeData, 'issueTypeLabel', 'issueTypeId'));
+        })
+        .catch(() => {
+          setIssueTypeOptions([]);
+        });
+      Promise.resolve(getDivisions())
+        .then(res => {
+          const divisionData = Array.isArray(res?.data) ? res.data : [];
+          setDivisionOptions(getDropdownOptions(divisionData, 'divisionName', 'divisionId'));
+        })
+        .catch(() => {
+          setDivisionOptions([]);
+        });
       getCategories()
         .then(res => {
           const rawPayload = res?.data ?? res;
@@ -1228,7 +1237,7 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
                 {
                   displayValue: ticket.category,
                   translate: false,
-                  disabled: !categoryOptions.length
+                  disabled: !(categoryOptions?.length)
                 }
               )}
             </Box>
@@ -1256,7 +1265,7 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
             {renderSelect(divisionId, setDivisionId, divisionOptions, {
               displayValue: ticket?.divisionName || ticket?.division,
               translate: false,
-              disabled: !divisionOptions.length,
+              disabled: !(divisionOptions?.length),
               editing: allowDivisionEdit && editing,
             })}
           </Box>}
@@ -1266,7 +1275,7 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
               {renderSelect(issueTypeId, setIssueTypeId, issueTypeOptions, {
                 displayValue: ticket?.issueTypeLabel || ticket?.issueTypeId,
                 translate: false,
-                disabled: !issueTypeOptions.length
+                disabled: !(issueTypeOptions?.length)
               })}
             </Box>
           )}

--- a/ui/src/components/TicketView/__tests__/TicketView.test.tsx
+++ b/ui/src/components/TicketView/__tests__/TicketView.test.tsx
@@ -7,6 +7,7 @@ import { getPriorities } from '../../../services/PriorityService';
 import { getSeverities } from '../../../services/SeverityService';
 import { getCategories, getAllSubCategoriesByCategory } from '../../../services/CategoryService';
 import { getFeedback } from '../../../services/FeedbackService';
+import { getDivisions } from '../../../services/DivisionService';
 import { getStatusWorkflowMappings } from '../../../services/StatusService';
 import Histories from '../../../pages/Histories';
 import ChildTicketsList from '../ChildTicketsList';
@@ -120,6 +121,7 @@ jest.mock('../../../services/TicketService', () => ({
   getTicketSla: jest.fn(async () => ({ status: 200, data: { body: { data: mockSla } } })),
   getChildTickets: jest.fn(),
   unlinkTicketFromMaster: jest.fn(),
+  getAttachmentsByTicketId: jest.fn(() => Promise.resolve({ data: [] })),
 }));
 
 jest.mock('../../../services/RootCauseAnalysisService', () => ({
@@ -145,6 +147,10 @@ jest.mock('../../../services/CategoryService', () => ({
 
 jest.mock('../../../services/FeedbackService', () => ({
   getFeedback: jest.fn(() => Promise.resolve({ data: null })),
+}));
+
+jest.mock('../../../services/DivisionService', () => ({
+  getDivisions: jest.fn(() => Promise.resolve({ data: [] })),
 }));
 
 jest.mock('../../../services/StatusService', () => ({
@@ -272,6 +278,7 @@ const getSeveritiesMock = getSeverities as jest.Mock;
 const getCategoriesMock = getCategories as jest.Mock;
 const getAllSubCategoriesByCategoryMock = getAllSubCategoriesByCategory as jest.Mock;
 const getFeedbackMock = getFeedback as jest.Mock;
+const getDivisionsMock = getDivisions as jest.Mock;
 const getStatusWorkflowMappingsMock = getStatusWorkflowMappings as jest.Mock;
 const getTicketSlaMock = getTicketSla as jest.Mock;
 const checkAccessMasterMock = checkAccessMaster as jest.Mock;
@@ -300,6 +307,7 @@ describe('TicketView', () => {
     getCategoriesMock.mockResolvedValue({ data: { body: { data: [] } } });
     getAllSubCategoriesByCategoryMock.mockResolvedValue({ data: { body: { data: [] } } });
     getFeedbackMock.mockResolvedValue({ data: null });
+    getDivisionsMock.mockResolvedValue({ data: [] });
     getStatusWorkflowMappingsMock.mockResolvedValue({});
 
     const defaultResponse = {
@@ -314,11 +322,13 @@ describe('TicketView', () => {
       { ...defaultResponse, data: mockTicket, success: true },
       { ...defaultResponse },
       { ...defaultResponse, data: { '1': [] }, success: true },
+      { ...defaultResponse, data: [], success: true },
+      { ...defaultResponse, data: [{ timestamp: '2024-01-02T00:00:00Z', remark: 'latest remark' }], success: true },
     ];
     let callIndex = 0;
     useApiMock.mockImplementation(() => {
-      const response = useApiResponses[callIndex] ?? defaultResponse;
-      callIndex = (callIndex + 1) % useApiResponses.length;
+      const response = useApiResponses[callIndex % useApiResponses.length] ?? defaultResponse;
+      callIndex += 1;
       return response;
     });
 


### PR DESCRIPTION
### Motivation
- Prevent runtime errors in tests caused by partially mocked async services and missing data that lead to `.then` and undefined-property crashes during component mount.
- Ensure `TicketView` rendering is resilient to empty or absent arrays (status history, dropdown options) to avoid infinite update loops and crashes in test environments.

### Description
- Wrapped `getIssueTypes()` and `getDivisions()` calls in the `ticketId` effect with `Promise.resolve(...).then(...).catch(...)` fallbacks and set empty option lists on failure to avoid `.then` on undefined results (`ui/src/components/TicketView/TicketView.tsx`).
- Made access to latest status remark safe by using optional chaining and a default empty string, and changed several render-time `disabled` checks to use safe `?(...)?.length` checks to avoid reading `.length` of undefined (`ui/src/components/TicketView/TicketView.tsx`).
- Updated the TicketView test setup to mock `DivisionService` and `getAttachmentsByTicketId`, added a status-history entry to the `useApi` response sequence, and adjusted the `useApi` mock sequencing to match the component hook consumption order (`ui/src/components/TicketView/__tests__/TicketView.test.tsx`).

### Testing
- Ran `cd ui && npm test -- --runTestsByPath src/components/TicketView/__tests__/TicketView.test.tsx --watch=false` and verified the suite executed.
- Result: all 5 `TicketView` tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3fa8279148332bb05db07f6b09d7d)