### PR TITLE
Add unit tests for SLA job components and ticket download/export flow

### DIFF
--- a/ui/src/components/AllTickets/__tests__/DownloadTicketsDialog.test.tsx
+++ b/ui/src/components/AllTickets/__tests__/DownloadTicketsDialog.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DownloadTicketsDialog from '../DownloadTicketsDialog';
+import { useApi } from '../../../hooks/useApi';
+import { useCategoryFilters } from '../../../hooks/useCategoryFilters';
+import { getDivisions } from '../../../services/DivisionService';
+import { searchTicketsPaginated } from '../../../services/TicketService';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('../../../hooks/useApi');
+jest.mock('../../../hooks/useCategoryFilters');
+jest.mock('../../../services/DivisionService');
+jest.mock('../../../services/TicketService');
+
+jest.mock('../DownloadFiltersScreen', () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <div>
+      <button onClick={() => props.onZoneChange('Z1')}>Set Zone</button>
+      <button onClick={() => props.onCategoryChange('C1')}>Set Category</button>
+      <button onClick={() => props.onSubCategoryChange('SC1')}>Set SubCategory</button>
+      <button onClick={() => props.onIssueTypeChange('IT1')}>Set Issue Type</button>
+      <button onClick={() => props.onDivisionChange('D1')}>Set Division</button>
+      <button onClick={() => props.onStatusChange('OPEN')}>Set Status</button>
+      <button onClick={() => props.onOpenColumns()}>Open Columns</button>
+      <div data-testid="estimated-count">{props.estimatedCount ?? '-'}</div>
+    </div>
+  ),
+}));
+
+jest.mock('../DownloadColumnsScreen', () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <div>
+      <button onClick={() => props.onToggleColumn('id')}>Toggle Id</button>
+      <button onClick={() => props.onBack()}>Back</button>
+    </div>
+  ),
+}));
+
+const mockUseApi = useApi as jest.MockedFunction<typeof useApi>;
+const mockUseCategoryFilters = useCategoryFilters as jest.MockedFunction<typeof useCategoryFilters>;
+
+const baseProps = {
+  open: true,
+  zoneOptions: [{ label: 'All', value: 'All' }, { label: 'North', value: 'Z1' }],
+  issueTypeOptions: [{ label: 'All', value: 'All' }, { label: 'Electrical', value: 'IT1' }],
+  statusOptions: [{ label: 'All', value: 'All' }, { label: 'Open', value: 'OPEN' }],
+  divisionOptions: [{ label: 'All', value: 'All' }, { label: 'Ops', value: 'D1' }],
+  initialFilters: {
+    category: 'All',
+    subCategory: 'All',
+    zone: 'All',
+    region: 'All',
+    district: 'All',
+    issueType: 'All',
+    division: 'All',
+    assignee: 'All',
+    status: 'All',
+  },
+  exportableColumns: [
+    { key: 'id', label: 'Ticket Id' },
+    { key: 'subject', label: 'Subject' },
+  ],
+  onClose: jest.fn(),
+  onGenerate: jest.fn(),
+};
+
+describe('DownloadTicketsDialog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseCategoryFilters.mockReturnValue({
+      categoryOptions: [{ label: 'All', value: 'All' }, { label: 'Infra', value: 'C1' }],
+      subCategoryOptions: [{ label: 'All', value: 'All' }, { label: 'Router', value: 'SC1' }],
+      loadSubCategories: jest.fn(),
+      resetSubCategories: jest.fn(),
+    } as any);
+
+    mockUseApi.mockImplementation(() => ({
+      data: [],
+      pending: false,
+      success: false,
+      apiHandler: jest.fn(async (fn) => fn()),
+    } as any));
+
+    (getDivisions as jest.Mock).mockResolvedValue({ data: [{ divisionName: 'Ops', divisionId: 'D1' }] });
+    (searchTicketsPaginated as jest.Mock).mockResolvedValue({ totalElements: 42 });
+  });
+
+  it('generates report with selected filters and selected columns', async () => {
+    render(<DownloadTicketsDialog {...baseProps} />);
+
+    await userEvent.click(screen.getByText('Set Zone'));
+    await userEvent.click(screen.getByText('Set Category'));
+    await userEvent.click(screen.getByText('Set SubCategory'));
+    await userEvent.click(screen.getByText('Set Issue Type'));
+    await userEvent.click(screen.getByText('Set Division'));
+    await userEvent.click(screen.getByText('Set Status'));
+
+    await userEvent.click(screen.getByRole('button', { name: 'Generate' }));
+    await userEvent.click(screen.getByText('As Excel'));
+
+    await waitFor(() => {
+      expect(baseProps.onGenerate).toHaveBeenCalledWith('excel', expect.objectContaining({
+        zoneCode: 'Z1',
+        zoneLabel: 'North',
+        categoryId: 'C1',
+        subCategoryId: 'SC1',
+        issueTypeId: 'IT1',
+        statusId: 'OPEN',
+        selectedColumnKeys: ['id', 'subject'],
+      }));
+    });
+  });
+
+  it('updates selected columns and triggers estimate call for valid dates', async () => {
+    render(<DownloadTicketsDialog {...baseProps} />);
+
+    await waitFor(() => expect(getDivisions).toHaveBeenCalled());
+    await waitFor(() => expect(searchTicketsPaginated).toHaveBeenCalled());
+
+    await userEvent.click(screen.getByText('Open Columns'));
+    await userEvent.click(screen.getByText('Toggle Id'));
+    await userEvent.click(screen.getByText('Back'));
+
+    await userEvent.click(screen.getByRole('button', { name: 'Generate' }));
+    await userEvent.click(screen.getByText('As PDF'));
+
+    await waitFor(() => {
+      expect(baseProps.onGenerate).toHaveBeenCalledWith('pdf', expect.objectContaining({ selectedColumnKeys: ['subject'] }));
+    });
+  });
+});

--- a/ui/src/components/AllTickets/__tests__/TicketsTable.test.tsx
+++ b/ui/src/components/AllTickets/__tests__/TicketsTable.test.tsx
@@ -109,9 +109,10 @@ jest.mock('../../UI/UserAvatar/UserAvatar', () => ({
 }));
 
 const mockRequestorDetails = jest.fn(() => <div data-testid="requestor-details" />);
+const mockDownloadTicketsDialog = jest.fn(() => <div data-testid="download-dialog" />);
 jest.mock('../DownloadTicketsDialog', () => ({
     __esModule: true,
-    default: () => <div data-testid="download-dialog" />,
+    default: (props: any) => mockDownloadTicketsDialog(props),
 }));
 
 jest.mock('../RequestorDetails', () => ({
@@ -204,6 +205,7 @@ const tickets: TicketRow[] = [
 beforeEach(() => {
     jest.clearAllMocks();
     mockUseApi.mockReset();
+    mockDownloadTicketsDialog.mockClear();
     mockUseApi.mockImplementation(() => ({ apiHandler: jest.fn(async (fn) => fn()) }));
     mockNavigate.mockReset();
     mockCheckAccessMaster.mockImplementation(() => true);
@@ -313,7 +315,7 @@ describe('TicketsTable', () => {
         expect(rendered.getByRole('button', { name: 'Submit RCA' })).toBeInTheDocument();
     });
 
-    it('offers pdf and excel downloads with data rows', async () => {
+    it('opens download dialog and passes export metadata', async () => {
         render(
             <TicketsTable
                 tickets={tickets}
@@ -321,12 +323,38 @@ describe('TicketsTable', () => {
                 onRowClick={jest.fn()}
                 searchCurrentTicketsPaginatedApi={jest.fn()}
                 statusWorkflows={{ OPEN: [] }}
+                selectedCategory="Infrastructure"
+                selectedSubCategory="Network"
+                selectedZone="All"
+                selectedRegion="All"
+                selectedDistrict="All"
+                selectedIssueType="All"
+                selectedDivision="All"
+                selectedAssignee="All"
+                selectedStatusFilter="All"
                 zoneOptions={[{ label: 'All', value: 'All' }]}
                 issueTypeOptions={[{ label: 'All', value: 'All' }]}
+                statusFilterOptions={[{ label: 'All', value: 'All' }]}
+                divisionOptions={[{ label: 'All', value: 'All' }]}
             />,
         );
 
-        await userEvent.click(screen.getByText('Download'));
-        expect(screen.getByTestId('download-dialog')).toBeInTheDocument();
+        await waitFor(() => expect(mockDownloadTicketsDialog).toHaveBeenCalled());
+
+        const initialProps = mockDownloadTicketsDialog.mock.calls[0][0];
+        expect(initialProps.open).toBe(false);
+
+        await userEvent.click(screen.getByRole('button', { name: /Download/i }));
+
+        const latestProps = mockDownloadTicketsDialog.mock.calls.at(-1)?.[0];
+        expect(latestProps.open).toBe(true);
+        expect(latestProps.initialFilters).toEqual(expect.objectContaining({
+            category: 'Infrastructure',
+            subCategory: 'Network',
+        }));
+        expect(latestProps.exportableColumns).toEqual(expect.arrayContaining([
+            expect.objectContaining({ key: 'id', label: 'Ticket Id' }),
+            expect.objectContaining({ key: 'status', label: 'Status' }),
+        ]));
     });
 });

--- a/ui/src/components/SlaJob/__tests__/SlaCalculationTrigger.test.tsx
+++ b/ui/src/components/SlaJob/__tests__/SlaCalculationTrigger.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SlaCalculationTrigger from '../SlaCalculationTrigger';
+import { useApi } from '../../../hooks/useApi';
+import { useSnackbar } from '../../../context/SnackbarContext';
+import {
+  fetchSlaCalculationJobHistory,
+  triggerSlaCalculationJob,
+  updateTriggerJobPeriod,
+} from '../../../services/ReportService';
+
+jest.mock('../../../hooks/useApi');
+jest.mock('../../../context/SnackbarContext');
+jest.mock('../../../services/ReportService');
+
+const mockUseApi = useApi as jest.MockedFunction<typeof useApi>;
+const mockUseSnackbar = useSnackbar as jest.MockedFunction<typeof useSnackbar>;
+
+const overviewResponse = {
+  running: false,
+  cronExpression: '0 0 */4 * * *',
+  batchSize: 100,
+  triggerJobs: [
+    {
+      triggerJobId: '1',
+      triggerJobCode: 'sla_job',
+      triggerJobName: 'SLA Job',
+      batchSize: 100,
+      triggerPeriod: 'PERIODIC',
+      cronExpression: '0 0 */4 * * *',
+      running: false,
+      nextScheduledAt: '2024-01-02T00:00:00.000Z',
+      minutesUntilNextRun: 20,
+    },
+  ],
+  history: [],
+};
+
+describe('SlaCalculationTrigger', () => {
+  beforeEach(() => {
+    jest.spyOn(window, 'setInterval').mockImplementation(() => 1 as any);
+    jest.spyOn(window, 'clearInterval').mockImplementation(() => undefined);
+
+    jest.clearAllMocks();
+    mockUseSnackbar.mockReturnValue({ showMessage: jest.fn() } as any);
+    mockUseApi.mockImplementation(() => ({ apiHandler: jest.fn(async (fn) => fn()), pending: false } as any));
+
+    (fetchSlaCalculationJobHistory as jest.Mock).mockResolvedValue(overviewResponse);
+    (triggerSlaCalculationJob as jest.Mock).mockResolvedValue({ runStatus: 'RUNNING' });
+    (updateTriggerJobPeriod as jest.Mock).mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('loads SLA overview, triggers run, and refreshes data', async () => {
+    render(<SlaCalculationTrigger />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Trigger SLA Calculation' }));
+
+    await waitFor(() => expect(fetchSlaCalculationJobHistory).toHaveBeenCalledWith(25));
+
+    await userEvent.click(screen.getByRole('button', { name: 'Trigger' }));
+
+    await waitFor(() => expect(triggerSlaCalculationJob).toHaveBeenCalledWith('sla_job'));
+    expect(fetchSlaCalculationJobHistory).toHaveBeenCalled();
+  });
+
+  it('shows cron validation feedback and blocks invalid periodic save', async () => {
+    const showMessage = jest.fn();
+    mockUseSnackbar.mockReturnValue({ showMessage } as any);
+
+    render(<SlaCalculationTrigger />);
+    await userEvent.click(screen.getByRole('button', { name: 'Trigger SLA Calculation' }));
+    await waitFor(() => expect(fetchSlaCalculationJobHistory).toHaveBeenCalled());
+
+    await userEvent.click(screen.getByTestId('EditIcon').closest('button')!);
+
+    const secondInput = screen.getByLabelText('second');
+    await userEvent.clear(secondInput);
+    await userEvent.type(secondInput, 'abc');
+
+    await waitFor(() => expect(screen.getByText(/Only \*, \*\/n or number/)).toBeInTheDocument());
+    const saveCronButton = screen.getByTestId('CheckIcon').closest('button');
+    expect(saveCronButton).toBeDisabled();
+    expect(updateTriggerJobPeriod).not.toHaveBeenCalled();
+    expect(showMessage).not.toHaveBeenCalledWith('Trigger period updated', 'success');
+  });
+});

--- a/ui/src/components/SlaJob/__tests__/SlaJobHistoryTable.test.tsx
+++ b/ui/src/components/SlaJob/__tests__/SlaJobHistoryTable.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SlaJobHistoryTable from '../SlaJobHistoryTable';
+
+const runs = [
+  {
+    id: '1',
+    startedAt: '2024-01-01T00:00:00.000Z',
+    completedAt: '2024-01-01T00:01:40.000Z',
+    durationMs: 100000,
+    triggerType: 'MANUAL',
+    scope: 'ACTIVE_ONLY',
+    triggeredBy: 'agent',
+    runStatus: 'COMPLETED',
+    totalCandidateTickets: 10,
+    processedTickets: 10,
+    succeededTickets: 9,
+    failedTickets: 1,
+    errorSummary: null,
+  },
+] as any;
+
+describe('SlaJobHistoryTable', () => {
+  it('renders run data with formatted duration and status chip', () => {
+    render(<SlaJobHistoryTable history={runs} />);
+
+    expect(screen.getByText('MANUAL')).toBeInTheDocument();
+    expect(screen.getByText('ACTIVE_ONLY')).toBeInTheDocument();
+    expect(screen.getByText('1m 40s')).toBeInTheDocument();
+    expect(screen.getByText('COMPLETED')).toBeInTheDocument();
+    expect(screen.getByText('agent')).toBeInTheDocument();
+  });
+
+  it('renders empty state when no runs are available', () => {
+    render(<SlaJobHistoryTable history={[]} />);
+    expect(screen.getByText('No SLA job runs found.')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Motivation
- Improve coverage for SLA-related UI and ticket export screens by adding focused unit tests for rendering, validation and integration behaviors.
- Capture edge cases around cron validation and empty history rendering for SLA jobs and ensure the download dialog maps filters to payloads correctly.

### Description
- Added new test suites: `SlaCalculationTrigger.test.tsx` and `SlaJobHistoryTable.test.tsx` under `ui/src/components/SlaJob/__tests__` to validate overview load, trigger flows, cron field validation and history rendering.
- Added `DownloadTicketsDialog.test.tsx` under `ui/src/components/AllTickets/__tests__` to validate filter-to-payload mapping, column selection behavior and estimate/division API interactions using mocked child screens and `useApi`/hooks.
- Updated `TicketsTable.test.tsx` to assert `DownloadTicketsDialog` integration and verify that the dialog receives `initialFilters` and `exportableColumns` as expected.
- Tests use mocked hooks and services (`useApi`, `useCategoryFilters`, `ReportService`, `TicketService`, `DivisionService`, etc.) and include small test scaffolding like mocking `setInterval` to avoid timer noise.

### Testing
- Ran the component tests with: `cd ui && npm test -- --watch=false --runInBand src/components/AllTickets/__tests__/DownloadTicketsDialog.test.tsx src/components/AllTickets/__tests__/TicketsTable.test.tsx` and `cd ui && npm test -- --watch=false --runInBand src/components/SlaJob/__tests__/SlaJobHistoryTable.test.tsx src/components/SlaJob/__tests__/SlaCalculationTrigger.test.tsx` and all targeted suites passed.
- Test output shows the new/updated suites passed locally; tests emit existing MUI ripple `act(...)` warnings which are pre-existing and did not cause failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3fd0edc308332a94d0f80de36ae2b)