### PR TITLE
test: add unit tests for AssigneeFilterDropdown and download screens

### DIFF
--- a/ui/src/components/AllTickets/__tests__/AssigneeFilterDropdown.test.tsx
+++ b/ui/src/components/AllTickets/__tests__/AssigneeFilterDropdown.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AssigneeFilterDropdown from '../AssigneeFilterDropdown';
+import { useApi } from '../../../hooks/useApi';
+import { getAllLevels, getAllUsersByLevel } from '../../../services/LevelService';
+import { getAllUsers } from '../../../services/UserService';
+
+jest.mock('../../../hooks/useApi');
+jest.mock('../../../services/LevelService');
+jest.mock('../../../services/UserService');
+
+jest.mock('@mui/material', () => {
+    const actual = jest.requireActual('@mui/material');
+    return {
+        ...actual,
+        Menu: ({ open, children }: any) => (open ? <div data-testid="assignee-menu">{children}</div> : null),
+        Tooltip: ({ children }: any) => <>{children}</>,
+    };
+});
+
+jest.mock('../../UI/UserAvatar/UserAvatar', () => ({
+    __esModule: true,
+    default: ({ name, onClick }: any) => (
+        <button data-testid="assignee-avatar" onClick={onClick}>
+            {name}
+        </button>
+    ),
+}));
+
+const mockUseApi = useApi as jest.MockedFunction<typeof useApi>;
+
+describe('AssigneeFilterDropdown', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        const levelsHandler = jest.fn(async (fn) => fn());
+        const usersByLevelHandler = jest.fn(async (fn) => fn());
+        const allUsersHandler = jest.fn(async (fn) => fn());
+
+        const responses = [
+            {
+                data: [
+                    { levelId: 'L1', levelName: 'Level 1' },
+                    { levelId: 'L2', levelName: 'Level 2' },
+                ],
+                apiHandler: levelsHandler,
+            },
+            {
+                data: [
+                    { userId: '3', username: 'level.user', name: 'Level User', roles: '8', levels: ['L1'] },
+                ],
+                apiHandler: usersByLevelHandler,
+            },
+            {
+                data: [
+                    { userId: '1', username: 'allowed.user', name: 'Allowed User', roles: '3|5', levels: ['L1', 'L2'] },
+                    { userId: '2', username: 'blocked.user', name: 'Blocked User', roles: '5', levels: ['L1'] },
+                ],
+                apiHandler: allUsersHandler,
+            },
+        ];
+        let index = 0;
+        mockUseApi.mockImplementation(() => {
+            const response = responses[index % 3];
+            index += 1;
+            return response as any;
+        });
+    });
+
+    it('loads levels/users, filters by role, searches, and selects from all users', async () => {
+        const onChange = jest.fn();
+        render(<AssigneeFilterDropdown value="All" onChange={onChange} />);
+
+        await waitFor(() => expect(getAllLevels).toHaveBeenCalledTimes(1));
+        expect(getAllUsers).toHaveBeenCalledTimes(1);
+
+        fireEvent.click(screen.getByRole('button'));
+
+        expect(screen.getByTestId('assignee-menu')).toBeInTheDocument();
+        expect(screen.getAllByText('Allowed User').length).toBeGreaterThan(0);
+        expect(screen.queryByText('Blocked User')).not.toBeInTheDocument();
+
+        await userEvent.type(screen.getByPlaceholderText('Search'), 'allowed.user');
+        expect(screen.getAllByText('Allowed User').length).toBeGreaterThan(0);
+
+        await userEvent.click(screen.getAllByText('Allowed User')[0]);
+        expect(onChange).toHaveBeenCalledWith('allowed.user');
+    });
+
+    it('shows avatar for selected value, resolves selected label, and handles level/all chips', async () => {
+        const onChange = jest.fn();
+        render(<AssigneeFilterDropdown value="allowed.user" onChange={onChange} />);
+
+        expect(await screen.findByTestId('assignee-avatar')).toHaveTextContent('Allowed User');
+
+        await userEvent.click(screen.getByTestId('assignee-avatar'));
+        await userEvent.click(screen.getAllByRole('button', { name: 'L1' })[0]);
+
+        await waitFor(() => expect(getAllUsersByLevel).toHaveBeenCalledWith('L1'));
+        expect(await screen.findByText('Level User')).toBeInTheDocument();
+
+        await userEvent.click(screen.getByText('All'));
+        expect(onChange).toHaveBeenCalledWith('All');
+    });
+});

--- a/ui/src/components/AllTickets/__tests__/DownloadColumnsScreen.test.tsx
+++ b/ui/src/components/AllTickets/__tests__/DownloadColumnsScreen.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DownloadColumnsScreen from '../DownloadColumnsScreen';
+
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockGenericTable = jest.fn(() => <div data-testid="preview-table">table</div>);
+jest.mock('../../UI/GenericTable', () => ({
+    __esModule: true,
+    default: (props: any) => mockGenericTable(props),
+}));
+
+describe('DownloadColumnsScreen', () => {
+    const columns = [
+        { key: 'id', label: 'Ticket Id' },
+        { key: 'subject', label: 'Subject' },
+    ];
+
+    it('triggers callbacks and toggles individual columns', async () => {
+        const onBack = jest.fn();
+        const onSelectAll = jest.fn();
+        const onToggleColumn = jest.fn();
+        const onPreview = jest.fn();
+
+        render(
+            <DownloadColumnsScreen
+                columns={columns}
+                selectedColumnKeys={['id']}
+                showPreview={false}
+                onBack={onBack}
+                onToggleColumn={onToggleColumn}
+                onSelectAll={onSelectAll}
+                onPreview={onPreview}
+            />,
+        );
+
+        await userEvent.click(screen.getByRole('button', { name: 'Back to Filters' }));
+        await userEvent.click(screen.getByRole('button', { name: 'Select All' }));
+        await userEvent.click(screen.getByRole('checkbox', { name: 'Subject' }));
+        await userEvent.click(screen.getByRole('button', { name: 'Preview' }));
+
+        expect(onBack).toHaveBeenCalledTimes(1);
+        expect(onSelectAll).toHaveBeenCalledTimes(1);
+        expect(onToggleColumn).toHaveBeenCalledWith('subject');
+        expect(onPreview).toHaveBeenCalledTimes(1);
+        expect(screen.queryByTestId('preview-table')).not.toBeInTheDocument();
+    });
+
+    it('renders empty-state message when preview is opened without selected columns', () => {
+        render(
+            <DownloadColumnsScreen
+                columns={columns}
+                selectedColumnKeys={[]}
+                showPreview
+                onBack={jest.fn()}
+                onToggleColumn={jest.fn()}
+                onSelectAll={jest.fn()}
+                onPreview={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('Please select at least one column.')).toBeInTheDocument();
+        expect(screen.queryByTestId('preview-table')).not.toBeInTheDocument();
+    });
+
+    it('builds preview columns/data for selected keys and passes them to GenericTable', () => {
+        render(
+            <DownloadColumnsScreen
+                columns={columns}
+                selectedColumnKeys={['subject']}
+                showPreview
+                onBack={jest.fn()}
+                onToggleColumn={jest.fn()}
+                onSelectAll={jest.fn()}
+                onPreview={jest.fn()}
+            />,
+        );
+
+        expect(mockGenericTable).toHaveBeenCalled();
+        expect(mockGenericTable).toHaveBeenLastCalledWith(expect.objectContaining({
+            columns: [
+                { title: 'Subject', dataIndex: 'subject', key: 'subject' },
+            ],
+            dataSource: [
+                { key: 'preview-row', subject: 'Subject Value' },
+            ],
+            pagination: false,
+            scroll: { x: true },
+        }));
+    });
+});

--- a/ui/src/components/AllTickets/__tests__/DownloadFiltersScreen.test.tsx
+++ b/ui/src/components/AllTickets/__tests__/DownloadFiltersScreen.test.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DownloadFiltersScreen from '../DownloadFiltersScreen';
+
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('../AssigneeFilterDropdown', () => ({
+    __esModule: true,
+    default: ({ value, onChange }: any) => (
+        <button data-testid="assignee-filter" onClick={() => onChange('agent.one')}>
+            {value || 'assignee'}
+        </button>
+    ),
+}));
+
+jest.mock('@mui/material', () => {
+    const actual = jest.requireActual('@mui/material');
+    return {
+        ...actual,
+        FormControl: ({ children }: any) => <div>{children}</div>,
+        InputLabel: ({ children }: any) => <label>{children}</label>,
+        Select: ({ value, onChange, children, label }: any) => (
+            <select aria-label={label} value={value} onChange={onChange}>
+                {children}
+            </select>
+        ),
+        MenuItem: ({ value, children }: any) => <option value={value}>{children}</option>,
+        Alert: ({ children, severity }: any) => <div data-testid={`alert-${severity}`}>{children}</div>,
+    };
+});
+
+describe('DownloadFiltersScreen', () => {
+    const props = {
+        year: 2025 as number | '',
+        month: '' as number | '',
+        fromDate: '2025-01-01',
+        toDate: '2025-01-31',
+        category: 'cat1',
+        subCategory: 'sub1',
+        zone: 'zone1',
+        region: 'region1',
+        district: 'district1',
+        issueType: 'issue1',
+        division: 'division1',
+        assignee: 'All',
+        status: 'OPEN',
+        yearOptions: [2024, 2025],
+        monthOptions: [{ value: 1, label: 'Jan' }],
+        categoryOptions: [{ label: 'Category 1', value: 'cat1' }],
+        subCategoryOptions: [{ label: 'Sub 1', value: 'sub1' }],
+        zoneOptions: [{ label: 'Zone 1', value: 'zone1' }],
+        regionOptions: [{ label: 'Region 1', value: 'region1' }],
+        districtOptions: [{ label: 'District 1', value: 'district1' }],
+        issueTypeOptions: [{ label: 'Issue 1', value: 'issue1' }],
+        divisionOptions: [{ label: 'Division 1', value: 'division1' }],
+        statusOptions: [{ label: 'Open', value: 'OPEN' }],
+        generationState: 'idle' as const,
+        estimateLoading: false,
+        estimateCountPending: false,
+        estimatedCount: 1234,
+        selectedRangeDays: 45,
+        isRangeInvalid: true,
+        onCancelExport: jest.fn(),
+        onRetryExport: jest.fn(),
+        onYearChange: jest.fn(),
+        onMonthChange: jest.fn(),
+        onCategoryChange: jest.fn(),
+        onSubCategoryChange: jest.fn(),
+        onZoneChange: jest.fn(),
+        onRegionChange: jest.fn(),
+        onDistrictChange: jest.fn(),
+        onIssueTypeChange: jest.fn(),
+        onDivisionChange: jest.fn(),
+        onAssigneeChange: jest.fn(),
+        onStatusChange: jest.fn(),
+        onFromDateChange: jest.fn(),
+        onToDateChange: jest.fn(),
+        onApplyPresetRange: jest.fn(),
+        onOpenColumns: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('handles all filter change interactions and actions', async () => {
+        render(<DownloadFiltersScreen {...props} />);
+
+        fireEvent.change(screen.getByRole('combobox', { name: 'Year' }), { target: { value: '2024' } });
+        fireEvent.change(screen.getByRole('combobox', { name: 'Month' }), { target: { value: '1' } });
+        fireEvent.change(screen.getByRole('combobox', { name: 'Module' }), { target: { value: 'cat1' } });
+        fireEvent.change(screen.getByRole('combobox', { name: 'Sub Module' }), { target: { value: 'sub1' } });
+        fireEvent.change(screen.getByRole('combobox', { name: 'Zone' }), { target: { value: 'zone1' } });
+        fireEvent.change(screen.getByRole('combobox', { name: 'Region' }), { target: { value: 'region1' } });
+        fireEvent.change(screen.getByRole('combobox', { name: 'District' }), { target: { value: 'district1' } });
+        fireEvent.change(screen.getByRole('combobox', { name: 'Issue Type' }), { target: { value: 'issue1' } });
+        fireEvent.change(screen.getByRole('combobox', { name: 'Division' }), { target: { value: 'division1' } });
+        fireEvent.change(screen.getByRole('combobox', { name: 'Status' }), { target: { value: 'OPEN' } });
+
+        fireEvent.change(screen.getByLabelText('From Date'), { target: { value: '2025-01-02' } });
+        fireEvent.change(screen.getByLabelText('To Date'), { target: { value: '2025-01-30' } });
+
+        await userEvent.click(screen.getByTestId('assignee-filter'));
+        await userEvent.click(screen.getByRole('button', { name: 'Last 7 days' }));
+        await userEvent.click(screen.getByRole('button', { name: 'Last 30 days' }));
+        await userEvent.click(screen.getByRole('button', { name: 'Select/Unselect Columns' }));
+
+        expect(props.onYearChange).toHaveBeenCalledWith(2024);
+        expect(props.onMonthChange).toHaveBeenCalledWith(1);
+        expect(props.onCategoryChange).toHaveBeenCalledWith('cat1');
+        expect(props.onSubCategoryChange).toHaveBeenCalledWith('sub1');
+        expect(props.onZoneChange).toHaveBeenCalledWith('zone1');
+        expect(props.onRegionChange).toHaveBeenCalledWith('region1');
+        expect(props.onDistrictChange).toHaveBeenCalledWith('district1');
+        expect(props.onIssueTypeChange).toHaveBeenCalledWith('issue1');
+        expect(props.onDivisionChange).toHaveBeenCalledWith('division1');
+        expect(props.onStatusChange).toHaveBeenCalledWith('OPEN');
+        expect(props.onFromDateChange).toHaveBeenCalledWith('2025-01-02');
+        expect(props.onToDateChange).toHaveBeenCalledWith('2025-01-30');
+        expect(props.onAssigneeChange).toHaveBeenCalledWith('agent.one');
+        expect(props.onApplyPresetRange).toHaveBeenNthCalledWith(1, 7);
+        expect(props.onApplyPresetRange).toHaveBeenNthCalledWith(2, 30);
+        expect(props.onOpenColumns).toHaveBeenCalledTimes(1);
+
+        expect(screen.getByText('Estimated records: ~1,234')).toBeInTheDocument();
+        expect(screen.getByTestId('alert-warning')).toHaveTextContent('Please select a valid date range.');
+        expect(screen.getByTestId('alert-info')).toHaveTextContent('Large date range selected. It may take some time to download this data.');
+    });
+
+    it('shows generating state with cancel and estimating label when loading', async () => {
+        render(
+            <DownloadFiltersScreen
+                {...props}
+                generationState="generating"
+                estimateLoading
+                estimateCountPending={false}
+                selectedRangeDays={null}
+                isRangeInvalid={false}
+            />,
+        );
+
+        expect(screen.getByText('Estimating records...')).toBeInTheDocument();
+        expect(screen.getByTestId('alert-info')).toHaveTextContent('Your report is being generated.');
+
+        await userEvent.click(screen.getByRole('button', { name: 'Cancel export' }));
+        expect(props.onCancelExport).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows error state with retry and unavailable estimate fallback', async () => {
+        render(
+            <DownloadFiltersScreen
+                {...props}
+                generationState="error"
+                estimatedCount={null}
+                estimateLoading={false}
+                estimateCountPending={false}
+                selectedRangeDays={null}
+                isRangeInvalid={false}
+            />,
+        );
+
+        expect(screen.getByText('Estimated records unavailable')).toBeInTheDocument();
+        expect(screen.getByTestId('alert-error')).toHaveTextContent('Export failed. Range may be too large; narrow filters or request async report.');
+
+        await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
+        expect(props.onRetryExport).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
### Motivation
- Improve unit-test coverage for the All Tickets download/filtering UI pieces and the assignee filter component to catch regressions in filtering, selection and preview generation logic.

### Description
- Add `AssigneeFilterDropdown` tests that mock `useApi`, Level/User services and `UserAvatar` to verify initial API calls, role-based filtering, search behavior, level-chip selection, avatar label resolution and selection callbacks.
- Add `DownloadColumnsScreen` tests that mock `GenericTable` and verify back/select-all/toggle/preview callbacks, empty-preview messaging and that preview columns/data are constructed and passed to the table component.
- Add `DownloadFiltersScreen` tests that mock `AssigneeFilterDropdown` and MUI select pieces and verify each filter callback, date inputs, preset range actions, assignee bridge callback, estimate label states and alert CTA behavior for generating/error/invalid/large-range scenarios.
- Only test files were added/modified; no production source files were changed.

### Testing
- Ran the new test suites with `cd ui && npm test -- --runTestsByPath src/components/AllTickets/__tests__/AssigneeFilterDropdown.test.tsx src/components/AllTickets/__tests__/DownloadColumnsScreen.test.tsx src/components/AllTickets/__tests__/DownloadFiltersScreen.test.tsx --watch=false` and observed the suites pass.
- The run emits MUI `TouchRipple` act() warnings in the console but these warnings do not fail the test run and all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b404979ab0833286222b955a72338a)