### PR TITLE
test: add unit tests for Dashboard, DivisionHistory, Notifications, Permissions and Ticket components

### DIFF
--- a/ui/src/components/Dashboard/__tests__/CustomMetricCard.test.tsx
+++ b/ui/src/components/Dashboard/__tests__/CustomMetricCard.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { renderWithTheme } from '../../../test/testUtils';
+import CustomMetricCard from '../CustomMetricCard';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key) => `t:${key}` }),
+}));
+
+describe('CustomMetricCard', () => {
+  it('renders defaults/fallbacks and respects show flag for children', () => {
+    renderWithTheme(
+      <CustomMetricCard
+        title={{ text: 'Open Tickets', attributes: { 'data-testid': 'title-text' } }}
+        subtitle={{ text: '' }}
+        metricValue={{ text: null }}
+        children={[
+          {
+            title: { text: 'Visible Child', attributes: { 'data-testid': 'visible-child' } },
+            metricValue: { text: 3 },
+            show: true,
+          },
+          {
+            title: { text: 'Hidden Child' },
+            show: false,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByTestId('title-text')).toHaveTextContent('t:Open Tickets');
+    expect(screen.queryByText('t:Hidden Child')).not.toBeInTheDocument();
+    expect(screen.getByTestId('visible-child')).toHaveTextContent('t:Visible Child');
+  });
+
+  it('does not render when show is false', () => {
+    const { container } = renderWithTheme(<CustomMetricCard show={false} title={{ text: 'Nope' }} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders metric text using translation wrapper', () => {
+    renderWithTheme(
+      <CustomMetricCard
+        title={{ text: 'Title', textColor: 'primary.main' }}
+        subtitle={{ text: 'Sub', textColor: 'secondary.main' }}
+        metricValue={{ text: 42, textColor: '#123456' }}
+        backgroundColor="background.paper"
+      />
+    );
+
+    expect(screen.getByText('t:Title')).toBeInTheDocument();
+    expect(screen.getByText('t:Sub')).toBeInTheDocument();
+    expect(screen.getByText('t:42')).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/DivisionHistory/__tests__/DivisionHistory.test.tsx
+++ b/ui/src/components/DivisionHistory/__tests__/DivisionHistory.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import DivisionHistory from '../index';
+import { useApi } from '../../../hooks/useApi';
+import { getDivisionHistory } from '../../../services/DivisionHistoryService';
+
+jest.mock('@mui/lab', () => ({
+  Timeline: ({ children }) => <div>{children}</div>,
+  TimelineItem: ({ children }) => <div>{children}</div>,
+  TimelineSeparator: ({ children }) => <div>{children}</div>,
+  TimelineDot: () => <span>dot</span>,
+  TimelineConnector: () => <span>connector</span>,
+  TimelineContent: ({ children }) => <div>{children}</div>,
+}), { virtual: true });
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key }),
+}));
+
+jest.mock('../../../hooks/useApi', () => ({ useApi: jest.fn() }));
+jest.mock('../../../services/DivisionHistoryService', () => ({ getDivisionHistory: jest.fn() }));
+
+jest.mock('../../History/HistoryReportDownloadMenu', () => ({
+  __esModule: true,
+  default: ({ title, rows }) => <div data-testid="download-menu">{title}:{rows.length}</div>,
+}));
+
+jest.mock('../../UI/ViewToggle', () => ({
+  __esModule: true,
+  default: ({ value, onChange }) => (
+    <button type="button" onClick={() => onChange(value === 'table' ? 'timeline' : 'table')}>
+      toggle-view
+    </button>
+  ),
+}));
+
+jest.mock('../../UI/GenericTable', () => ({
+  __esModule: true,
+  default: ({ dataSource, columns, rowClassName, locale }) => (
+    <div>
+      <div data-testid="row-class">{rowClassName(dataSource[0], 0)}</div>
+      {dataSource.length === 0 ? <div>{locale?.emptyText}</div> : null}
+      {dataSource.map((record) => (
+        <div key={record.id} data-testid={`row-${record.id}`}>
+          {columns.map((column) => (
+            <span key={column.key}>{column.render?.(record[column.dataIndex], record) ?? record[column.dataIndex]}</span>
+          ))}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+describe('DivisionHistory', () => {
+  it('fetches history and renders sorted table data with fallback values', () => {
+    const apiHandler = jest.fn((fn) => fn());
+    (useApi).mockReturnValue({
+      data: [
+        { id: '2', previousDivision: '', currentDivision: '', divisionName: 'Fallback', updatedBy: '', timestamp: '2024-01-01T00:00:00Z', remark: '' },
+        { id: '1', previousDivision: 'Old', currentDivision: 'New', updatedBy: 'Agent', timestamp: '2024-01-02T00:00:00Z', remark: 'Moved' },
+      ],
+      apiHandler,
+    });
+
+    render(<DivisionHistory ticketId="TK-1" />);
+
+    expect(apiHandler).toHaveBeenCalled();
+    expect(getDivisionHistory).toHaveBeenCalledWith('TK-1');
+    expect(screen.getByTestId('download-menu')).toHaveTextContent('Ticket TK-1 - Division History:2');
+    expect(screen.getByTestId('row-class')).toHaveTextContent('latest-row');
+    expect(screen.getByTestId('row-1')).toHaveTextContent('Old');
+    expect(screen.getByTestId('row-2')).toHaveTextContent('Fallback');
+    expect(screen.getByTestId('row-2')).toHaveTextContent('-');
+  });
+
+  it('switches to timeline view', () => {
+    (useApi).mockReturnValue({
+      data: [{ id: '1', currentDivision: 'Ops', updatedBy: 'Admin', timestamp: '2024-01-02T00:00:00Z' }],
+      apiHandler: jest.fn(),
+    });
+
+    render(<DivisionHistory ticketId="TK-2" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'toggle-view' }));
+
+    expect(screen.getByText('Ops')).toBeInTheDocument();
+    expect(screen.getByText(/Admin/)).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/Notifications/__tests__/NotificationBell.test.tsx
+++ b/ui/src/components/Notifications/__tests__/NotificationBell.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import NotificationBell from '../NotificationBell';
+import { useNotificationContext } from '../../../context/NotificationContext';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../../../context/NotificationContext', () => ({
+  useNotificationContext: jest.fn(),
+}));
+
+describe('NotificationBell', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('marks all as read on open and navigates when a notification is clicked', async () => {
+    const markAllAsRead = jest.fn().mockResolvedValue(undefined);
+    const markAsRead = jest.fn();
+    useNotificationContext.mockReturnValue({
+      notifications: [
+        { id: '1', title: 'Older', timestamp: '2024-01-01T00:00:00Z', read: true },
+        { id: '2', title: 'Newer', timestamp: '2024-01-02T00:00:00Z', read: false, data: { ticketId: 'TK-22' } },
+      ],
+      unreadCount: 1,
+      markAllAsRead,
+      markAsRead,
+      hasMore: false,
+      loadMore: jest.fn(),
+      loading: false,
+      latestNotification: null,
+      acknowledgeLatestNotification: jest.fn(),
+    });
+
+    render(<NotificationBell iconColor="#fff" />);
+
+    fireEvent.click(screen.getByLabelText('Notifications'));
+
+    await waitFor(() => expect(markAllAsRead).toHaveBeenCalled());
+
+    const notificationItems = screen.getAllByText(/Older|Newer/);
+    expect(notificationItems[0]).toHaveTextContent('Newer');
+
+    fireEvent.click(screen.getByText('Newer'));
+
+    expect(markAsRead).toHaveBeenCalledWith('2');
+    expect(mockNavigate).toHaveBeenCalledWith('/tickets/TK-22');
+  });
+
+  it('shows snackbar and empty menu state', () => {
+    const acknowledgeLatestNotification = jest.fn();
+
+    useNotificationContext.mockReturnValue({
+      notifications: [],
+      unreadCount: 0,
+      markAllAsRead: jest.fn(),
+      markAsRead: jest.fn(),
+      hasMore: false,
+      loadMore: jest.fn(),
+      loading: false,
+      latestNotification: { id: 'latest', title: 'Incoming', message: 'A new update', timestamp: '2024-01-03T00:00:00Z', read: false },
+      acknowledgeLatestNotification,
+    });
+
+    render(<NotificationBell iconColor="#fff" />);
+
+    expect(screen.getByText('Incoming')).toBeInTheDocument();
+    expect(acknowledgeLatestNotification).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByLabelText('Notifications'));
+    expect(screen.getByText("You're all caught up!")).toBeInTheDocument();
+  });
+
+  it('loads more notifications when requested', async () => {
+    const loadMore = jest.fn().mockResolvedValue(undefined);
+
+    useNotificationContext.mockReturnValue({
+      notifications: [{ id: '1', title: 'Item', timestamp: '2024-01-03T00:00:00Z', read: true }],
+      unreadCount: 0,
+      markAllAsRead: jest.fn(),
+      markAsRead: jest.fn(),
+      hasMore: true,
+      loadMore,
+      loading: false,
+      latestNotification: null,
+      acknowledgeLatestNotification: jest.fn(),
+    });
+
+    render(<NotificationBell iconColor="#fff" />);
+    fireEvent.click(screen.getByLabelText('Notifications'));
+    fireEvent.click(screen.getByRole('button', { name: 'Show more' }));
+
+    await waitFor(() => expect(loadMore).toHaveBeenCalled());
+  });
+});

--- a/ui/src/components/Permissions/__tests__/PermissionTree.test.tsx
+++ b/ui/src/components/Permissions/__tests__/PermissionTree.test.tsx
@@ -7,7 +7,7 @@ import { renderWithTheme } from '../../../test/testUtils';
 
 jest.mock('../JsonEditModal', () => ({
   __esModule: true,
-  default: ({ open, onSubmit, onCancel }: { open: boolean; onSubmit: (value: any) => void; onCancel: () => void }) => (
+  default: ({ open, onSubmit, onCancel }) => (
     open ? (
       <div data-testid="json-edit-modal">
         <button type="button" onClick={() => onSubmit({ show: false })}>
@@ -29,23 +29,23 @@ const devModeValue = {
   setJwtBypass: jest.fn(),
 };
 
-const renderWithContext = (ui: React.ReactNode, value = { ...devModeValue, devMode: false }) =>
+const renderWithContext = (ui, value = { ...devModeValue, devMode: false }) =>
   renderWithTheme(
-    <DevModeContext.Provider value={value as any}>
+    <DevModeContext.Provider value={value}>
       {ui}
     </DevModeContext.Provider>,
   );
 
-const findCheckboxForLabel = (label: string): HTMLInputElement => {
+const findCheckboxForLabel = (label) => {
   const textEl = screen.getByText(label);
-  let current: HTMLElement | null = textEl.parentElement as HTMLElement | null;
+  let current = textEl.parentElement;
   while (current && !current.querySelector('input[type="checkbox"]')) {
-    current = current.parentElement as HTMLElement | null;
+    current = current.parentElement;
   }
   if (!current) {
     throw new Error(`Checkbox for ${label} not found`);
   }
-  return current.querySelector('input[type="checkbox"]') as HTMLInputElement;
+  return current.querySelector('input[type="checkbox"]');
 };
 
 describe('PermissionTree', () => {
@@ -100,7 +100,7 @@ describe('PermissionTree', () => {
     await userEvent.type(input, 'New Child');
 
     const confirmButton = screen.getByTestId('CheckIcon').closest('button');
-    await userEvent.click(confirmButton!);
+    await userEvent.click(confirmButton);
 
     await waitFor(() => expect(screen.getByText('New Child')).toBeInTheDocument());
 
@@ -175,7 +175,7 @@ describe('PermissionTree', () => {
       />, devModeValue
     );
 
-    const editJsonButton = screen.getAllByLabelText('Edit JSON').find(el => el.tagName === 'BUTTON') as HTMLElement;
+    const editJsonButton = screen.getAllByLabelText('Edit JSON').find(el => el.tagName === 'BUTTON');
     await userEvent.click(editJsonButton);
 
     expect(screen.getByTestId('json-edit-modal')).toBeInTheDocument();
@@ -186,5 +186,55 @@ describe('PermissionTree', () => {
       pages: { show: false },
     });
     await waitFor(() => expect(screen.queryByTestId('json-edit-modal')).not.toBeInTheDocument());
+  });
+
+  it('closes json editor without submitting on cancel', async () => {
+    const handleChange = jest.fn();
+    const data = {
+      pages: {
+        show: true,
+        metadata: { name: 'Pages' },
+        children: null,
+      },
+    };
+
+    renderWithContext(
+      <PermissionTree
+        data={data}
+        onChange={handleChange}
+        allowStructureEdit
+      />, devModeValue
+    );
+
+    const editJsonButton = screen.getAllByLabelText('Edit JSON').find(el => el.tagName === 'BUTTON');
+    await userEvent.click(editJsonButton);
+    expect(screen.getByTestId('json-edit-modal')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /close json/i }));
+
+    expect(handleChange).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.queryByTestId('json-edit-modal')).not.toBeInTheDocument());
+  });
+
+  it('does not render structure edit controls when dev mode is disabled', () => {
+    const data = {
+      pages: {
+        show: true,
+        metadata: { name: 'Pages' },
+        children: null,
+      },
+    };
+
+    renderWithContext(
+      <PermissionTree
+        data={data}
+        onChange={jest.fn()}
+        allowStructureEdit
+      />,
+      { ...devModeValue, devMode: false }
+    );
+
+    expect(screen.queryByLabelText('Add child attribute')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Edit JSON')).not.toBeInTheDocument();
   });
 });

--- a/ui/src/components/Ticket/__tests__/ChildTicketsTable.test.tsx
+++ b/ui/src/components/Ticket/__tests__/ChildTicketsTable.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import ChildTicketsTable from '../ChildTicketsTable';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key, vars) => key.replace('{{id}}', vars?.id || '') }),
+}));
+
+jest.mock('../../../utils/Utils', () => ({
+  truncateWithEllipsis: (value) => value,
+  getStatusNameById: jest.fn((id) => (id === '1' ? 'Open' : '')),
+}));
+
+jest.mock('../../UI/IconButton/CustomIconButton', () => ({
+  __esModule: true,
+  default: ({ onClick, disabled, 'aria-label': ariaLabel, icon }) => (
+    <button type="button" onClick={onClick} disabled={disabled} aria-label={ariaLabel}>
+      {icon}
+    </button>
+  ),
+}));
+
+jest.mock('../../UI/GenericTable', () => ({
+  __esModule: true,
+  default: ({ dataSource, columns, locale }) => (
+    <div>
+      {dataSource.length === 0 ? <div>{locale.emptyText}</div> : null}
+      {dataSource.map((record) => (
+        <div key={record.id} data-testid={`row-${record.id}`}>
+          {columns.map((column) => (
+            <div key={column.key}>{column.render?.(record[column.dataIndex], record) ?? record[column.dataIndex]}</div>
+          ))}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+describe('ChildTicketsTable', () => {
+  const tickets = [
+    { id: 'TK-1', subject: 'Issue 1', category: 'Infra', subCategory: 'Network', statusId: '1', assignedToName: 'Alex' },
+    { id: 'TK-2', subject: '', category: 'App', statusId: '', statusLabel: 'Pending', assignedTo: 'user2' },
+  ] as any;
+
+  it('renders table content and triggers view/unlink actions including keyboard', () => {
+    const onView = jest.fn();
+    const onUnlink = jest.fn();
+
+    render(<ChildTicketsTable tickets={tickets} loading={false} onView={onView} onUnlink={onUnlink} unlinkingId="TK-2" />);
+
+    expect(screen.getByTestId('row-TK-1')).toHaveTextContent('Infra > Network');
+    expect(screen.getByTestId('row-TK-2')).toHaveTextContent('Pending');
+    expect(screen.getByLabelText('Unlink ticket TK-2')).toBeDisabled();
+
+    const ticketIdBtn = screen.getAllByRole('button').find((el) => el.textContent === 'TK-1');
+    fireEvent.click(ticketIdBtn!);
+    fireEvent.keyDown(ticketIdBtn!, { key: 'Enter' });
+
+    expect(onView).toHaveBeenCalledWith('TK-1');
+
+    fireEvent.click(screen.getByLabelText('Unlink ticket TK-1'));
+    expect(onUnlink).toHaveBeenCalledWith('TK-1');
+  });
+
+  it('renders empty state', () => {
+    render(<ChildTicketsTable tickets={[]} loading={false} onView={jest.fn()} onUnlink={jest.fn()} />);
+    expect(screen.getByText('No child tickets linked yet.')).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/TicketView/__tests__/RequestorModal.test.tsx
+++ b/ui/src/components/TicketView/__tests__/RequestorModal.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import RequestorModal from '../RequestorModal';
+
+const mockUserDetails = jest.fn();
+
+jest.mock('../../UserDetailsCard', () => ({
+  __esModule: true,
+  default: (props) => {
+    mockUserDetails(props);
+    return (
+      <div>
+        <button type="button" onClick={() => props.onCopy('email', 'user@example.com')}>copy</button>
+        <div data-testid="copied">{props.copiedField || 'none'}</div>
+        <div data-testid="detail-count">{props.details.length}</div>
+      </div>
+    );
+  },
+}));
+
+describe('RequestorModal', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    Object.assign(navigator, { clipboard: { writeText: jest.fn() } });
+    mockUserDetails.mockClear();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('passes filtered details and handles copy state lifecycle', () => {
+    const onClose = jest.fn();
+
+    render(
+      <RequestorModal
+        open
+        onClose={onClose}
+        name="Test User"
+        email="user@example.com"
+        role="Manager"
+        officeCode="OC-1"
+      />
+    );
+
+    expect(screen.getByTestId('detail-count')).toHaveTextContent('2');
+    fireEvent.click(screen.getByRole('button', { name: 'copy' }));
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('user@example.com');
+    expect(screen.getByTestId('copied')).toHaveTextContent('email');
+
+    act(() => {
+      jest.advanceTimersByTime(2100);
+    });
+    expect(screen.getByTestId('copied')).toHaveTextContent('none');
+
+  });
+});


### PR DESCRIPTION
### Motivation
- Increase unit test coverage for several UI components and exercise edge cases not covered previously.
- Validate rendering, user interactions, and integration points (i18n, API hooks, context, and service calls) without changing production code.

### Description
- Added tests for `CustomMetricCard` to verify translation wrapper, visibility flags, and fallback rendering.
- Added tests for `DivisionHistory` that mock `useApi`, `getDivisionHistory`, MUI `Timeline` components, table view and timeline view switching, and download menu rendering.
- Added tests for `NotificationBell` that mock `NotificationContext` and `react-router` navigation to verify marking as read, navigation on click, snackbar behavior, empty menu, and load-more behavior.
- Added/extended `PermissionTree` tests to cover toggling node visibility, adding a child node in dev mode, cycling visibility via the chip, opening and submitting/ canceling the JSON editor, and the absence of structure-edit controls when dev mode is disabled; also simplified some test helpers and mocked the JSON editor.
- Added tests for `ChildTicketsTable` to cover table rendering, view/unlink actions (including keyboard Enter), and empty-state rendering, with mocks for utility functions and UI table/button components.
- Added tests for `RequestorModal` to cover filtered details propagation, clipboard-copy behavior, and the copied-field timeout lifecycle while mocking `UserDetailsCard`.

### Testing
- Ran the component unit test suite with Jest (project test runner) for the modified files and their surrounding suites, and all new and updated tests completed successfully.
- The new tests exercise mocked paths for `useApi`, service calls, context providers, and MUI subcomponents to ensure deterministic behavior under CI-like conditions.
- Coverage increased for the touched components according to the local coverage report produced by the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b40d9039b08332b9cd094aa40f40e5)