### PR TITLE
test(ui): add high-coverage tests for MIS report hooks

### DIFF
--- a/ui/src/hooks/__tests__/useMisReportDownloader.test.ts
+++ b/ui/src/hooks/__tests__/useMisReportDownloader.test.ts
@@ -1,0 +1,157 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+jest.mock('xlsx', () => {
+  const mock = {
+    utils: {
+      book_new: jest.fn(() => ({})),
+      aoa_to_sheet: jest.fn(() => ({ '!ref': 'A1:B2' })),
+      book_append_sheet: jest.fn(),
+    },
+    writeFile: jest.fn(),
+  };
+  return { __esModule: true, default: mock, ...mock };
+}, { virtual: true });
+
+import { useMisReportDownloader } from '../useMisReportDownloader';
+import {
+  fetchCustomerSatisfactionReport,
+  fetchProblemManagementReport,
+  fetchTicketResolutionTimeReport,
+  fetchTicketSummaryReport,
+} from '../../services/ReportService';
+import { useSnackbar } from '../../context/SnackbarContext';
+import { getCurrentUserDetails } from '../../config/config';
+import { extractApiPayload } from '../../utils/misReports';
+import * as XLSX from 'xlsx';
+
+jest.mock('../../services/ReportService');
+jest.mock('../../context/SnackbarContext');
+jest.mock('../../config/config');
+jest.mock('../../utils/misReports', () => {
+  const actual = jest.requireActual('../../utils/misReports');
+  return {
+    ...actual,
+    extractApiPayload: jest.fn(),
+    calculateColumnWidths: jest.fn(() => [{ wch: 12 }]),
+    applyThinBorders: jest.fn(),
+    formatDateInput: jest.fn(() => '2025-01-31'),
+  };
+});
+
+describe('useMisReportDownloader', () => {
+  const showMessage = jest.fn();
+  const mockRequestParams = {
+    fromDate: '2025-01-01',
+    toDate: '2025-01-31',
+    scope: 'all' as const,
+    userId: 'u-1',
+  };
+  const sampleRange = {
+    startDate: new Date('2025-01-01T00:00:00Z'),
+    endDate: new Date('2025-01-31T00:00:00Z'),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useSnackbar as jest.Mock).mockReturnValue({ showMessage });
+    (getCurrentUserDetails as jest.Mock).mockReturnValue({ username: 'qa.user', userId: 'u-1' });
+    (extractApiPayload as jest.Mock).mockImplementation((response) => response);
+    (XLSX.utils.book_new as jest.Mock).mockReturnValue({});
+    (XLSX.utils.aoa_to_sheet as jest.Mock).mockImplementation(() => ({ '!ref': 'A1:B2' }));
+    (XLSX.utils.book_append_sheet as jest.Mock).mockImplementation(() => undefined);
+    (XLSX.writeFile as jest.Mock).mockImplementation(() => undefined);
+  });
+
+  it('downloads excel successfully and builds workbook sheets', async () => {
+    (fetchTicketSummaryReport as jest.Mock).mockResolvedValue({
+      totalTickets: 10,
+      openTickets: 4,
+      closedTickets: 6,
+      statusCounts: { Escalated: 2 },
+      modeCounts: { Email: 5 },
+    });
+    (fetchTicketResolutionTimeReport as jest.Mock).mockResolvedValue({
+      categoryStats: [{ categoryName: 'Infra', subcategoryName: 'Network', averageResolutionTime: 11, medianResolutionTime: 9, closedTickets: 3 }],
+      categoryPriorityStats: [{ categoryName: 'Infra', priority: 'P1', averageResolutionTime: 8, medianResolutionTime: 7, closedTickets: 2 }],
+      priorityStats: [{ priority: 'P2', averageResolutionTime: 15, medianResolutionTime: 13, closedTickets: 1 }],
+    });
+    (fetchCustomerSatisfactionReport as jest.Mock).mockResolvedValue({
+      overallStats: [{ any: true }],
+      totalResponses: 9,
+      averageRating: 4.6,
+      positivePercentage: 88,
+      categoryStats: [{ categoryName: 'Infra', subcategoryName: 'Network', averageRating: 4.5, responses: 3 }],
+      ticketStats: [{ ticketNumber: 'T-1', rating: 5, feedback: 'Good', ratingCounts: { '1': 0, '2': 0, '3': 0, '4': 1, '5': 3 }, totalResponses: 4 }],
+    });
+    (fetchProblemManagementReport as jest.Mock).mockResolvedValue({
+      categoryStats: [{ category: 'Legacy Cat', subcategory: 'Legacy Sub', ticketCount: 5 }],
+    });
+
+    const { result } = renderHook(() => useMisReportDownloader(mockRequestParams));
+
+    await act(async () => {
+      await result.current.handleDownload('excel', 'monthly', sampleRange);
+    });
+
+    expect(fetchTicketSummaryReport).toHaveBeenCalledWith(mockRequestParams);
+    expect(XLSX.utils.book_append_sheet).toHaveBeenCalledTimes(4);
+    expect(XLSX.writeFile).toHaveBeenCalledWith(expect.any(Object), expect.stringContaining('mis-reports-monthly-2025-01-31.xlsx'));
+    expect(showMessage).toHaveBeenCalledWith('MIS reports downloaded successfully.', 'success');
+    expect(result.current.downloading).toBe(false);
+  });
+
+  it('handles unsupported download option with info toast', async () => {
+    const { result } = renderHook(() => useMisReportDownloader(mockRequestParams));
+
+    await act(async () => {
+      await result.current.handleDownload('pdf', 'daily', sampleRange);
+    });
+
+    expect(fetchTicketSummaryReport).not.toHaveBeenCalled();
+    expect(showMessage).toHaveBeenCalledWith('PDF downloads are not available yet.', 'info');
+  });
+
+  it('shows an error when any report payload is missing', async () => {
+    (fetchTicketSummaryReport as jest.Mock).mockResolvedValue(null);
+    (fetchTicketResolutionTimeReport as jest.Mock).mockResolvedValue({});
+    (fetchCustomerSatisfactionReport as jest.Mock).mockResolvedValue({});
+    (fetchProblemManagementReport as jest.Mock).mockResolvedValue({});
+
+    const { result } = renderHook(() => useMisReportDownloader({ ...mockRequestParams, fromDate: undefined, toDate: undefined }));
+
+    await act(async () => {
+      await result.current.handleDownload('excel', 'weekly', sampleRange);
+    });
+
+    expect(showMessage).toHaveBeenCalledWith('Incomplete data received for MIS reports.', 'error');
+    expect(XLSX.writeFile).not.toHaveBeenCalled();
+    expect(result.current.downloading).toBe(false);
+  });
+
+  it('shows a fallback error message for non-Error rejection', async () => {
+    (fetchTicketSummaryReport as jest.Mock).mockRejectedValue('boom');
+    (fetchTicketResolutionTimeReport as jest.Mock).mockResolvedValue({});
+    (fetchCustomerSatisfactionReport as jest.Mock).mockResolvedValue({});
+    (fetchProblemManagementReport as jest.Mock).mockResolvedValue({});
+
+    const { result } = renderHook(() => useMisReportDownloader(mockRequestParams));
+
+    await act(async () => {
+      await result.current.handleDownload('excel', 'daily', sampleRange);
+    });
+
+    await waitFor(() => {
+      expect(showMessage).toHaveBeenCalledWith('Failed to download MIS reports.', 'error');
+    });
+  });
+
+  it('notifies that report will be emailed', () => {
+    const { result } = renderHook(() => useMisReportDownloader(mockRequestParams));
+
+    act(() => {
+      result.current.handleEmail('half-yearly', sampleRange);
+    });
+
+    expect(showMessage).toHaveBeenCalledWith(expect.stringContaining('Half-Yearly report for'), 'success');
+  });
+});

--- a/ui/src/hooks/__tests__/useMisReportFilters.test.ts
+++ b/ui/src/hooks/__tests__/useMisReportFilters.test.ts
@@ -1,0 +1,131 @@
+import { act, renderHook } from '@testing-library/react';
+
+jest.mock('xlsx', () => {
+  const mock = { utils: { decode_range: jest.fn(), encode_cell: jest.fn() } };
+  return { __esModule: true, default: mock, ...mock };
+}, { virtual: true });
+import { useMisReportFilters } from '../useMisReportFilters';
+import { useCategoryFilters } from '../useCategoryFilters';
+import { getCurrentUserDetails } from '../../config/config';
+
+jest.mock('../useCategoryFilters');
+jest.mock('../../config/config');
+
+describe('useMisReportFilters', () => {
+  const loadSubCategories = jest.fn();
+  const resetSubCategories = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useCategoryFilters as jest.Mock).mockReturnValue({
+      categoryOptions: [{ value: 'All', label: 'All' }, { value: 'cat-1', label: 'Category 1' }],
+      subCategoryOptions: [{ value: 'All', label: 'All' }, { value: 'sub-1', label: 'Sub 1' }],
+      loadSubCategories,
+      resetSubCategories,
+    });
+  });
+
+  it('initializes with user scope for non-admin and resets sub-categories for All', () => {
+    (getCurrentUserDetails as jest.Mock).mockReturnValue({ userId: 'u-9', role: ['User'] });
+
+    const { result } = renderHook(() => useMisReportFilters());
+
+    expect(result.current.viewScope).toBe('user');
+    expect(result.current.requestParams.userId).toBe('u-9');
+    expect(result.current.requestParams.categoryId).toBeUndefined();
+    expect(result.current.requestParams.subCategoryId).toBeUndefined();
+    expect(resetSubCategories).toHaveBeenCalled();
+  });
+
+  it('uses all scope for admin role', () => {
+    (getCurrentUserDetails as jest.Mock).mockReturnValue({ userId: 'admin-1', role: ['System Administrator'] });
+
+    const { result } = renderHook(() => useMisReportFilters());
+
+    expect(result.current.viewScope).toBe('all');
+    expect(result.current.requestParams.scope).toBe('all');
+  });
+
+  it('updates time scale and picks first default time range for the scale', () => {
+    (getCurrentUserDetails as jest.Mock).mockReturnValue({ userId: 'u-1', role: [] });
+    const { result } = renderHook(() => useMisReportFilters());
+
+    act(() => {
+      result.current.handleTimeScaleChange({ target: { value: 'WEEKLY' } } as any);
+    });
+
+    expect(result.current.timeScale).toBe('WEEKLY');
+    expect(result.current.timeRange).toBe('LAST_4_WEEKS');
+  });
+
+  it('updates explicit time range', () => {
+    (getCurrentUserDetails as jest.Mock).mockReturnValue({ userId: 'u-1', role: [] });
+    const { result } = renderHook(() => useMisReportFilters());
+
+    act(() => {
+      result.current.handleTimeRangeChange({ target: { value: 'LAST_7_DAYS' } } as any);
+    });
+
+    expect(result.current.timeRange).toBe('LAST_7_DAYS');
+  });
+
+  it('handles custom month range changes and forces monthly custom range', () => {
+    (getCurrentUserDetails as jest.Mock).mockReturnValue({ userId: 'u-1', role: [] });
+    const { result } = renderHook(() => useMisReportFilters());
+
+    act(() => {
+      result.current.handleCustomMonthRangeChange('start')({ target: { value: '2021' } } as any);
+      result.current.handleCustomMonthRangeChange('end')({ target: { value: '' } } as any);
+    });
+
+    expect(result.current.customMonthRange).toEqual({ start: 2021, end: null });
+    expect(result.current.timeScale).toBe('MONTHLY');
+    expect(result.current.timeRange).toBe('CUSTOM_MONTH_RANGE');
+  });
+
+  it('updates custom from/to dates and normalizes invalid ranges', () => {
+    (getCurrentUserDetails as jest.Mock).mockReturnValue({ userId: 'u-1', role: [] });
+    const { result } = renderHook(() => useMisReportFilters());
+
+    act(() => {
+      result.current.handleDateChange('to')({ target: { value: '2025-02-10' } } as any);
+      result.current.handleDateChange('from')({ target: { value: '2025-02-12' } } as any);
+    });
+
+    expect(result.current.activeDateRange).toEqual({ from: '2025-02-12', to: '2025-02-12' });
+    expect(result.current.timeScale).toBe('CUSTOM');
+    expect(result.current.timeRange).toBe('CUSTOM_DATE_RANGE');
+
+    act(() => {
+      result.current.handleDateChange('to')({ target: { value: '2025-02-11' } } as any);
+    });
+    expect(result.current.activeDateRange).toEqual({ from: '2025-02-11', to: '2025-02-11' });
+  });
+
+  it('loads subcategories and updates request params when category/subcategory selected', () => {
+    (getCurrentUserDetails as jest.Mock).mockReturnValue({ userId: 'u-1', role: [] });
+    const { result } = renderHook(() => useMisReportFilters());
+
+    act(() => {
+      result.current.handleCategoryChange({ target: { value: 'cat-1' } } as any);
+    });
+
+    expect(loadSubCategories).toHaveBeenCalledWith('cat-1');
+    expect(result.current.selectedSubCategory).toBe('All');
+    expect(result.current.requestParams.categoryId).toBe('cat-1');
+    expect(result.current.requestParams.subCategoryId).toBeUndefined();
+
+    act(() => {
+      result.current.handleSubCategoryChange({ target: { value: 'sub-1' } } as any);
+    });
+
+    expect(result.current.requestParams.subCategoryId).toBe('sub-1');
+
+    act(() => {
+      result.current.handleCategoryChange({ target: { value: 'All' } } as any);
+    });
+
+    expect(resetSubCategories).toHaveBeenCalled();
+    expect(result.current.requestParams.categoryId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Motivation
- Increase unit-test coverage for MIS report related hooks by adding tests that exercise key branches and error paths without modifying production code.

### Description
- Added `ui/src/hooks/__tests__/useMisReportDownloader.test.ts` with mocks for XLSX, report services, snackbar, current user details and MIS utilities and tests for successful Excel download, unsupported option handling, incomplete payload error, non-`Error` rejection handling and email notification messaging.
- Added `ui/src/hooks/__tests__/useMisReportFilters.test.ts` with mocks for category filters and current user details and tests for admin vs non-admin scope, time scale/range handlers, custom month/date behaviors, category/subcategory selection, and request parameter derivation.
- Tests isolate workbook interactions by mocking `xlsx` utilities and stub MIS helper functions like `calculateColumnWidths`, `applyThinBorders`, `formatDateInput`, and `extractApiPayload`.

### Testing
- Ran the targeted test suites with `CI=true npm test -- --runInBand --watch=false src/hooks/__tests__/useMisReportDownloader.test.ts src/hooks/__tests__/useMisReportFilters.test.ts` and both suites passed.
- Collected coverage with `CI=true npm test -- --runInBand --watch=false --coverage --collectCoverageFrom=src/hooks/useMisReportDownloader.ts --collectCoverageFrom=src/hooks/useMisReportFilters.ts ...` and confirmed coverage improvements: `useMisReportDownloader.ts` at 93.61% statements and `useMisReportFilters.ts` at 98.50% statements, with all new tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b40f013b5c8332a2cf7c9889c4fd16)