### PR TITLE
test: expand coverage for StatusHistory, user tables, PriorityIcon, and SlaProgressChart

### DIFF
--- a/ui/src/components/StatusHistory/__tests__/index.test.tsx
+++ b/ui/src/components/StatusHistory/__tests__/index.test.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import StatusHistory from '../index';
+
+const mockApiHandler = jest.fn();
+const mockUseApi = jest.fn();
+const mockGetAllUsers = jest.fn();
+const mockGetStatusHistory = jest.fn();
+const mockReportMenu = jest.fn(() => <div data-testid="download-menu" />);
+
+jest.mock('../../../hooks/useApi', () => ({
+  useApi: () => mockUseApi(),
+}));
+
+jest.mock('../../../services/StatusHistoryService', () => ({
+  getStatusHistory: (...args: any[]) => mockGetStatusHistory(...args),
+}));
+
+jest.mock('../../../services/UserService', () => ({
+  getAllUsers: () => mockGetAllUsers(),
+}));
+
+jest.mock('../../UI/ViewToggle', () => ({ value, onChange }: any) => (
+  <div>
+    <button type="button" onClick={() => onChange('table')} aria-label="table-view">table</button>
+    <button type="button" onClick={() => onChange('timeline')} aria-label="timeline-view">timeline</button>
+    <span data-testid="view-value">{value}</span>
+  </div>
+));
+
+jest.mock('../../History/HistoryReportDownloadMenu', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    mockReportMenu(props);
+    return <div data-testid="report-menu" />;
+  },
+}));
+
+jest.mock('../../UI/GenericTable', () => (props: any) => (
+  <div data-testid="generic-table">
+    {props.dataSource.map((row: any, idx: number) => (
+      <div key={row.id} data-testid={`row-${idx}`} data-row-class={props.rowClassName?.(row, idx)}>
+        {props.columns.map((column: any) => {
+          const value = row[column.dataIndex];
+          const text = column.render ? column.render(value, row) : value;
+          return <div key={column.key}>{text}</div>;
+        })}
+      </div>
+    ))}
+  </div>
+));
+
+jest.mock('@mui/lab', () => ({
+  Timeline: ({ children }: any) => <div data-testid="timeline">{children}</div>,
+  TimelineItem: ({ children }: any) => <div>{children}</div>,
+  TimelineSeparator: ({ children }: any) => <div>{children}</div>,
+  TimelineDot: ({ children }: any) => <div>{children}</div>,
+  TimelineConnector: () => <div data-testid="connector" />,
+  TimelineContent: ({ children }: any) => <div>{children}</div>,
+}), { virtual: true });
+
+jest.mock('@mui/material', () => ({
+  Paper: ({ children }: any) => <div>{children}</div>,
+}));
+
+describe('StatusHistory', () => {
+  const data = [
+    {
+      id: '1',
+      updatedBy: 'alpha',
+      timestamp: '2024-01-02T00:00:00.000Z',
+      currentStatus: 'IN_PROGRESS',
+      label: 'In Progress',
+      remark: 'assigned',
+    },
+    {
+      id: '2',
+      updatedBy: 'beta',
+      timestamp: '2024-01-01T00:00:00.000Z',
+      currentStatus: 'ON_HOLD',
+      statusName: 'On Hold',
+      remark: '',
+    },
+    {
+      id: '3',
+      updatedBy: 'missing',
+      timestamp: '2023-12-30T00:00:00.000Z',
+      currentStatus: 'WAITING_APPROVAL',
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockApiHandler.mockImplementation((fn: any) => fn());
+    mockUseApi.mockReturnValue({ data, apiHandler: mockApiHandler });
+    mockGetStatusHistory.mockResolvedValue({ data });
+  });
+
+  it('loads status history and user names for table/report rendering', async () => {
+    mockGetAllUsers.mockResolvedValue({
+      data: [
+        { username: 'alpha', name: 'Alpha User' },
+        { username: 'beta' },
+      ],
+    });
+
+    render(<StatusHistory ticketId="T-101" />);
+
+    await waitFor(() => {
+      expect(mockApiHandler).toHaveBeenCalled();
+      expect(mockGetAllUsers).toHaveBeenCalled();
+    });
+
+    expect(mockGetStatusHistory).toHaveBeenCalledWith('T-101');
+
+    expect(screen.getByTestId('row-0')).toHaveAttribute('data-row-class', 'latest-row');
+    await waitFor(() => {
+      expect(screen.getByText('Alpha User')).toBeInTheDocument();
+    });
+    expect(screen.getAllByText('beta').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('-').length).toBeGreaterThan(0);
+    expect(screen.getByText('In Progress')).toBeInTheDocument();
+    expect(screen.getByText('On Hold')).toBeInTheDocument();
+    expect(screen.getByText('WAITING APPROVAL')).toBeInTheDocument();
+
+    expect(mockReportMenu).toHaveBeenCalledWith(expect.objectContaining({
+      fileBaseName: 'T-101-status-history',
+    }));
+    const reportRows = mockReportMenu.mock.calls.at(-1)[0].rows;
+    expect(reportRows[0].updatedByName).toBe('Alpha User');
+    expect(reportRows[1].updatedByName).toBe('beta');
+    expect(reportRows[2].updatedByName).toBe('-');
+  });
+
+  it('falls back to empty user map when user service fails', async () => {
+    mockGetAllUsers.mockRejectedValue(new Error('failed'));
+
+    render(<StatusHistory ticketId="T-102" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('-').length).toBeGreaterThan(0);
+    });
+  });
+
+  it('switches to timeline view and renders connectors/remarks conditionally', async () => {
+    mockGetAllUsers.mockResolvedValue({ data: [] });
+    render(<StatusHistory ticketId="T-103" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'timeline-view' }));
+
+    expect(await screen.findByTestId('timeline')).toBeInTheDocument();
+    expect(screen.getAllByTestId('connector')).toHaveLength(2);
+    expect(screen.getByText('assigned')).toBeInTheDocument();
+    expect(screen.queryByText('undefined')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/components/TicketView/__tests__/SlaProgressChart.test.tsx
+++ b/ui/src/components/TicketView/__tests__/SlaProgressChart.test.tsx
@@ -17,45 +17,84 @@ describe('SlaProgressChart', () => {
     elapsedTimeMinutes: 45,
     totalSlaMinutes: 90,
     timeTillDueDate: 40,
+    workingTimeLeftMinutes: 20,
     breachedByMinutes: 0,
   } as any;
+
+  beforeEach(() => {
+    mockReactECharts.mockClear();
+  });
 
   it('returns null when no data available', () => {
     const { container } = render(<SlaProgressChart sla={null} />);
     expect(container.firstChild).toBeNull();
   });
 
-  it('creates stacked bar chart configuration', () => {
-    render(<SlaProgressChart sla={baseSla} className="chart" />);
+  it('returns null when all segment values resolve to zero', () => {
+    const { container } = render(
+      <SlaProgressChart
+        sla={{
+          responseTimeMinutes: 0,
+          idleTimeMinutes: 0,
+          resolutionTimeMinutes: 0,
+          elapsedTimeMinutes: 0,
+          totalSlaMinutes: 0,
+          workingTimeLeftMinutes: 0,
+          breachedByMinutes: 1,
+        } as any}
+      />,
+    );
 
-    const mock = mockReactECharts;
-    expect(mock).toHaveBeenCalled();
-    const props = mock.mock.calls[0][0];
-    expect(props.className).toBe('chart');
-    expect(props.option.series.length).toBeGreaterThanOrEqual(3);
-    const segmentNames = props.option.series.map((series: any) => series.name);
-    expect(segmentNames).toContain('Idle Time');
-    expect(segmentNames).toContain('Resolution Time');
+    expect(container.firstChild).toBeNull();
+    expect(mockReactECharts).not.toHaveBeenCalled();
   });
 
-  it('includes breached time segment when SLA is exceeded', () => {
-    const breachedSla = {
-      ...baseSla,
-      workingTimeLeftMinutes: -15,
-      elapsedTimeMinutes: 60,
-      idleTimeMinutes: 0,
-      responseTimeMinutes: 0,
-      resolutionTimeMinutes: 0,
-      totalSlaMinutes: 45,
-    } as any;
+  it('creates stacked bar chart configuration with remaining and other elapsed segments', () => {
+    render(<SlaProgressChart sla={baseSla} className="chart" />);
 
-    render(<SlaProgressChart sla={breachedSla} />);
+    const props = mockReactECharts.mock.calls[0][0];
+    expect(props.className).toBe('chart');
+
+    const seriesByName = Object.fromEntries(props.option.series.map((s: any) => [s.name, s]));
+    expect(seriesByName['Idle Time'].data[0]).toBe(8);
+    expect(seriesByName['Resolution Time'].data[0]).toBe(20);
+    expect(seriesByName['Other Elapsed'].data[0]).toBe(7);
+    expect(seriesByName['Remaining Time']).toBeUndefined();
+  });
+
+  it('includes breached time segment when working time left is negative', () => {
+    render(
+      <SlaProgressChart
+        sla={{
+          ...baseSla,
+          idleTimeMinutes: 0,
+          resolutionTimeMinutes: 0,
+          elapsedTimeMinutes: 60,
+          workingTimeLeftMinutes: -15,
+        } as any}
+      />,
+    );
 
     const props = mockReactECharts.mock.calls[0][0];
     const seriesNames = props.option.series.map((s: any) => s.name);
     expect(seriesNames).toContain('Breached Time');
     expect(seriesNames).not.toContain('Remaining Time');
-    const breachedSeries = props.option.series.find((s: any) => s.name === 'Breached Time');
-    expect(breachedSeries.data[0]).toBeGreaterThan(0);
+  });
+
+  it('formats tooltip duration text for mins, hrs, and days', () => {
+    render(<SlaProgressChart sla={{ ...baseSla, elapsedTimeMinutes: 1600 } as any} />);
+
+    const formatter = mockReactECharts.mock.calls[0][0].option.tooltip.formatter;
+
+    const tooltip = formatter([
+      { marker: '•', seriesName: 'Segment A', value: 1 },
+      { marker: '•', seriesName: 'Segment B', value: 125 },
+      { marker: '•', seriesName: 'Segment C', value: 2880 },
+    ]);
+
+    expect(tooltip).toContain('1 min');
+    expect(tooltip).toContain('2 hrs 5 mins');
+    expect(tooltip).toContain('2 days');
+    expect(tooltip).toContain('Total: 2 days 2 hrs 6 mins');
   });
 });

--- a/ui/src/components/UI/Icons/__tests__/PriorityIcon.test.tsx
+++ b/ui/src/components/UI/Icons/__tests__/PriorityIcon.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import PriorityIcon from '../PriorityIcon';
+
+const mockIconComponent = jest.fn((props: any) => <span data-testid="priority-arrow" {...props} />);
+
+jest.mock('@mui/material', () => ({
+  Box: ({ children, sx, ...rest }: any) => <div data-testid="priority-box" data-transform={sx?.transform} {...rest}>{children}</div>,
+  Tooltip: ({ children }: any) => <>{children}</>,
+}));
+
+jest.mock('../../IconButton/CustomIconButton', () => ({
+  IconComponent: (props: any) => mockIconComponent(props),
+}));
+
+describe('PriorityIcon', () => {
+  beforeEach(() => {
+    mockIconComponent.mockClear();
+  });
+
+  it.each([
+    { level: 4, expectedColor: '#ffd700' },
+    { level: 3, expectedColor: 'orange' },
+    { level: 2, expectedColor: 'orange' },
+    { level: 1, expectedColor: 'red' },
+    { level: 0, expectedColor: 'ffd700' },
+  ])('uses getColor mapping for level $level', ({ level, expectedColor }) => {
+    render(<PriorityIcon level={level} priorityText="priority" />);
+
+    const firstCallProps = mockIconComponent.mock.calls[0][0];
+    expect(firstCallProps.style.color).toBe(expectedColor);
+    expect(firstCallProps.color).toBe(expectedColor);
+  });
+
+  it('renders inverted count based on level', () => {
+    render(<PriorityIcon level={2} />);
+
+    expect(mockIconComponent).toHaveBeenCalledTimes(3);
+  });
+
+  it('applies rotate style when rotateRight is true', () => {
+    render(<PriorityIcon level={3} rotateRight />);
+
+    const firstBox = document.querySelector('[data-testid="priority-box"]') as HTMLElement;
+    expect(firstBox.getAttribute('data-transform')).toBe('rotate(90deg)');
+  });
+});

--- a/ui/src/components/Users/__tests__/HelpdeskUsersTable.test.tsx
+++ b/ui/src/components/Users/__tests__/HelpdeskUsersTable.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import HelpdeskUsersTable from '../HelpdeskUsersTable';
+
+const mockGenericTable = jest.fn(() => null);
+
+jest.mock('../../UI/GenericTable', () => ({
+  __esModule: true,
+  default: (props: any) => mockGenericTable(props),
+}));
+
+describe('HelpdeskUsersTable', () => {
+  const user = {
+    userId: 'U1',
+    name: 'Alice',
+    emailId: 'a@example.com',
+    mobileNo: '9999999999',
+    office: 'HQ',
+    username: 'alice',
+    roles: 'HELPDESK',
+    stakeholder: 'Support',
+    levels: ['L1', 'L2'],
+  } as any;
+
+  beforeEach(() => {
+    mockGenericTable.mockClear();
+  });
+
+  it('passes table props and formats levels fallback', () => {
+    render(<HelpdeskUsersTable users={[user]} loading onViewProfile={jest.fn()} />);
+
+    const props = mockGenericTable.mock.calls[0][0];
+    expect(props.rowKey).toBe('userId');
+    expect(props.loading).toBe(true);
+    expect(props.pagination).toBe(false);
+
+    const levelsColumn = props.columns.find((c: any) => c.key === 'levels');
+    expect(levelsColumn.render(['L1', 'L2'])).toBe('L1, L2');
+    expect(levelsColumn.render([])).toBe('-');
+  });
+
+  it('handles actions for view and reset button disabled/enabled states', () => {
+    const onViewProfile = jest.fn();
+    const onResetPassword = jest.fn();
+
+    render(
+      <HelpdeskUsersTable
+        users={[user]}
+        onViewProfile={onViewProfile}
+        onResetPassword={onResetPassword}
+        resettingUserId="U1"
+      />,
+    );
+
+    const props = mockGenericTable.mock.calls[0][0];
+    const actionsColumn = props.columns.find((c: any) => c.key === 'actions');
+    const actionNode = actionsColumn.render(undefined, user);
+    const buttons = React.Children.toArray(actionNode.props.children);
+
+    buttons[0].props.onClick();
+    expect(onViewProfile).toHaveBeenCalledWith(user);
+
+    expect(buttons[1].props.disabled).toBe(true);
+
+    render(
+      <HelpdeskUsersTable
+        users={[user]}
+        onViewProfile={onViewProfile}
+        onResetPassword={onResetPassword}
+        resettingUserId="other"
+      />,
+    );
+
+    const nextActions = mockGenericTable.mock.calls[1][0].columns.find((c: any) => c.key === 'actions');
+    const nextButtons = React.Children.toArray(nextActions.render(undefined, user).props.children);
+    expect(nextButtons[1].props.disabled).toBe(false);
+    nextButtons[1].props.onClick();
+    expect(onResetPassword).toHaveBeenCalledWith(user);
+  });
+});

--- a/ui/src/components/Users/__tests__/RequesterUsersTable.test.tsx
+++ b/ui/src/components/Users/__tests__/RequesterUsersTable.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import RequesterUsersTable from '../RequesterUsersTable';
+
+const mockGenericTable = jest.fn(() => null);
+
+jest.mock('../../UI/GenericTable', () => ({
+  __esModule: true,
+  default: (props: any) => mockGenericTable(props),
+}));
+
+describe('RequesterUsersTable', () => {
+  const user = {
+    requesterUserId: 'R1',
+    name: 'Requester',
+    emailId: 'r@example.com',
+    mobileNo: '999',
+    office: 'Office',
+    username: 'requester',
+    officeType: 'RO',
+    officeCode: '001',
+    roleIds: [],
+  } as any;
+
+  beforeEach(() => {
+    mockGenericTable.mockClear();
+  });
+
+  const getActions = () => {
+    const props = mockGenericTable.mock.calls.at(-1)[0];
+    return props.columns.find((c: any) => c.key === 'actions');
+  };
+
+  it('passes table props and handles view/reset actions', () => {
+    const onViewProfile = jest.fn();
+    const onResetPassword = jest.fn();
+
+    render(<RequesterUsersTable users={[user]} loading onViewProfile={onViewProfile} onResetPassword={onResetPassword} />);
+
+    const props = mockGenericTable.mock.calls[0][0];
+    expect(props.rowKey).toBe('requesterUserId');
+    expect(props.loading).toBe(true);
+    expect(props.pagination).toBe(false);
+
+    const buttons = React.Children.toArray(getActions().render(undefined, user).props.children);
+    buttons[0].props.onClick();
+    buttons[1].props.onClick();
+    expect(onViewProfile).toHaveBeenCalledWith(user);
+    expect(onResetPassword).toHaveBeenCalledWith(user);
+  });
+
+  it('hides appoint button for non-RO offices', () => {
+    render(<RequesterUsersTable users={[{ ...user, officeType: 'HO' }]} onViewProfile={jest.fn()} />);
+
+    const buttons = React.Children.toArray(getActions().render(undefined, { ...user, officeType: 'HO' }).props.children);
+    expect(buttons).toHaveLength(2);
+  });
+
+  it('disables appoint button when already RNO, appointing, or missing handler', () => {
+    render(<RequesterUsersTable users={[{ ...user, roleIds: ['4'] }]} onViewProfile={jest.fn()} onAppointRno={jest.fn()} />);
+    let buttons = React.Children.toArray(getActions().render(undefined, { ...user, roleIds: ['4'] }).props.children);
+    expect(buttons[2].props.disabled).toBe(true);
+    expect(buttons[2].props.title).toBe('Already appointed as RNO');
+
+    render(<RequesterUsersTable users={[user]} onViewProfile={jest.fn()} onAppointRno={jest.fn()} appointingUserId="R1" />);
+    buttons = React.Children.toArray(getActions().render(undefined, user).props.children);
+    expect(buttons[2].props.disabled).toBe(true);
+
+    render(<RequesterUsersTable users={[user]} onViewProfile={jest.fn()} />);
+    buttons = React.Children.toArray(getActions().render(undefined, user).props.children);
+    expect(buttons[2].props.disabled).toBe(true);
+  });
+
+  it('enables appoint when eligible and handles reset disabled state', () => {
+    const onAppointRno = jest.fn();
+
+    render(
+      <RequesterUsersTable
+        users={[user]}
+        onViewProfile={jest.fn()}
+        onAppointRno={onAppointRno}
+        onResetPassword={jest.fn()}
+        resettingUserId="R1"
+      />,
+    );
+    let buttons = React.Children.toArray(getActions().render(undefined, user).props.children);
+    expect(buttons[1].props.disabled).toBe(true);
+
+    render(<RequesterUsersTable users={[user]} onViewProfile={jest.fn()} onAppointRno={onAppointRno} />);
+    buttons = React.Children.toArray(getActions().render(undefined, user).props.children);
+    expect(buttons[2].props.disabled).toBe(false);
+    expect(buttons[2].props.title).toBe('Appoint as RNO');
+    buttons[2].props.onClick();
+    expect(onAppointRno).toHaveBeenCalledWith(user);
+  });
+});


### PR DESCRIPTION
### Motivation
- Improve unit-test coverage for UI components that previously had low or missing coverage: status history rendering, priority icon color/count logic, helpdesk/requester user tables, and SLA progress chart behavior.

### Description
- Added focused tests for `StatusHistory` that mock `useApi`, `getStatusHistory`, and `getAllUsers` to validate table rendering, timeline toggle, user-name mapping success/fallback, report rows, and row-class selection.
- Added tests for `PriorityIcon` that verify all `getColor` branches (including default), inverted arrow count logic derived from `level`, and `rotateRight` transform via mocked icon and container props.
- Added `HelpdeskUsersTable` tests that assert `GenericTable` wiring, `levels` rendering (`join` vs `-`), and actions column behavior including view/reset callbacks and reset-button disabled state handling.
- Added `RequesterUsersTable` tests that inspect table props, view/reset actions, conditional rendering of the appoint-as-RNO button for `RO` offices, all disabled/enabled button states, and the appoint callback execution when eligible.
- Expanded `SlaProgressChart` tests to cover null/empty option early exits, composition of stacked series (idle, resolution, other elapsed, breached/remaining logic), and the tooltip formatter output for minutes/hours/days.

### Testing
- Ran targeted Jest suites with `cd ui && npm test -- --watch=false --runTestsByPath <test paths>` for the new/updated tests covering `PriorityIcon`, `HelpdeskUsersTable`, `RequesterUsersTable`, `StatusHistory`, and `SlaProgressChart`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b413cec6ac833292290a205fe07468)