### PR TITLE
test: expand coverage for CategoryService, TicketService, and reportPeriods

### DIFF
--- a/ui/src/services/__tests__/services.test.ts
+++ b/ui/src/services/__tests__/services.test.ts
@@ -145,6 +145,39 @@ describe("CalendarService", () => {
 });
 
 describe("CategoryService", () => {
+  it("normalizes category sub-category fields from different payload shapes", async () => {
+    axiosMock.get.mockResolvedValue({
+      data: [
+        {
+          id: "C1",
+          subCategories: [
+            { id: "S1", subCategory: "Power+Issue=", severity: { id: "SEV-1" } },
+            { id: "S2", subCategory: "Already Clean", severityId: "SEV-2" },
+          ],
+        },
+      ],
+    });
+    const service = await import("../CategoryService");
+
+    const response = await service.getCategories();
+
+    expect(response.data[0].subCategories).toEqual([
+      expect.objectContaining({ id: "S1", subCategory: "Power Issue", severityId: "SEV-1" }),
+      expect.objectContaining({ id: "S2", subCategory: "Already Clean", severityId: "SEV-2" }),
+    ]);
+  });
+
+  it("does not cache category responses when the payload is not an array", async () => {
+    axiosMock.get.mockResolvedValueOnce({ data: { body: { data: [] } } });
+    axiosMock.get.mockResolvedValueOnce({ data: [] });
+    const service = await import("../CategoryService");
+
+    await service.getCategories();
+    await service.getCategories();
+
+    expect(axiosMock.get).toHaveBeenCalledTimes(2);
+  });
+
   it("caches categories after the first request", async () => {
     const response = { data: [{ id: 1 }] };
     axiosMock.get.mockResolvedValue(response);
@@ -172,6 +205,36 @@ describe("CategoryService", () => {
     const cached = await service.getAllSubCategoriesByCategory("network");
     expect(cached.data).toEqual(response.data);
     // expect(axiosMock.get).not.toHaveBeenCalled();
+  });
+
+  it("resets category and sub-category caches on mutating operations", async () => {
+    const service = await import("../CategoryService");
+
+    axiosMock.get.mockResolvedValue({ data: [{ id: "C1" }] });
+    await service.getCategories();
+    axiosMock.get.mockClear();
+    await service.addCategory({ name: "New Category" });
+    axiosMock.get.mockResolvedValue({ data: [{ id: "C2" }] });
+    await service.getCategories();
+    expect(axiosMock.get).toHaveBeenCalledTimes(1);
+
+    axiosMock.get.mockClear();
+    axiosMock.get.mockResolvedValue({ data: [{ id: "S1" }] });
+    await service.getAllSubCategoriesByCategory("network");
+    axiosMock.get.mockClear();
+    await service.updateSubCategory("S1", { name: "Updated" });
+    axiosMock.get.mockResolvedValue({ data: [{ id: "S2" }] });
+    await service.getAllSubCategoriesByCategory("network");
+    expect(axiosMock.get).toHaveBeenCalledTimes(1);
+
+    axiosMock.get.mockClear();
+    axiosMock.get.mockResolvedValue({ data: [{ id: "S3" }] });
+    await service.getAllSubCategoriesByCategory("network");
+    axiosMock.get.mockClear();
+    await service.deleteSubCategory("S1");
+    axiosMock.get.mockResolvedValue({ data: [{ id: "S4" }] });
+    await service.getAllSubCategoriesByCategory("network");
+    expect(axiosMock.get).toHaveBeenCalledTimes(1);
   });
 
   it("supports CRUD operations on categories and sub categories", async () => {
@@ -588,7 +651,31 @@ describe("TicketService", () => {
 
   it("constructs search query parameters", async () => {
     const service = await import("../TicketService");
-    await service.searchTicketsPaginated("query", "OPEN", true, 2, 10, "assignee", "level1", "assigner", "requestor", "createdAt", "desc", "HIGH", "creator", "reported_date", "2024-01-01", "2024-02-01", "cat", "sub");
+    await service.searchTicketsPaginated(
+      "query",
+      "OPEN",
+      true,
+      2,
+      10,
+      "assignee",
+      "level1",
+      "assigner",
+      "requestor",
+      "createdAt",
+      "desc",
+      "HIGH",
+      "creator",
+      "reported_date",
+      "2024-01-01",
+      "2024-02-01",
+      "cat",
+      "sub",
+      "Z1",
+      "R1",
+      "D1",
+      "I1",
+      "DIV-1"
+    );
     const url = axiosMock.get.mock.calls.find((call: any[]) => String(call[0]).includes("/tickets/search"))[0] as string;
     expect(url).toContain("query=query");
     expect(url).toContain("status=OPEN");
@@ -608,6 +695,11 @@ describe("TicketService", () => {
     expect(url).toContain("toDate=2024-02-01");
     expect(url).toContain("category=cat");
     expect(url).toContain("subCategory=sub");
+    expect(url).toContain("zoneCode=Z1");
+    expect(url).toContain("regionCode=R1");
+    expect(url).toContain("districtCode=D1");
+    expect(url).toContain("issueTypeId=I1");
+    expect(url).toContain("divisionId=DIV-1");
   });
   it("constructs export search query parameters", async () => {
     const service = await import("../TicketService");

--- a/ui/src/utils/__tests__/reportPeriods.test.ts
+++ b/ui/src/utils/__tests__/reportPeriods.test.ts
@@ -13,6 +13,11 @@ describe("utils/reportPeriods", () => {
   it("has configured periods and labels", () => {
     expect(REPORT_PERIODS).toHaveLength(5);
     expect(getPeriodLabel("weekly")).toBe("Weekly");
+    expect(getPeriodLabel("half-yearly")).toBe("Half-Yearly");
+  });
+
+  it("falls back to the raw value for unknown labels", () => {
+    expect(getPeriodLabel("custom" as any)).toBe("custom");
   });
 
   it("calculates period ranges", () => {
@@ -21,5 +26,12 @@ describe("utils/reportPeriods", () => {
     expect(calculatePeriodRange("monthly").startDate.toISOString()).toContain("2024-07-15T00:00:00.000Z");
     expect(calculatePeriodRange("quarterly").startDate.toISOString()).toContain("2024-05-15T00:00:00.000Z");
     expect(calculatePeriodRange("half-yearly").startDate.toISOString()).toContain("2024-02-15T00:00:00.000Z");
+
+    const dailyRange = calculatePeriodRange("daily");
+    expect(dailyRange.endDate.toISOString()).toContain("2024-08-15T12:00:00.000Z");
+    expect(dailyRange.startDate.getHours()).toBe(0);
+    expect(dailyRange.startDate.getMinutes()).toBe(0);
+    expect(dailyRange.startDate.getSeconds()).toBe(0);
+    expect(dailyRange.startDate.getMilliseconds()).toBe(0);
   });
 });


### PR DESCRIPTION
### Motivation
- Improve unit test coverage for category normalization/cache behavior and ticket search parameter handling, and make `reportPeriods` assertions more robust.

### Description
- Added tests in `src/services/__tests__/services.test.ts` to validate `CategoryService` normalization of `subCategories` (strips `+`/`=` and resolves `severityId`), non-array payload handling for `getCategories`, and cache invalidation after `addCategory`, `updateSubCategory`, and `deleteSubCategory`.
- Extended the `TicketService` `searchTicketsPaginated` test to include optional filters `zoneCode`, `regionCode`, `districtCode`, `issueTypeId`, and `divisionId` to cover previously uncovered branches.
- Enhanced `src/utils/__tests__/reportPeriods.test.ts` with a fallback label assertion for unknown periods via `getPeriodLabel` and stronger `calculatePeriodRange` checks to confirm start-of-day normalization and `endDate` retention for `daily`.

### Testing
- Ran `npm test -- --runInBand src/services/__tests__/services.test.ts src/utils/__tests__/reportPeriods.test.ts` and both test suites passed (2 test suites, 46 tests passed).
- Only test files were modified; no production source files were changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b41fa8d8e883328620d86e90884afa)