### PR TITLE
Fix TicketView tests and restore TicketView coverage

### DIFF
--- a/ui/src/components/TicketView/TicketView.tsx
+++ b/ui/src/components/TicketView/TicketView.tsx
@@ -525,12 +525,12 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
 
       getAttachmentsByTicketIdHandlerApi(ticketId)
     }
-  }, [ticketId, pageType, getTicketHandler, workflowApiHandler]);
+  }, [ticketId, pageType, getTicketHandler]);
 
   useEffect(() => {
     const masterTicketId = ticket?.masterId;
     if (!masterTicketId || masterTicketId === ticketId) {
-      setMasterSla(null);
+      setMasterSla(prev => (prev === null ? prev : null));
       return;
     }
 
@@ -1256,7 +1256,7 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
             {renderSelect(divisionId, setDivisionId, divisionOptions, {
               displayValue: ticket?.divisionName || ticket?.division,
               translate: false,
-              disabled: !divisionOptions.length,
+              disabled: !(divisionOptions || []).length,
               editing: allowDivisionEdit && editing,
             })}
           </Box>}
@@ -1266,7 +1266,7 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
               {renderSelect(issueTypeId, setIssueTypeId, issueTypeOptions, {
                 displayValue: ticket?.issueTypeLabel || ticket?.issueTypeId,
                 translate: false,
-                disabled: !issueTypeOptions.length
+                disabled: !(issueTypeOptions || []).length
               })}
             </Box>
           )}

--- a/ui/src/components/TicketView/__tests__/TicketView.test.tsx
+++ b/ui/src/components/TicketView/__tests__/TicketView.test.tsx
@@ -321,16 +321,19 @@ describe('TicketView', () => {
       apiHandler: (cb: () => Promise<any>) => Promise.resolve(cb()),
     } as any;
 
-    const useApiResponses = [
-      { ...defaultResponse, data: mockTicket, success: true },
-      { ...defaultResponse },
-      { ...defaultResponse, data: { '1': [] }, success: true },
-    ];
+    const ticketApiResponse = { ...defaultResponse, data: mockTicket, success: true };
+    const workflowApiResponse = { ...defaultResponse, data: { '1': [] }, success: true };
+    const attachmentsApiResponse = { ...defaultResponse, data: { body: { data: [] } }, success: true };
+
     let callIndex = 0;
     useApiMock.mockImplementation(() => {
-      const response = useApiResponses[callIndex] ?? defaultResponse;
-      callIndex = (callIndex + 1) % useApiResponses.length;
-      return response;
+      const slot = callIndex % 5;
+      callIndex += 1;
+
+      if (slot === 0) return ticketApiResponse;
+      if (slot === 2) return workflowApiResponse;
+      if (slot === 3) return attachmentsApiResponse;
+      return defaultResponse;
     });
 
     getTicketSlaMock.mockResolvedValue({ status: 200, data: { body: { data: mockSla } } });


### PR DESCRIPTION
### Motivation
- TicketView test runs became unstable and produced 0% coverage due to non-deterministic `useApi` mock responses and a couple of runtime issues during test render.
- The component also had a noisy effect dependency and a state update path that could trigger repeated renders during tests, causing failures and crashes.

### Description
- Made the `useEffect` that loads ticket data depend only on `ticketId`, `pageType`, and `getTicketHandler` by removing `workflowApiHandler` from the dependency list to avoid unnecessary re-execution of that effect (`TicketView.tsx`).
- Prevented redundant state updates for `masterSla` by only clearing it when needed (`setMasterSla(prev => (prev === null ? prev : null))`) to avoid extra renders (`TicketView.tsx`).
- Hardened rendering guards for dropdown option arrays by using safe checks `!(divisionOptions || []).length` and `!(issueTypeOptions || []).length` to avoid runtime `undefined.length` errors during test renders (`TicketView.tsx`).
- Stabilized tests by making the `useApi` mock deterministic across the multiple hook slots used by `TicketView` (returning specific per-hook responses for ticket, workflow and attachments APIs) to prevent response-slot drift between renders (`TicketView.test.tsx`).

### Testing
- Ran the focused TicketView tests: `CI=true npm test -- --watch=false --runInBand src/components/TicketView/__tests__/TicketView.test.tsx` and they passed.
- Ran the focused TicketView coverage command with `--collectCoverageFrom='src/components/TicketView/**/*.{ts,tsx}'` and confirmed the TicketView tests passed and coverage report generated (coverage no longer 0%).
- Ran the TicketView test directory: `CI=true npm test -- --watch=false --runInBand src/components/TicketView/__tests__` and all suites in that directory passed (8 suites, 30 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b422c703348332908cc58b4b6a2486)