### PR TITLE
Add script to generate consolidated PDF from Istanbul coverage JSON

### DIFF
--- a/ui/coverage/test-coverage-report.pdf
+++ b/ui/coverage/test-coverage-report.pdf
@@ -1,0 +1,207 @@
+%PDF-1.3
+% ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 15 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 14 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 16 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 14 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 17 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 14 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/Contents 18 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 14 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/Contents 19 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 14 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/Contents 20 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 14 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+10 0 obj
+<<
+/Contents 21 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 14 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+11 0 obj
+<<
+/Contents 22 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 14 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+12 0 obj
+<<
+/PageMode /UseNone /Pages 14 0 R /Type /Catalog
+>>
+endobj
+13 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260316062925+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260316062925+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+14 0 obj
+<<
+/Count 8 /Kids [ 4 0 R 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R ] /Type /Pages
+>>
+endobj
+15 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2099
+>>
+stream
+Gat%f95iQS&:j6J'tb5O$C&_^07-@Y)@9fHKr+F+$S?38-5,R#<$)(R_hY02QPO3G+Hd%ZZf:0$g"E3IP/0B>s1d57akLsTDKs#eZMp)-Q)\ACS,BhrV8"Y@8q5ZmmX1Rd+bWLb1<Llrn5STk5-dsjI<_Ahe_g:uGkB+kJ#X#ro't7B]^krtZ7:%^Q_poL^4)WS^Ei.&VU9XOpOd%D#?*`bgrb)M<IHuGr#a%cA>^U'bZN1]'"!c(kf@epO*"=g4:ZH/]JLgTo(hHMD:/3nYM*T[;HB[CBnr[sLSELMp+J,RaY]@XfbZ_NS$oE!(Dr@RB:T\Q\h,Eh8/9o;GH"T18G7o#1=]">o<hl03rQ3dB/!-+-%VJ<+h?imC^qEXk34=3Rib9E6d,mL%:g%*LAgdjcMV$]Le?6L3_Qdq_9"+b,a81gr5+P.Y9B@>$p^Ci)KX?%ngp'^kU/MD?Q:trhpt"7Bbqa4Q7E12FD9N%&n2S[-;Tp=W0prp-V9,QPB?ZP-V9eRs&<(U`+!Y.]61[[lFXO[D_Q81p.a##O&\.-rd*jB`H>>Ml:41lTn//1VRsNHVhuTR6q,*`%]IJu7M0>=dcH_+6YMufD,P'aNV4^4^HU.Cg\Q7c;&BEoL06ChN$&rG8>2I<"fde?$Of=g\"*_=8H&ZG:7o`2bW*ul/0(cV`)mH.CX0<N'%(!HERku$:r\`)dP6"U8J!?#OSt1^1.:.r$B`2BMZo<ri,)O3gT,XEgfMa8F7>bH1(;Jdj3%VlCbfNq^Q9"BA-b6Y,&1XZ`d,dM.Uf"tH5n[q_IFEh==.j;8&TEpjKPl2AW_eu9Z/J@+WI7U])J6IWZ6L80/=q<GCk[Qb7J;b^$HBJ3TRMe6^`>4^n,'\<*?([R8.*+F`N>c30tD0cdJ3bQhUL:UMnl_E:)DSgbfe*@:Uu.Qh65)/7jE.%RVqMqa"b_6EPd^m"3+5or9uf.It?C7Pi)s>f\>:1dVpiVQ5UdGBo`KA60#I(#FfUh::1bLrS,32O-T[FZSRKD:u91I:5r\'\l;.&/nfjrWL&"#7miX,O6cR(U?)7<Xul'_@hjT3/%DPGJ7#da4GJ(Yk&Q_5u?M[PHN497@LpkbFuleY3T&O\Y*@D(nfG6hNqQ<O`E-@j8<KX]ed:M/H/TEn&'L0^+^lJF45?VU]qF)'$tMFf:'!sKVX6CX0YR%IN]RT:H4Pq4J2'QViBQFZ<KG?ZEi3\*s@!?C0-9PIITQRL]*YYb1L`eNChQ]2&SeuS3be]6@G<i%'PQ>5LtV<2g7[m%H6Qgc`RhnDuH9e15rC?e,?h6899C*&;=*MpF:-WbCpLi4G/J1Te^0=<,.O&-YH*2<P@:b2_3dXa\`J$@Cp"S3uB78K*[1F>^"6Qe:i3,)+8#bD@`F\![Z>6X(U2'X!>jIrCuO#gP/Z0;6]Hu]#94rQ(mY+g3;J>-3fT0*?ZQdXDsR6@qRm=l_=4Q:d`hnqRc@dU"g465SR>9,!:$'0CR-1#")@%_eCPZ>2IaPdP*cL63sJH#`KFa"V2uP$S9&X%F!;b,p\Eue9GdW0$Kro]+F)!G(")pT%kJ%<Y.3k4YO"pB6td?AWK2AJLNf2n&G7l6a?GJ]t(2Q`K"=ZN2[fGC7)Sc2'XBCL;%Z+Q-8S^OB]_k:G=,>+W@9(fMj7Vg\OY4<c)id0A<_+S0">ZQ:2e2+O[NBanXpKj9-,.g-RR?RteU)h".VViTLUu?gI0=l>\plV76o.P%rQN?AS0"3+Oq3EehcHV@TqO!i8S!ZT$Y2SLWIj3]s&uSS$^Rl:=bi`ePn.0;"8r?%smVTdH$JQo!S@>&[*SK#fp6*;XQ8c*i#/`R"D5Z?O%8ddf&M761];3t"obR-G$U[?URs8_'GB)q)V9"@bDpTtf`![`KJRrI'(GQ(-_;K"*LBegCkTd4i"V"".ZIisWb!_IA:iHpQ@,11b+!h'd)>DZ)pg8MV!]X#GpK*Q+fo]*h7k<^EPJ+"(8eEJD7WBh#!_2t#,4*2SeH%#'X&;FYKH_]f4Q/['thHWUEaVK;A-nEB:-it')9!(E)hgr2A';fdVLTpp+fV\t<OS8gjoCCPs2kUlVl5J]j6L&~>endstream
+endobj
+16 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2152
+>>
+stream
+Gat=m>B?;m'S,*4.sU;Pd[;;$5n\T=gn[ZamUWub532sOYsZAp$>^[]qs%Y.OitU=-So(ulmFCB*h@?tBTed5eGVKLPN9tP+n')2=gGe8W(9@_^J*MP?b#FG>]JA,Wor^?E<rF?/u4S#/nrK!_S"ut]_pf<Emahkp#UUe>Z]goIS;r=4?QsGl)npI-N,]AmAF$hP5U_Xs5PpT9aWg^[Q^+PWM#-\a`cL>5?'ipVj]_B5o/U/4qkiY`/K_X&8n@hF]4"34M@@[Q>6EsrO]<SX(0\?__NMP:V"bn8A492p@,UR_rR8a"]s#6fVq#mFk<3nA7=>q2%-,$\d^!#_-L!1.Zq!sQtXXk>];l6CQdN&GGVFX,*cpF1M*GZdS2ao#P6Ic^NHZD6E]26HuoeXi\ZVMZ0HPp=:]VP],Ud"kr=(JOq-Y_Ot^IaXcP"3iH]tPf/uH8iDGl:i[d-=!<FVTc0_<SA^^BiJ7qD-"4A_nZa8_';\WBWmHj-sVdFqU>-e^YY")S&`YLQHc=3BFD2SG;"C]`QCrOAW`IObI:i/b*dph'@JAt`>qV:BP5PEo-;]W'aemoE*N6qYD9OOWQft3Ct;)PD-W/5(<Cd?-"hc:UgRM"g370R4P`i72,1/hC(rTctKnZmQ+:+1g(?nT*Hp!5HF"K2c![1uT'5laeX.,UP92@.YhJ\3[E7Q1bDRdst=hf\nF'Sd#;Li@I$'5\P_<[gC<KP7MO.MX-`#,M2!EhA@H)Bg$^OdU;9bsGY/\??EM/$k=mXuY/RZ`fE%2W5W,,E2I-M6Rqkr6YgT\[0C),jhm\P@ga%$.1`%=e9Y4p/*_lVrP&K+7L3-i&9c166fBccj8$N'Us;'=bNGk+L9-T0ZkQjm^ISciU>T)hpmM12/U0:DlT[#3"-!-bSP&#?n+j#E_V4PTi<L#,mL/>OMV5W6=YPcBiHqN>VA!sVP9IWhJ0[dg9L+8!M^,7a9s1sb<[k`3(,b=Fqq'c&j*(FADn?0R8Y?S5r-_j/e"."2N+H"*:%$PiV11TNo&XDj&L;-U1+XnMlW&J_13i?7EI:M2rFhlmKR9QOGreO<QZ1`Ci5o\q=f;E<>^:+?n+%-KhFr<[<r)/D*0T2+sJR)eqSYAqpP'fri?^+E>k80e*1<[>dcVb!tgJcQ*2Fb3!?2Nb>E:R$3XU/nq\t&@%=sTI,msQ2Mf^%\GWpP/j@n3D-s^5oc(mrSAb&G&L&BT=dYCE#Vq_QYUUe6jcZ$6B19)X,[Qi1;#,j#]J`ORgT,?3X574#L1Dt?b9(rF&lW$:e?3TSlgjiinY@o_UQT+P`i52V+mEHk#ZY3^mFQd\^Jr&fBP-OghaXBHA,o7k$<s8>VV_l]e\9/WCW@R(9o-gBbZW(F?VHX0k&p@KW>`c`Wj/X&bt]ss\JlHlZpU/U'/!7n'9I27$->/\ghao.^=Xec-o=eW.Fl85Z2Oe_p[uZ#_<5mUj:@E@F?KGQA=Pl!5+,B.h;X%$Y)`iT3&K0_hA3ZZ3M51hbSC<5IKdICd46_fnd&CIYId`/6ETT2B9<ab':FD!+Y+a\Vo,2HL:^B:cA6FMbU-eb#YF1T(4dp_cT%C^-)t5Z^aOW\,^>LV[d<f+Hjml#BkEN2[M]I:4ijYITWVQO&;^s][Mr%l_gK2ES-2/6cC\&b'4S4Rgbn2Km`)tGPg/1:\?5A:YOCp1bS,S9BY04/G@O#`P$u-uq<6`.gtN(g!QlhLe=T,Q_D"781n&811O$R9dCfBXgLU)`05hb&5mbPB)<'9"R[OsXPY1BfVheVO5XoTp!]!LnkGd,f/iJOZ_<>TX1e6j)[ec"]#=l-+=5;D+6ou6Y9G-68O!5(?"4@m'k))rpEX0uOGLX"]/6coqIH(.1Y5TS^PNVre/r`P`6T?hOI/"Gdn:RZF^fDVUL]jA6_;7()4+qF7_nu'*2F4GqI#PmII9YNlQlHBeNBI)iBZs3hEf+ZTE_Q$H)!+M^-9MrV1&1iq;_*Z@@"NAqO!lB$!F#8nB.4B<2upM<Na'3u(o:$j.4q@P>/&To2dV`HTmGO\c,3AQcb4r#>r1NX&9n$o^e0f"F+='t17Ycqbdf9*p+qoU!0)=<V,ODeE]4G4RTb[="bSP)::gSU/q:G)lsP,>"j*\pEBp+<Qb<)0pX-YO~>endstream
+endobj
+17 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1846
+>>
+stream
+Gat%e95iQE&:j6J'tPsC0!M/HVL%!A2ar64-lTRm?;t-#e]Lc4akQOH0.#B$0X^6b"@sNLhi.B!O!,g42#N1"pL]a;2sZ.SMF>NrrK%<0FL$@br4@D4[`d#Q[ThnWG&[p64]C'LRi!ZC1g,(H/p[9_/m1(3'lEqP,ThoAVX9Sn0/pq;^E1NYYLp=eWB\.DQ)q_HlT_:`,0@i8l/cGZ0J/e5PMJ1pG#Q%Kp*Dr"i+I'ncQmLuAC-HNHH^J8<^e"joR:?toBQ/Kn,'aNG"(52k:,d4;r7;:\nUb^o<h\.N)qQ/mb%j"f:0Kjl351>iP"*k(j]E;;3Dji>'T1O.[+/tKjmM%27HT-rTUrbK>EN"9*/$.;@5L_m+P2/C3EBI4\4PtEq@!.5F'1uIUD4*gZGam]'^n`=l91j-5sn3RTgS_=D!rrj8#AEh)7[/i78._VG&S9POp7P[t,3,b0i^t2@mooVcUu3T[(D%)j6s"Y.j%8O&-Z^es>XfrL"WpXHHi3^cK["<JM/8;D,,aQn1]Xc/Ru??a_r/`;"s><U+i(Oq/eZ+p:57>/cI<'Ul81>uq;7UU`'G?DT<JZU2a]'H5/Z]3p`(^6[=Cn@Die?`F/P&O[@oMd\5MQ[1D+KV[RIk__/4H8=`;T\uU>9JD6`#=t:FPm&iVkN2@r;_WsbL+lb?EgYuT`V&=FidrSq7"lo2Pa!_@=e7GBnW)MnqnB'*.Vt59oln*_hga=ErLpX:8;,q:<s4AAP[%N@-]8P3=bJ'F@VV8;g\,3:Di2,>bKW?8Tadb.`Z>obTgrO"c4CI/RN5u]DTY9W,CakB8WlI&a&`K,&<9,2_^IFfiGYYUm(CO*8Rb)N,Xs%RU(^3LJ%#9E-'n54pkdB&UNu:tZSs'KGNd^!JM_)&Ue*@'OQkG]01]=7]=usP%CTK3g+i#':n\BZ#&=aTR(@LI#=6S*2;<a/c(8rL8U7a@$24@4S#:,pURkenR_!F,W[]^CN[VF"Rc"a?Qjuh#+\3Q'e<I:,)%(5c[.I'"O,Mo[IuHT'39(lB*rolVO<(b>`2X&.P!&fnjJCfkVs\B+GJP>;*5W\_)**V.,\\5b&5tX7-E/FAQ-tF4AX4oJK=?,/mG$W+Zct"RZmZi)/54J9&i8oNdNXcPr'_l*R`tm_QAWH3ZDb3;33H\6h'a==)^I08oqW%K1i8>MBetoDYEfs;iUZHt;q9r5N%u6n)4h:#n.KfDNDS`H)-4<[GPQJE8V:P59?UaDYQf/!&>:pratW)(;Ls$sj05un;)Ct72J[pjBnes92Uij@P9rDUeh%V]GFPHn*H]>*Df3?MKY`H@NU'l=/OGb$kX?V.RuKt-`=tFT\7kD2(kW@6BGP#qg7egD9T:hgKHP+W6B^D+GTFl%rH0gFn[nXk)."Jf_/O9sn%HVDa[;(Dll[[rP/LPJ73:N'^8tgBl_W>'+RECjogOd="s]98>!u7<\HjGi1ig`AS4T+WS\?N?I9SUHg&JphK/&)=JoE(UZ`(nUP<Oec$K6f:ku3InPMB&1G?7#rqr;:.gU+T_IuHZ1QFL!aXL)5m:Z*e`?9-;')LmjE#o')'QK_:iG7]##<m^PJ9[\oJ7,"oknHMkM73'Pl,Y@.(:f%P1<8bIE=+0lnYP&-EIZ$Bn^t;7u2(8)<oDB#[_K.`=RpIdu<?VJW>LXo0E[6..m$F\p9.SnTHs8Mpk4,]+hR(Q,$"5EC836Z=,c++n5gl);OX+r*kTVeJQ_s,)@[FR]O+/Q:Ti#'s&'qqq9@IhM(SS`Vn"Dfa,;:;r-_!\87+.Y.Gp^12/<K>pRn]9Rf\;T<)Q?Pi8BRlh5h_th81mM-?Mk=R-#2H~>endstream
+endobj
+18 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1920
+>>
+stream
+Gat%e968iG&:j6F'teW8ktLUO#kjS:9q.QHdts?]EhOd]Ak\C@8NFo-01]7,64X\jT!9SFhh(d5>V&.30`T%Ghs8<.H+-E0H_,2=XR6_(Le:\iP<W*OL?$,m)3,YFVrR\$KWmioUJ.Bk-UMJF,EKt40-?@XqUmb%eg6sE;r)Q;f@T>T,JW%L<F1i,D-_R<o-RUg93/ffU[]TK#%R7W.8CRQjY5=]]kc3epLI@P_[uIa=N;YC\<2Hr_(mm,oY)_Z)!:=5B`t^3q"$FMhRQ-XFmXHHV34BMD+M?UnnNUA/hl!OP0*@[`-0\B/*cC$@l"'eCIJMW/?3*>$=#Ht,ZRM`O,;t]BI2b^XA!LAhj*R<B#Mn"A>pZ6RpjCH=o5DbnYr[;.J1dgqPA>ZgZQ5m)t9#4m>iR>0W_+=cS''*p<.GFSZ5/2UMn4F.Qtfi,O?U68V\RdClo^nWJhGB%t<Bk^P2R!Wjga270j91V)2I?MpYWlAsE$+ONimmAH@Tb(6CLeLU01BbU;&NlggcdYOZ9=,7R-&Ree\b?b7RA_AYh-U!!)-Sj>k`ON`FfNR\5)S2P5?9J9Rbl!LT@g:6ibGdkh6j)PVtNOb-B*WT\jF]8T*6OgmP!-."/k!@!?S,;ROgUXb6%8Iq&b6@Q[F1f1r<qSmVPB>J",]Nl/M)-O_nWthX_<S2U^AK.@k0D'_jQ2IS9#SpV!Q\q-.4WA)9J0_:Tod//@[]hP#9On*eT8)C(kP\H81$mISG).Q$VmS'jCh0>iK].pg+Mi4`nS)mg9/PiY0+Co?+]GS#c=S]G8?8WB4u7+L*e9\.48"sfUu68qpEf,p\_#I\?#S_Lmf&H&r__0Z^?s\/7#E%UG<*q7X9JNVIl\*9[4c<F/G3M=aK)o@pX"rIbfR:#")O.&]u5Q;AOkt0On^,LIi<cEPc6YU_*5ff\^gQg_K.f?bISX_/Q?u+s9b2Yi'%$OuR6o\%u=A8@tklottY'+G>;:>jXV)=CVo%QoRWEJ5\i.ZuNYWLU4tt)7,R"kZZg>76&.!N.Yr[!`m][c(cirlCj.+eO`3nJfr4&Y_IrbRi8L-\pe>WY'"ZTMWO(W^ni\/#Yb?C;_%W=e**4c4a7<)</2BR3)M$o,aW.3mCN0ZGPef/OtIRSGmag--EGMOA.+P[>?VSHV*;;0Q$7+M2a?19V-a^$FC7D55/m@JP0MeuP;7sJ]ks;Q^8rjg(\`\3@h?QrPF@;,Ro<hKm^CtPCDWZO`^$pD!JtMk!t^f(fHDVBg_+&DoMjA=U>>8p?e=29ZHbD3M6I3%=oW?>rVhh6cj!A-B*mEjNEShg,mL;E<++3A(8m1D%Jo\]ibqL-bP3jJcW?M\3l2h(V4fAb4#%i]Vdd1QRC#6qV2\^@aYT,+ls(d"_)U6FqJV/;@Uf$D+e*6(OS!\B`&NCFe5Yu::/F>c!D/e8P7jQ'5;i.q?Poo&Y)FcA5nKXTQ]dbsWFl7#%[GD<1RU8'JfLe\"XMBYAjlEP*aKN9<Y9Kt`eL'IWmi,1nYI99:2[;sj@2c$=%uWF<E'q3,GKYu^uZ$:a\Ko#lsRZO%[NXOE8SnI2K`.uroRt[gWcVQAra,!"'B^p.OrRTA@6'*-'D.^oB,6DU68C0GOTor`gpX+'I>:$]dsu^fMu(WMY2Vfg'Ct<7+@P!-ju2Y=Kq"VUk4sT0`MZoC^G,18_1AS9VpaidT'VbC(p862Mf/:T;Z:MhPm]=bF/K7)/=qMC2S>[QjQA-l&`uSLq3Ne'P5H@<dA<Dnbr3f`$nsg.IWo)6s'g@AcD=)?a8,9PJU1#^e.At^e,BIc3[@?Qu(Zo7T^$pgli.>\@%t7IBdsf='OQ'[-dV!g%9,JbS)`KMedh4fh8cm4Oj^F?\`m[[puCn-t*/Bg\7D@dW<\%oOJ&u(X480rW``Sif4~>endstream
+endobj
+19 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1907
+>>
+stream
+Gat%ebAQ)n'L;Eg$>g+q"j6SG]@r:mTJd@+VWc#=Gp5=B1o"$=8`RQ=.G5>*a3l7B(kt09?Kqq@QR"/=qk:prh7b;_[KXC@"_G[H^7YOa@XD+fhnBu"1\YF)Y)o'De#*c$+>/mTKiAa@C#);Q`S8-l'^+lXW[f0kihlS'G/rV9mI'5\DtipuCs\N_4l!bu=)>VcgL$jp['2nQZCFTb,cKimZ;#]2G1H'#WQ*75n5")$R2@IgF#o*l6`/&<WT#VXTBD(T_pcqMNodP"=,1;cF%U,+\</,8cFWSNqcphO8AgSO3bd72YWLG'i>"gbpK;!.$shD=.*3WWCMJqHKGFC$:l_@0I"'W\S*07_G_6d2-%SIrPZ/)@qeh2(\Z_jMk?[3)gpBe0Nr>"rWF64\YqpS#<[qX08NY9lZQX';'9;/AJ$5$!h[lRl1S7UMKq,L2&1*]'O:m/dX5kO!=G"'/T#`tca*(g4S+9\UpZ:mE?aec3TIu*M.@/Pm`[E+`eO:lf=Eo%E,.$Pe,,rH/]/'ZN/jf0b4h#doh)H^/FT7+5%-%uE?&P$&1[Bt0of&<*`?8AV3314s33.+1M<i[H7J6VZIAdYf7mR,J0c^IVVMG:1KrDh:;BNoe>5&_me0UADkL._K9a,(!-uL%rBO^7T^FPf%pT3\d5?8fC=;XVC/@?QD$qYuS&>^@F5GXQI(t+VQL_Q6P=4a\%'r$!!(dm`!=mG@/'BRg-o<N)ub2$-TZS7O]M%i&dA!!gDPHU@K"?[B.0ZOrkLqE=<Z#s4K$P=)i9Od]Pfe\/Q&>a\XmM%s5>uF5Y;%g*/Kk-JqDMGpe92!'30a]$/ep`pMEadOe9LU@rf_BUt%TjJk;I[8(EY9+<H(s(>bdg<G042e,QO!8oY>.$;DUJSh$_p#A0h]\9-YL!J/1m3YV+KW:P#c"@euk2"lDfW,$:>(M1/*C4QDkF;b@-.)gm#,oXq>:tXW7=$[/W#6VhaQ=lldZU'ZSZ'^?q@@bWW;7OCWuV$'H$DI,M@7\I-/8=3O[Q1nCqF'imlgNP%r(16fo*L,-SJ&91Dk3\@K=6blkg$GeS8Cts78lHffZ<Rn<s$3?RG,EcKEnH8N_&C$BWr3C3W>#ejXfSl:=a<VM>+BUtRWJ%UnC+@'NMQfZM_W=<der_d@VQM"*G3s\e3dQTKOKmAk8P25M[1mZhCanLe/4kS`iT\R.rOAtR?Ro5S$:AcjKhlVEA2b0qbb>#q'o/.`8MbHUfGR$Zk,I>Q0eLjplMC%C[endcjX5kb0S\NG$X4*]'r&q>JG<6BYO@`$dVkF-b(GMpdmX^T8uIB-)gup)[@[iRXRhf-BZ><k_SK<j"9b@;A1*n\Ol.cRn92BYl5a[k(kl(1oP>u=1+^BeI!3h13*DtF3&4b?Dp#Yp`gI4-.?'tu%UY9p:On$?6oi0UBe6EZ_F-C=opf.<UJImV0[H!3L^B2E<rVaiU,nT_".A2E+P&Dt3'B$i?59`n@f(8YnG5dRZ9j]\b_P:G/aNpY>p5["bO$I?Hh!a'![$o#0nej7_so#9i&sE+*%rnndb3Ph.j>^?6[,u#1XQKQZc+qF4/0+)\nTpZH$S\U57V8rf[lc[(5C8?ZrH'\&9-#1ThJnVV`[6]cq.D3HJNC":PFbK&C$D.h2l7p/\3i7$*W6](`E!n_EmM^"9[!>$'ugW\rrAb[+a6(^3N'^AcMS//NZMJ'a>;(@O7Wn+@*sS=iMj*`ck#u!Q-W[.1pH1kbT^/3V*X3/8<*=[m]G%nf!i_piIU3Oi'B$/7#DP^*4,-[.5auij-k5+u7?,P)*:QdSW!8\uGP73VcmMD8!-YC=FYL7ZEjUnEMM)_)5tN_YKqC+DT,Y)Kf#g3UQQPpR$0N)@"ErB8sH\He'$ehm7nI(2s0WSmKch~>endstream
+endobj
+20 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1672
+>>
+stream
+Gat%e?#SIU'Sc)R.s*S?*AC+`-?n'R$W\AhMV?m(HD<MpU;iKS8Ih&95>&)t6X-g?&0M5m5NfEqPLQ9tZblahnb6X^AKTK+ISDW@ZLqKm"VKGa-Mr5iB"ZFeQ1;F0-=!H58h`WB:dS_k;8T.%0A0oT^O48.RV16<pFc@0Ssm+6^:rG$\FRgK<L6q\]kco:n(qXAn(IR#.?.q_$nErc#tb?NHjj4:qf_"Kc1Y.dN6#Y;:6Sd`'(\-k/&nCNC?sk7a4GCOLuG88?hJ"!G-:8FGtMaF\</,85."n7H#Tr@dVr[+5'^Z8HIGqir<f=$J#tFVL2O"P$E:jI;a[o?=LQB]j[9I$_mO?i3dt+A0PH<S,d>WZP,^7BCH)'Qs&cl19BY#)D0+m"P.pg3aXSi>j@o@-<06+;e+%K32?s+s>QuRf0rGek+?8KjcdC_b3I)7G+FJu/pXCK+MK$^`:8RUA7M<%D.=r;ZmI7iT^477f7AO>e(oe;_bGla#Vs=&kO/goRM>>2?qn).:m@\7:(9C?n-?V;=E(e)fZ4pe"FYoY.(e%=7Y(Il^MOpl.+&D@;Y.Cfl2<g1%l^RTZFneaa1Jj7sFRd$IB`Li;M9-Yk0PEfX#&E"?Yb3f+pAI@i.9K(%&toYq4Qkt3Y`V3e,]U70,Q=:f\ZMoQlg!619fE8LWH#IC2$QW1:9?oo=>1SE,gKL8$24tZ3Ffb78'OM*9$(<Ko>=HM'9keIq;k-XCUP@-fi^_#S.4N&W[)9i77lNOr(EVSqlP1I3oBU<=0ebKC+5'3bZ]a]SA_*GK/cR3k=3-;0&7?qA]EnEW\I&%nVNZI%"]p$@5%mWS1uHT=m0p:fB'd3Z="D*hQfgr"[UZ%67)n:fYjG?CVgsYkqK92]DYcJ*n,PR;CS5[&-b^j0Pk8RL5cV]R.#7`bVD*C.fV&8hsM"l=h6Lf:ZiX)%=fj@J4l<P_&5!^-nG4"0(_h%2E8<%rMlKm$eE0HqN+)O_aXi?fZ6W%1Q!l%B:?,e?+5%DQRA-$/?2-A:5=+(IIjf3/40%)^bGUOF)k4qEN"^3OZ6ppHBQQqAN0&1D:<XD3eOTsShg(m/ES[D#(nU#ie0lmR,KhofhJe%HV@o]PsVVO&W)p@kf@-?)]=TS8XPf"Xk6uT?en^aCTq'dhBc9VjRP5AP;@#_E#&[fS5DY@dPK/#Vm7muY'9,gIoHe'%$IPtL5cVaY`V4S!PX2IQ*jW@<djfc.4U&*O[g[/7ude+0hA$t;'S1`o<^WM=sWEcFf<CGniAo/Jga))5'$2t;4K88#npdF+oC&2di44D%'Hjk:s==*B*MYobi$Z__jJ4+3F>L1<UMsC^+QlJ?.GdpK/K(=R6>p(UCuWRPj4bJ%fAQYZ9:aUlo'GX8E/]M:Adk&VCu0L^'qE<7AVCqI/&.'Uc="*)EV(R;oTd;:i/Ziif$al"1)I60jF>4UO-[_[tofO<"8L+Le-$aL'<2d8>;n_hZd";e!^`D\,-[4jWZ72g1EY_Z`mj?-Y:rGadDU8E$=ktWch4)lmaK<3[fhUN%K/4U^J2'q,3APX3Aep>Z[CbQel:AKri?IU<SKrl*o`kjRQNjjZRlW%d+#=[m!BA=PR&9+k2mi??S:@:Hp4XAXLUXk%k@0p<[4sEM6m0c:K-L4_YM+99=SP=SCm,Z[qds~>endstream
+endobj
+21 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1530
+>>
+stream
+Gat%e95iQS&:j6F'mhBk'^.`k&,)A5!Eu9a&M(=q=D8f)OXPdVde)F@8Qjgl@uE,s+:AR+1ZYH^%Mb2l:Q;"$"(Q7.9RKZ1BstQbWo+'8Ht;\)YJtaV>/ka+6Z,t$+`uY>E.qfQ.B[NU/ig/fTDr<fNo+>NI?!Sl4<<1JI<iMSCAI82DQ5jLm#K>W2fI@2O_oQ<Z7/h7alMi"L#RgWAk[Al4La)?4$2'RRR0-#CRIcS1?kT%QGo6U6bSQP0\>WMdla#Zolki7a$X\>mWki%L7;SgS9ipjc1W<p^t<%>C&Hu1cHWf$O3J&k/(:mLkW/:?DIuHYnC/q,?V&EO/1ADQ@8(RnZb,OA'aB::GII]IT2I-tVX3$=k[OG&hSr;iVjbA2-MrI@+c=d1Pa#GPZKsV:4,'IEEg<0=;SfH$8kt\0;K=Q=J'QKSI@^5]\uSsFAV:t<Q("'*Z=^$K+bAJo>g55[9]DT&IU1J4UoCr^o2Sd4]3ZJgJ&Oe*m.R^O&>ihD/R6G9;@C>T"P!dX>L,BVJt*N9EMsqdi$b%qj2N`'Fg40'2X)1#&I;dG0]CHJ'LEETX\co0>Kjm8SC0aW"9tAC5gh3O14`?J2%:Y"qg(J/qQZn(7Ml?ccmM.`$PAsQ>)EqU6d7kTK#gdo6(04(H$X(n76RH3X\0&hreMJ4OB4d-kOBE]RE*EWejLgj->C"^bN2XNjW?f&jMNqf@l6Q8UkoFj9iQ/]AA\,dAki;rL:-I)5HHr8_3hTn,;OOe6j>#/A267;MAm5a_U5gGa(AD\#Z!,SbnHA44Air]M+VAU[Rd4d$W$M2YPqVRUbfde[<\3pU"Q0'P:\8OD,JDkbBRp3%LZK`Z\q$ZOs!J_6mX3P<%pt>P$*rCRo?_bSXO%qhq-Ut3+sI7JJ^4B6uWc-jK^-WQo3!-bL3GFVc37G*P.B!?jN2J.QMdKJlreQS4r2*\1UGQPGtuO`#a&3R=ucO,*Q),A8j:m-F5.&-;p7cWHKg:@5L9AVMRo?R]'WF6m]/dX18^P3CS)flHeKT#YP`,=e_(C,q>96;9<Xr=K]>CDP>>rDT"i0-Ab>iP,McS6m]/b'tAF9Z%%X*(SBtfO/o!_"?E(@E15o/5nb!WR]'cJ,XHj*cu^<9"QET3=Ao@eZ4KWgAV+m]d%3*\eceqITfOQ><+71MOORV#Ti+^U)e9]f;3E=BMF?``Vr;<u3IZmB4TPsFP^tZ?i'C>#FmpjfEgTf"U^;W09?qTa'Pa=U=7m0YV.L<u&nZCDdUB/h1K4OOoqc78ejVmQ$;3&V8X_+Z\PA4!:j&_K:Y8sh/4=Gkq"[R"Ys?B^XOY/uZFmnKi1"7C;AGOE4B<8/BtB8^l-s2Y\k]M)`k(+T&],?CTu5?tiOD8=JuGuAH>&ag&:FqLQuZl+"\G.6Pr>XGg4cWOG4Y1Tf#Je#(Q>*DANZeAJsb>+W#_e-'\0A0JfNpd=I'+^P,pG+<g@h9='Zeme[d&_HRV'c6T%5r#kG9GY4j@N.X?:UJb0)m(H&I!rr]h7d&-~>endstream
+endobj
+22 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 280
+>>
+stream
+Gasc>Z"a@q$jPWQ:SFVHFH@eQ-efXDbnTA<O'.M'8lG's8=Vel*E--.Te-<T5Nn<L5de,p@0Tg]0H15)OPYKk"k"0Xe"Yq>Qs9"*IcpW#fRQ^r'KTg4>mug,=MA%\;a4!<NhrAn.nK,j*l#Y)M444?-]Gq!2=IsFAXpeGc;1+(F!e,9fI[3!IFt[i(]:(FI>O[TC45C=YTGA@jLe>/[6c@as+&0lLp]O<9-277R&e/Ve6(>Y,d6G3Q6[*Sk^8T&LO?^h%+TVM6FmD0nGsP*@.O~>endstream
+endobj
+xref
+0 23
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000526 00000 n 
+0000000731 00000 n 
+0000000936 00000 n 
+0000001141 00000 n 
+0000001346 00000 n 
+0000001551 00000 n 
+0000001757 00000 n 
+0000001963 00000 n 
+0000002033 00000 n 
+0000002295 00000 n 
+0000002399 00000 n 
+0000004590 00000 n 
+0000006834 00000 n 
+0000008772 00000 n 
+0000010784 00000 n 
+0000012783 00000 n 
+0000014547 00000 n 
+0000016169 00000 n 
+trailer
+<<
+/ID 
+[<311a11d8c2a3873a5161f39cf2759247><311a11d8c2a3873a5161f39cf2759247>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 13 0 R
+/Root 12 0 R
+/Size 23
+>>
+startxref
+16540
+%%EOF

--- a/ui/scripts/generate_coverage_pdf.py
+++ b/ui/scripts/generate_coverage_pdf.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Generate a PDF coverage report from Istanbul coverage-final.json."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from reportlab.lib.pagesizes import A4, landscape
+from reportlab.lib.units import mm
+from reportlab.pdfgen import canvas
+
+
+def pct(covered: int, total: int) -> float:
+    return (covered / total * 100.0) if total else 100.0
+
+
+def get_counts(items: dict) -> tuple[int, int]:
+    total = 0
+    covered = 0
+    for hit in items.values():
+        if isinstance(hit, list):
+            total += len(hit)
+            covered += sum(1 for value in hit if value > 0)
+        else:
+            total += 1
+            covered += 1 if hit > 0 else 0
+    return covered, total
+
+
+def relabel_path(path: str) -> str:
+    marker = "TicketingSystem\\ui\\"
+    if marker in path:
+        return path.split(marker, 1)[1].replace("\\", "/")
+    return path.replace("\\", "/")
+
+
+def summarize(coverage_data: dict) -> tuple[list[dict], dict]:
+    rows: list[dict] = []
+    totals = {
+        "statements": [0, 0],
+        "branches": [0, 0],
+        "functions": [0, 0],
+        "lines": [0, 0],
+    }
+
+    for path, payload in sorted(coverage_data.items()):
+        s_cov, s_total = get_counts(payload.get("s", {}))
+        b_cov, b_total = get_counts(payload.get("b", {}))
+        f_cov, f_total = get_counts(payload.get("f", {}))
+        l_cov, l_total = get_counts(payload.get("l", {}))
+
+        totals["statements"][0] += s_cov
+        totals["statements"][1] += s_total
+        totals["branches"][0] += b_cov
+        totals["branches"][1] += b_total
+        totals["functions"][0] += f_cov
+        totals["functions"][1] += f_total
+        totals["lines"][0] += l_cov
+        totals["lines"][1] += l_total
+
+        rows.append(
+            {
+                "file": relabel_path(path),
+                "statements": f"{s_cov}/{s_total} ({pct(s_cov, s_total):.1f}%)",
+                "branches": f"{b_cov}/{b_total} ({pct(b_cov, b_total):.1f}%)",
+                "functions": f"{f_cov}/{f_total} ({pct(f_cov, f_total):.1f}%)",
+                "lines": f"{l_cov}/{l_total} ({pct(l_cov, l_total):.1f}%)",
+            }
+        )
+
+    overall = {
+        name: f"{cov}/{total} ({pct(cov, total):.1f}%)"
+        for name, (cov, total) in totals.items()
+    }
+    return rows, overall
+
+
+def draw_table(pdf: canvas.Canvas, rows: list[dict], overall: dict, input_file: Path):
+    width, height = landscape(A4)
+    left = 10 * mm
+    right = width - 10 * mm
+    y = height - 12 * mm
+    line_height = 6 * mm
+
+    columns = [
+        ("File", 118 * mm),
+        ("Statements", 39 * mm),
+        ("Branches", 39 * mm),
+        ("Functions", 39 * mm),
+        ("Lines", 39 * mm),
+    ]
+
+    def header():
+        nonlocal y
+        pdf.setFont("Helvetica-Bold", 14)
+        pdf.drawString(left, y, "UI Coverage Report (coverage-final.json)")
+        y -= 7 * mm
+
+        pdf.setFont("Helvetica", 9)
+        pdf.drawString(left, y, f"Source: {input_file}")
+        y -= 6 * mm
+
+        pdf.setFont("Helvetica-Bold", 9)
+        x = left
+        for title, col_width in columns:
+            pdf.drawString(x, y, title)
+            x += col_width
+        y -= 2 * mm
+        pdf.line(left, y, right, y)
+        y -= 4 * mm
+
+    header()
+
+    pdf.setFont("Helvetica", 8)
+    for row in rows:
+        if y < 14 * mm:
+            pdf.showPage()
+            y = height - 12 * mm
+            header()
+            pdf.setFont("Helvetica", 8)
+
+        x = left
+        pdf.drawString(x, y, row["file"][:93])
+        x += columns[0][1]
+        pdf.drawString(x, y, row["statements"])
+        x += columns[1][1]
+        pdf.drawString(x, y, row["branches"])
+        x += columns[2][1]
+        pdf.drawString(x, y, row["functions"])
+        x += columns[3][1]
+        pdf.drawString(x, y, row["lines"])
+        y -= line_height
+
+    if y < 30 * mm:
+        pdf.showPage()
+        y = height - 12 * mm
+
+    pdf.setFont("Helvetica-Bold", 11)
+    pdf.drawString(left, y, "Overall Totals")
+    y -= 7 * mm
+    pdf.setFont("Helvetica", 10)
+    pdf.drawString(left, y, f"Statements: {overall['statements']}")
+    y -= 6 * mm
+    pdf.drawString(left, y, f"Branches: {overall['branches']}")
+    y -= 6 * mm
+    pdf.drawString(left, y, f"Functions: {overall['functions']}")
+    y -= 6 * mm
+    pdf.drawString(left, y, f"Lines: {overall['lines']}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate PDF from Istanbul coverage-final.json")
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=Path("ui/coverage/coverage-final.json"),
+        help="Path to coverage-final.json",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("ui/coverage/test-coverage-report.pdf"),
+        help="Output PDF path",
+    )
+    args = parser.parse_args()
+
+    with args.input.open("r", encoding="utf-8") as f:
+        coverage_data = json.load(f)
+
+    rows, overall = summarize(coverage_data)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    pdf = canvas.Canvas(str(args.output), pagesize=landscape(A4))
+    draw_table(pdf, rows, overall, args.input)
+    pdf.save()
+
+    print(f"Generated PDF: {args.output} ({len(rows)} files)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a single human-readable PDF report that consolidates per-file coverage from the existing Istanbul `coverage-final.json` under `ui/coverage`.
- Support mixed hit formats in the Istanbul JSON (scalar hit counts and branch hit arrays) so coverage counts compute correctly.
- Normalize Windows-style paths in coverage keys so filenames are presented cleanly in the report.

### Description
- Added `ui/scripts/generate_coverage_pdf.py`, a CLI script that parses `ui/coverage/coverage-final.json` and renders a paginated PDF with per-file `statements`, `branches`, `functions`, and `lines` coverage plus overall totals.
- Implemented robust counting in `get_counts` to handle both scalar hits and branch hit arrays, and added `relabel_path` to replace Windows path fragments with cleaner relative paths.
- Used `reportlab` to render the PDF and defaulted the output to `ui/coverage/test-coverage-report.pdf` with sensible column widths and pagination.

### Testing
- Installed the PDF library with `python3 -m pip install reportlab` and the install succeeded.
- Ran the generator with `python3 ui/scripts/generate_coverage_pdf.py`, which succeeded and produced `ui/coverage/test-coverage-report.pdf` (file size reported ~17K).
- Programmatically validated `summarize` by importing it and running against `ui/coverage/coverage-final.json`, which returned 193 files and overall metrics: Statements `6533/8147 (80.2%)`, Branches `4037/6296 (64.1%)`, Functions `1806/2356 (76.7%)`, Lines `0/0 (100.0%)`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7a22104c48332b7d7753346545519)