### PR TITLE
Add PDF coverage report generator and include generated report

### DIFF
--- a/ui/coverage/test-coverage-report.pdf
+++ b/ui/coverage/test-coverage-report.pdf
@@ -1,0 +1,226 @@
+%PDF-1.3
+% ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 16 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 17 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 18 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/Contents 19 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/Contents 20 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/Contents 21 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+10 0 obj
+<<
+/Contents 22 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+11 0 obj
+<<
+/Contents 23 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+12 0 obj
+<<
+/Contents 24 0 R /MediaBox [ 0 0 841.8898 595.2756 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+13 0 obj
+<<
+/PageMode /UseNone /Pages 15 0 R /Type /Catalog
+>>
+endobj
+14 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20260316082529+00'00') /Creator (anonymous) /Keywords () /ModDate (D:20260316082529+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+15 0 obj
+<<
+/Count 9 /Kids [ 4 0 R 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R ] /Type /Pages
+>>
+endobj
+16 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2001
+>>
+stream
+Gat=m?#SIU'L:RQ/+bTi*ACCh-Ms)U$T=ZoJCrUT?W<LheCmeIa_gY<G:CWHkr9G='W><hk>F>fn%GMfQGXfms1R)ufnX^)Db3E3[f2F%Nd/#3R/OaJdsk-OPQ#W[o_^]e6VraZQX",h&k%G)YO&U)Iog3JX_lg(p\(S(]'N)GAF":-c$![kOKG,/cL0S$l`]"<f4c@jR=:\(ni3-^:)*$7=k/:>A)CpS&o[(([OE9ao]EV9AQA*Df=%hW7tOsfqk<5MJLH>q%3Gd8m.Ws?r')hPrgtr;qag%a.sBT_\[1]#N#3=bI)0hJ;(fo$m0_3PWt%ZL(rMe]Q$mtZ+oF!chCV1E"DL$u5TcGhg,ur>i&O_<;Bm?HjG62,OpWW^73Cae:i3eLY2%:c>[kj/MkhUr&Wm2`K!XG(5*hJGSfHq/P<;A2MZE13M\47&7"U9SVfSla?O-KS8@-e6c^)mU>VX1(clmNGHCb_;+iDgOKcS^7B;C+SV_npWhNA+Cr`t-k.7pto1`=8-TC&r7EQW$/cldU*+>HD`-2Sk?AqR:YSl"&<>k7)gMIP\E!o1f];dl!VUC94\S=9R5N!:9>X<3U1(io?8UR.k690G:(Jf$B0=kTP&4FX5Y6Fp<?jKjML8?PVGcB<R@j(38:jF[Ml7<"RRP=^qqMLd%!P-h4_:Nbb7(;AMiL2$^,\)1WUf^2\nQ4K6bGCMdKX5^!-G4e5@X:#5q'MEXs7NfDr1dGc8WGu(f6l6A)3KVt5be!jL;^sX;3AX<#H^31=2"f>+r_^WooHR"c'd%>Vosun?oMI(l1J=!DEYsnBG4VQQ0g#$T1ku//#6Phuc66/Jc8I*urV1tP6/?A,(NdkJI2$]>B1kE8P<K:".3Fk+N\K^mBdVLMij-ZFn@#BUm<-*(m&P<;Brm:,l%^VfPNAl'S+Kk:=-L-^)1WXkpd?!]Bc`*411u^jLDcN<d19"fVCKDl^_5l!L?cpI70]R'1nj%7Cmmuk)HW.nWZ;$Z?YTH-6rQd#2aar=,/U/e)jnrV%uKlM*';:7;6I-B10kWOE9X,h/h%4c^U`_%hYqkPNF(GrfWHWHD1onO11?QSp_asR0amX;0E@;?TR]^7-mdk>WWe*olZLTkA*!G?V1:_edLL5>kG+PTg$e`M7&:AaQNpcT=7eh;2;@`M1je"#%Pa^E[3*T#Mp^\mV38`u3.WE;fq\a)1#RVpH),Q+r:='"Y[YN=(/^e.1ef-Ghh^Gg%HI5p/jA`?N'ffZeJ^7"cNbN!J:3eMQUA/r<k,eM@WL\=8n-5H?^4.+6_@):874*efM]cb:MG:empd(.0d3=8^1iVm&d-XSh7.b`6pqn!8.EP]H&kUL5+*[W5jQUm38YuV>J<<o=$`Et=`*QP#^o!<Q]F[b"US944#]4]ZK3]#,bsYUA2%E?$u57Ho>KR0dFj;d.;aE5[*TO/5BqA)nB]DJ@pJm#"i^H9SY=+mW:WrSMZ&8ubD9sOO<fUHS=n;Cdo8s.8G?(p^#''5<jk5`M_XFNFU&Im0Gr1O"t2=kbY:RO0-mpH?pH&Uq#WBI+G\6)-YIeClN=6IrG?7mgGUMd#/T(8\;@,+PdXMtDo6'GR=ItG!s:=')Tr_6K:fDl;m_UXCM<Z9Is8>:b"ZD"(^-^4LW<HXp$LFKcpq5&S=>,*jdf[B9!!cL8Apoj!2^&Jj&M]b=FMo-=Js7e`/dLcG^r:;XIn1:O-3AP\5^*gG6&!b6k?]gp"DR`o?eh17O"^o&a/N:>.a`<Cq`V^mcnYoMpN7CjVeLj/Dc2_&YMf_pGetlAUOSN'IM!n)3_gc:%G1jOEl:up.bNe?.%FDmce>:]HErc#mW3dWNfThIP_j['[q;F!L`!XmM>6cD!*aK@6sVQm!V_oN5r"3lMR;PBkpW0PJdlbbq^X)"^kNckG)`eQipmIPL1%ha%SG+%St`<7p:,F3lF.[oA`1O9U:`1kGM-?)`*hXVbfQj0^2@c85.&:OKXPchY[W.++\>~>endstream
+endobj
+17 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1960
+>>
+stream
+Gat=m>Ar"N'S,*:'mWpg<a%T!`o[_4fSeH`eIHN1KW,?1R=n9iX6&5[Cek_V9bSHhd:kZ!3QX5#p9BAe-2]"Us8B2N?LJ7!NYI-^]=WZ6`/EG?nTOZN?)MY\?'e+,f?$#U<JYY:AK`<b<+pO"Z$?8^D8p$tL9\6Hhn"7fm^g-b2>aRhCt_\(c1bX'`tu__9<nA:8jj$Rns&Hc3'j'6biQD":As%^/5?Z2GQ4)Fra_lB^YLbaI6_.oY'lZD*iX7\kZT/;,"g+.U=8X7pYUJkQJq:s8a7Me]!4F5n!\kH?5>r8392<MCPbZ/IbM%2D5J>)P_(Wk#d9*rcP;-5jhm"Y8;\Odc6(F!^2E\;m4Igj<EN-N+ctc@,Qs8FWe_?Ad(<5g+.KF@&#2aR.2+U;,uKp=8MDDLo1sSX[.\r@>QR^D&s\LZfM=+g3+ij1-N$AH<A357HmD7fL[Uie02oMmLaf$,l<`[0,8<M6<=a!6?JR@]2:S6r1kqNs!,09J"tNT7i`IUL(->e`'K>b4X/nUHjI/?.Oe@t].>N?_KBi66CTS:u;1J%0,Q?0A\#)[UnGeg00GYs2+n5;BK%Q:[0cLU"`\HYb[&Oj_&fm,T]Ad-Ia]WcmY1;NAB-fuuk\A)ie`l+fg&#,Sb_6X%9]9=/mUXlaF5,"p=c5SOO`6VPRrFMppBr6D/(/=(>P#*pWO+&j@@5\fd1kh^AMM=^]Q0:72P!8^_lc<pMR3Z5P9q"W-.CVsP"RA6C"9K5gR6lOXE7r(XkY+^])#_<B6PMek>";>TOC07g>2YBoTuF<V.^730nm0gVA/"refp>fAh-XHQ'HaF(6X>Y6N)S+0Y9beSi:g&Z/G$?Y8cB]%J\1^(qZR-DsFSFmV95Fq7icY%!,8/-#@W)rD1:&&YVU>Zmo-@Lrj6s_T3NO.9fA)gC2IlS"p+kA/dG)Q[bA<HJ5VsRK^U]>[Z/-C9^YXZc*KP*)l)Ld-^Ka,)Ps`-Ob[+Vr$*9Luqin\+,@H%?";9p[MXOQZW\J!o)A((M&oK<g=\>8gY#9&;=;"gip_H>@j&+oYXn0'kE,4WMGWk]i\A#IpR]HjHV$K$pC*oOgq\bXKBNXX/bS67V(5!2Hc!k4H%QrEZl6'^qesSTtW9FCl+4WB/%HX(e(V2<d&SbC1YAO7>@a;*eeIdp@K2ap*1,t:/:<rU3Rfj7N>lRGk;4Jf4O4V-bIalRU_)s0F*="ReUSP`Fae/ZP/eSnO0/ngFd3.1/15OSkV\*//R'[7lJZu*U+K[i-++(X3K?Y_Q5I[2:flt@g"7dVCaY;R-0P:"T.H&[dfu-D!ma?mIp+uDm.FEOQ%r&cDb0UPtkIo,1JNDg@&8,[`"8$g+:Je6SqF\dEih2Z.ML^Wm\7LgRG>dqsH-`W/C^4NOe@:8BN?@;:rG4;-^6*ZhN`/;Yrar&(e877:_uM'c_Qa1hZYp1CUGarZ8ZEm;4XcG.2Tdm6u"N2h!LIp2;-dr'h[HgC;!c0-p/eal#""`S^T>f,Knt0FUXN_F/1SP=lb,1$j'*V=,'2/;C5XIGp[EKPb+Mk%Wo'1mDOU:L)I1,ZeFlRT+_^8ZfpmXo+!>/7B<Q5_2?n.>DB)6WPCCPA`Dh0#'FehL'2N\%QM7kI2.p@1m8K10fQEb35@#L1&SP:.46T,j2dGE-Y_JKCN4VIK`J2[?pP?RbhCD0$>pN($@`b9Nkjk2![sm,4fEfON^U:%pGu*M_121:&B(brJ\lI""@Z`nJgbhWA9':Ksb3bWg'AB:9/c?YLX1O-CYU9A[BfMQK;^e?CQF?Af-"VA)/DQ4AfL2)Nlh^A!ZnrY,%@2,-qV3,-r!#'>ma%p504^Ta4S_lS*"L]a,@%I=cmfp47&dVG+sm]+E3`/kR6EIBgBNY3XR&0+(Df/@JaWSTD["/2:u>qgM&;%*%PTWK;g_h&Rd*C1X;'Im4[B:Pp]pr;c(BSt>~>endstream
+endobj
+18 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1886
+>>
+stream
+Gat=m>Ar7S'S,*</+bTi*AI"YOaV$#FVf/8:qM)>MrH.a3a:kpH#<QZ8BI/-'3R@9!lU,Ymu[Hh805o)U$d^/^\>bo\_/:i*D75FG4u<,WD%L(PFm%PqWlpBl*'F&9\7rX"?3<A>3\LiQ?$Qm7uk^7O&ajZ];"\U&&m/3l&tqT8Ts4pn"M>5LLg;7G/`uOZMTgOIN0;9M='&kbO%id8sY=JSS`dip;Q@Y<0D\.DpdVV`VASnqm+?Tl'Ji]T!m^77/NkV;FB5rTN2O3SW:b'H2O:?G5p_lo01U*md`a9XumEcl\&CQL4%!5X&H%EU[<*"Xf+9NC*a!;9P2DEQc=aZiR=j88;<t\S8ZbKP?7Y-^'g*]N+d+:$`%@V&:nqhAk]6hd(<5an&i64K/$==/sME]kqkaq;Bf+=%&8/V<k^e_:rb@a;u/%q^N17N;Wq'd2;C6rHG1KhQD?u4rVU2OSs#L4Ki'1m/je_=AOL9%p7u17Fn:R#0)pmh+k0]t5Qs[FXD#kA@q+(nm!.oZCbI5Q]Kr%P-%X:;MJ'M=Z>K;Q;B<O'Q'Xg$jCMO(F.$i?qgHl#pSYnNopqRg?2K%E22l>X@m5BJ@U;cp8N.nT;%Ah38b1)Na9eL%9A)=NLYu'651`;MWgM&^oF3HlM_6Xn/Oge?b:"To9%PS_/POp@++uH8=RTSN<3.U'-s)*!<QFZ0,:#T48ttXY,FOs`\38off=1`jP99Lr6gj-bXskG6M?`#o#]2?6\/nUSn(+El@'r2U!q#.)Wl>&#N/7H;A=-U1co@$=Ul#MkXO4`Z>.._m4RVdp6\04_j)R`p?(4r[6ARB[GYi3"SOS6n<;d`>XC2_IaZ+jSB5SMtZNArhEGEh^86Oa`h_FD(6t(oDCQ^EO7&Y_dc\UqOO"I$"3_2"bLV8:5U"hpjcCHqMQuP&9IXdX%2mW6a*q"ctg\4Gi`Z^;bm>uc4Q[TM='A+hRlm)VQkWiVK&$g0b=lr7)<ZI]pE*M06[lJ18KQ3D&9W[r%;@$Dsj=3/>KO@9T#_A(r'BhV,1G2`3IOP1U(#C+BPR6@GFPqTdMhV+Oncr#n"j*J5?JgSA;"Wb0Eu9L+qRC=PJ$YlQY.IDWC5Y%=eFhI[/QQ?m^Fs?u9JdNk*X6RqM!aM"[BL'E9SUeq_L%Vmi?U:l%+$u#DM+0GcPD8NV;%+%7:?bV&;-Uo!U3Yc4VZr.'o_]+M4+C-4%RB%P:e(bN-0>o2YBGtN[6W_FYJWP-..-\Wtt!28K^DI,MEQ1ane+0)^RO3+=,tM$LUGG>7&R_gjIBdb[qh_QC>nfnOsE9.l`Z=G^P$46:aR``rR,lOf?j$XCo^B?u^LNnHWP2RLqup+d9'q`03FlF"N452^3r)$3O=#_N\ujQRW8pOH!/ZXK-KS>,Vd\M@b+Y$,SHAWq3RE/raFa(o!DWpgPp&fh_fRL,m]dBUh<iSq0'=f\pY_(mq)J,V(/5>1GF/Jt+WNT</,3B1df3\5,eHr/KL%\ur3W-Em-^iD"I(4l%1&DRbSWH\:g>6r_M6aU(I=ciFtr&X%,LV5q9YRk4XgMn]s+d?OMok&:d)&B=FE\0$j0WC8e"W#_`VDULi_,Ca_>aZ,'meHN[,N'itf(l'egUr0+/(q/>fkU7%+E=sE4-]st3]dOKi*%$IW<B1:0jqp0PK4(3+84H1W3Ybe0eJ2efP<8CXh'Ulo0%U^'JtS6%%g!MFr*J^n@+=5OJ;gesNeAUOoNKDND<e<Kos\[`Z`1".W=K6`KBOF;jr?6>$qSTm/e.t;.KcH8*$)WL\foDNHVi[Hn[n^Yn-9&"@e':;aINJrC`ViB?3&!tK4*K$8LbJ8Q_\kQ;0a"cJXMYL[n;a@ahn+sPYT\/8uO)#(]ONPk_JO~>endstream
+endobj
+19 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1742
+>>
+stream
+Gat=m>Ar7S'S,*</,1lm*ACC(LnaaSA4m`3"cC7?;dWLZajeCpVb>V=qbaXD*VpuM$isg?p3.p63[,)K:*TGQL]?ZL+VuZGXuPBlX<%[L<0>^Do&o;oE*g%1_g+u$FIqqg#XbH:8s<@u.cSs+AOG>3Q$H#'[V<jCh,\Yk*ika2o(B>+oC@an^,E+LHm#I3AG,9@&1?_h:,Ljgi`,G9%di%P?+mZg8XHc+oj[7Rac6V@4m$<VclYt^*k(.@'Fdcn\V>bN&Z'6o:q,+gp$;XjAG<Wr=q$No<LX`a.PGW0Oml?H+cf`jC)Z>bDqiKMZXrGn*D=K_<se]rhRN'iI/C,^a`)"=rWZZX=h4OD^B>:nKP?Q`(J$(!!s7_?-="SYTW>5#[s;!ISM?7=6H4GL7+3D(;ClO`jK<^!o<Q-&Ldd?e;+.1S!<&Gr&[%q,Z&En9Y#g&J3nu<\7NR#.Z@&*=M58S<`i%[HSn;FVBe#=!$[YfrRaJ+X5@]?W%@-uj_Ho;S>'$tmL@<*Ak6c8,QEmAHQr6'pOJaoNM&r+%lEtu;2VY7uV6IRIG*V/X=5,CYK6tDfk3%n6(el](pAQ*`L889nOW6eWO>FTV::;<+Q]/u5,!f_1-Kh2d[WlJ%bOY5?rX@0Yj5I@2dP)?;%>$QVO@3f(=6rIqc>"lrh6s8fLB(mlX<_ClhZG+%>'B&%DFf`8IR"T'_q:G8O5pT\_b_8t1ceh3:n0C[BH5.dN3uHiZus)hA`!k7iXJ@M=;%3?*f5//4V3ln*f6'r]@nENUZ#p$fB]HLkh<Hpfk&dBeRgiSiXc=WY"-Z@ROgd+1EC?FJg"XBA.ataMfKnKdGhj__8fWI72R"%k]p^]dVssQ`+:,<E=R9Ra@OT9CtNn+=S50-g0hR()"C<eirEj+6tIDB"dAnP2coWGdNF@0k.[]*Tk:-LakYUE%b1b.ij'#V+h\`+5nKB"fHs+._R2NHb_c4#k>e(^YCYuOQontC%[Z@b&`_jH4B)f)(T>Y)EV`pLX&tuEm&nNKfC!:1X/b"bmm@N#YfI-g@te-1oi&;'.`u=R?E9Iko15B:Pu?^QbR3-l/A_$fba;hE&!D5eG$Gon>j$APc5\*Lk+jM6<HPCfqpH3rI\.@GrE<8u[;D@jX:AQEGek\=ZBo55eH$.'apf$_d+N=k/6dd<^e?UWKHO#6GK%(VkK:N.lliQ5e^IH*5LicC%5A)4L<Q*M3(RNDAIl]gI#paQj/J_E`9/V`)nX5WkP`TcgID;@]XZ*ekQRi)cf"$56`"0?g22?l$hVN%29mVs,B3bofW71NGh]@Pm[4O?8+E=IWYLT5A=Wt"`]T=#8^h)-oiTpRA*`#ZZITJ,dp\%q(tK,]"#nf-!V2?1kRMX3-e9M^mZ]6),CZfD]?flZ]9+^6(lX1&'_'1c=5Kc>klsGD1.^Dhab\*RnPdS8K)K-4/2*I8X:Ep7ntPegnM%>lR>Gph##V4b1:pD'Gu"%ROJVEA%?`\fI"0g^Zo.2'>APBto/sYnh21^>L3."T#K`'L*UQ-HA29eD5n[b40@c73NR-@kZ2\pS?co,8H#^B&*&1#)Yq!+9p.1E6O$jjZ;Fa1gbeN^'J(hZaF2-RjVEA/pl(USeFPq_t0UIN)f`<E9YgLeuLG7e8l?Xrj"kiGme.IWN1AQuk+Ge\j_/c:s/-p]VUiQA>Ec7pkZi2u_?<(jkf%Kc&aI:+,bJ(VsW&:PE@Z7"sknfg3P.^Z&$t2J&~>endstream
+endobj
+20 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1839
+>>
+stream
+Gat=m95iQE&:j6J'tPsC0!K_e,(&WcZ^5j?B\ZfFWi[O]D5iWX55tM@-sITnM+eZgMF?tn,X7F/+jDeIs1&)YHcWMERuH4nN/MLnQZ5Gn[X"5<]m8b4$[C[')e/!nr"MJ",*c"PdtSO0*IQq04o\VcIC:T:55S0*CYCtaCYET'D82Bb<SqGu^Uh-A]Z<!<ZH]"?6TfG(*Oagbi^E<AqK?bGA%O="B#fdHS*somgm?J#J)++IYpWniVS6jQL;\I<@]^dS,+);=6c[*<BRftmQf7C")W;oXR_IEe2q>Y/?=r!70][gcc4FS_U[8H9<n9Eq7S?<)=*aN(\V9O&I!TcaP3'X9dgLKX(A7B0k^m8!Va`WJJW(d8,*9o<cAhOKDN=CuYF9bSN+I_NWJ=$T+aHI$/W!MK*8S6,*r<c&".h;<fHS-#k$iuoBo&($I!(),a85n@KNNNqq:Y?!Pfb;7<ni]s$[nPm<Y?eOMiO@Y4jFlLo?USP6J`=VC-678@LUQmRH5g$e$FIGH_.Nd0^+<q'?D3A+ud6XY2-shWr)@":Z%Jqh`&1<c1igR]:[^)i^eYunatRA$4^/fY*+u\%!"hJ*2fTZP+6)nFDWW_SM<DeGPT,/];!#(6:+;+L-o*Y'9lo\8Qc</_T^^PSqUT,8JlOd88]6\rb_MsY1aZ/ieWp:KQGY^9+/fTC!#:D/KiND)+ufMDIMq@0",+O(N"aY*/Z6Rqg?&_J>GBb)$Ui+j8Kdg%"i9:1mACYP2N1Bbl]6f"CF+u(R/9ViNk2].XKqCj9pU/%f:Ya:Ek0p0[5qHKfJsUBUZ+F4a,qfD\[P4?^ru^>XC&7d=bYo;rPn4]e\Hd'.+/G$#:-:Bqfh^,a4:F3qa*a*/etVTaM)s?%nY?RT6?FC^ZG@[btXF(M[[M%9-U,:&>;j[D$Ih#\Q-H0ZAc'imsF7X:1kI[&rqb\p%$fK#@RsD+mM5J4[``2!ocp(jfJ9DP2A.YH&">,h3M.):S&\W;oV\>ff^cWh<Nmg>kn,n#L=gKYD;PeGH,qQ#213*6uFU*X:RK0bN+nC1*Cd_rdojb#FeI@8nX);Uf,59q?;m6&ZP$d0hadAKVEmqiuen42Mq+V4hW@Jr?(9QkZ'Jlda(X%C9d&U]?RgV)DSn`]1ke\:G[9qW)+ANNe/r>XM4@Ud>`k%AQg"2/'=3HgPVYUM8:=1a")O>5Jhj8=QX:a5f&sKY-bNl#]m&_eAJeU!6Z9k9LFVBfQWd8Zk$(*$t5^LK3-\fBi\Xo;-_3^;&Uco6iAR\Oe,\2\o[$H8kN"r#&AM#9`UCh)IJ>QXD0USF*,8ZQ4\d/dFJq?u^>]eSb,do@r/&9/qH5kHptX9OUs(ld&-pX_aSm.u[(irEZ.(gNI44(ep3jTV?#Q>ftdh`uF=s`YXXi*"CGc9:rp`R<;q;qLa]dRTGm*SqFf!#ZDR61F3p$6ee<62oWM4G=C#o_@\b[rCZqPidBhlHT$RdAZ59Ue_2oA\\b/(eB__SU)"nAdqnPQ^FsI"_bO3Tmu+?0>E(V*KC6&hD(-K(+9\e,P^=/MFoB5lU+eIX=NJKa_e>2jB8FcQV_>/8'_OW=#[R2"Bm2qH&E,3s`AJ(\SRu(o)@KtE7Q_d8Z<TfYZ%.NphNq8hXULfF"_a(0g]>OL@_T5rbd\2.5/p\9"(&OHit?_8ln\AD:ck7SjB=l2b6gMUSRQ82M3t&\J0rBi!Q1SLV5n+X2i"]PL"a5P/,\!T2beXT0S]bI9[fmP52o$5PJarOD]LqaX'q)/3&X038RO=@9+F\WoSq\<\+/Mr\Pe'i$!#X^(LNG5JDs1Ro@G![%;*rc#DRNpN;~>endstream
+endobj
+21 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1825
+>>
+stream
+Gat=m95iTD&:j6F'tP)M$Bu7^A8]Z0B[IY&i[oJu7Gc+G'!7D$G166DB.0l.P.%d9,![9lq[LYCjCh)hU4e#4r-u=/MH?:!?Ef%O@WPI%8S#)O=1m?O)t.jX1Z$a%0)+$J"Lgci/TmaD,@!8(af]mfGLmgl9g'JR&,!D\Ijf42IBdLp?gC).h%j(9_kGr#-oPFic*)1UXDhZ2ja'"O&]otKgUZU1qec;;3&Ym5J$8UsD*;8(G11P59>1g_QaR#a.`\F]>!j8tPYOs_*I#,1J+l1>%"IG,o.e[j5?)K>dBrT9Z=$GG+Wmr:Bi=6FBFbhkX1JIq=p[JHPG\-Mgd:dC5/&umaYI>mklJKO=5ESVmt**ETpe%PJ[?[2&P*jMQr[^iMds4Z1k"Nl@nTP,:d1&i`#p6Q6'N)4kh\1fmnZMJi)s3Gnj*9Uj=nHIcpS0t4Z]eCnUA7u+]bDR?S"E:8L'%qb/VrEd)R#8"`_C)*P5DI327M<5APNQNKsX=$V(Y,Zt@:[Yj<WY^=O-%pJ]XhK9#.QJ]n_FN?4Q/p07A&(=YV,eDK0V[nT@&_iJk2_[)9"`iYjKCh82M@O'H%^Y1n9=.8>#fi`9M12'_a<[$mpjJ"Y&f4Nu/>9tYS3Kr*A4)Ct+nk]%dJpb&J=:6?F6e/]Zi>t<hLb_8ao*a7bH/;[l9$7+Zc.^5TB-E`*%/LAXZ`18Q+:?Qjl`+g*X6iuAZRA^C"bTROF^[1oJG^C3mjm@!H%qf*-")`bG`\p>0!TOrrJM7%_H]t+B84qemu0\4Lb_?<7BF[tgce@<8M`rTc)HNCZ_X6NE00E-=M!_j4,g-mJ1R\Y54>G8]X*t4;5'r]rK`&fo;4iP;0T1b78sQTM%Z]tM(!UI?</(Oqq'_)Ug^?Yd4kN$UudcGZWqI3Q:ijYQiXK,M6oL9iR%%_HGGmT6V&[_9SI#CW=XaW@>:c:-5TVM1MO?m9`<N7s0_Ntg\Oo-e/2Cu(oRL`h[Nr74c?G(jJ-@AOqi"HjGZF9$Ge8p*1@p%@TV2;/&JXD?8d'^.3"d/AWr#uXbg"<Xft8fn)4mh.LZ>^*pIaX[?u7s6D:b)?_C:@EdLK#au"E:7;/8Dl%k!0M6+lbYGTQ(-<!>f8uf*Q<Pgb,8X3]H.^;E?biMA.*69n;W%RPqn,"&K%q6N4+j-eB`^rcfMmX7?)JpqcE\&q6?lPM7<0qgX=Uo0nKcu,EdPpV'AkNf2*74576=<K@U`H?V/9Q_E'nTSgR"N'f=(tBOH1t+Ls4[1s-\SNKL(r*eS\Vam:_)5&0idN%\',HK\',^I6H&$NZGA9PU'k#ZF^+=#.We9ca;c9*"UEZ`R;hqF@01K9MTfsWnYUq;ahZ[$\o"mcrEp?!I&@cR0pc;t#1;*e]>;ILK\EhEBiXi"C5.%,>o6@G&FDFQAibZ5PRJ-S3)um<GlBNHDNusfb-fLjU+7M\FGZ.dhftlrDsK@TTk[b)U5smckkTI`A8tNuA<iqXFO'CJW+TBZaX%\^4(@ULH1;WDH+qq1h[b./O8>Rf&nZrgNm42f+cEH6AVtNC;:00WKX7e:e<H"Mg0p"3,;dT0dmP&5e,rqRiH98_lJK4R]c.m6*/d-$W%[hN-[bd85"gf1Y,V,?:U1`-?<TaCh0_7d74cOdc&u\sTpW,ZVq>!RiJ[IZ7Rdu^E7c?u_9cm[iA)[p5[gm2a`Vb(jpf#'L<nJ"[Drtf@3A+7<3&q!6;4JBjd]1^rM5YbYoH,qPnLN\D#+Ko3;j6<]WW'-M#!h#@VpECimW;i7ZElL]Cqe,q+qZTLdRL(1I]ArSRb1MPHKdU563k)fBi~>endstream
+endobj
+22 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1591
+>>
+stream
+Gat=m?#SIU(kqGU.sNkC*AC+`VL#^h$T9+HJk"R6HDA&FWn*Ik8Ih&9hcI*8P-u"n*<H@uUiR%An69?ILHd]qhs:Vo=-Dp-&]RCf8!p*8Ph5!*o$qiQ_j0JtVUf*e7gj46OBQCn1o":jnApX&rm9-s.:#0"p[4aB#'/==UoZN4ge]s(jS#Pph!PV#^QS0.3J`f,b/n#9Oc2nE`0>>tm^nI*9D3M:BcgV^h7NL':Npq[D<]ZdD9e?<9)01??OGcm+tr"#BYW;%h:)BT1>M%Zo?!tJLMBJblE0C0&lsh@nj4i79lk`am8*gAf*n>%8r1\HBun?H(@6PGph%dm12?3]J_kNLZhZ?l60?$pRMQm$[%o7h8/l<2<g1q]^=`p;gPhE&\^%]]UQa*T,WI5=Pn]#-?.[>'Sik1^cgmUg(C"BmV#ZiK;^Kqeksj1Gja\\O<h)DC.5.`t&QDkDA(:nLZ:7t_$Xq<fG!`[>d09/,CO%J"-j>2LX>Ni%RZSVqlj.dK[O&D\/o*t/"k>7,A-GugkUEh+2VA0@W'3;%i:jBm\,3GkA\E/?!Ib.Fl-TI>#!2D$1BB)@eBXDZA)6`>j8sQWj=>eQ3B#6Zb;iS(0T5.Tdg1t:BS^(4lO_9L@6-2\i62VP$VG$WR!n1(GLNsD0Rsfr74(iIR0r4Q.+SZr31];U.]5'CL6K&Fje>l8e>EibjUB]NVUW,'-u'DDKjr<4@OsI>"OB_R:8(SVC^Pk"67/?4V)VE][L!+2Hm_nL2!4dWTDl!%!?Q6_d0^obbU.P3=LZijB1fE[H.8DL0SmZpie.TKd:9k@%eXo#fD!P"#6%s'6eac[*pt:=$U%Y4<_MJXKhBR2KoYfhY`TtI1SDt2!kS@"-(S(MUG@Or'e720-m[6X7XA73&k<<NPD77R>/+$@f6ja4FCLr/T'"g-@\Jr\j"$6/<p5Bo8e`uig!buc@Y;;5N6'(4X3?M)UgR0(,E&?;k+qOO@9tu>S=%8fRIRPSN@1-:BTWu69uEEo[(1k`C].B0Y[>ApAs"<Q2N*fefaJnc_-nQO3*B&a*m]I3-Pfn=C!fU#(+SFQCaKc&Kdfro-Pe1O_up<V?<e,TWr>_J'tWn6asrBN-q*_\A>2SJ:%YBOU2U`V$`KTmr2JCt9BR$nV6mT7(+N1sY`YLo2KC.a$;2[H$i@7"<Q:Y2".T:0DjJU!1,PCjk8#L$g`g1LBV)c.,<[t)]G\B?G$i)8T8kJp6I#Fj&qp`5l&fC!4Ye%jj,B)udJ%uh5!?DtA>'h")&ifR_5Tt5(.uiYC0:)E%V8*Fl;463;W<d0fEUMT@;C&R*o/^p=6MI">2NG.?D/.@<hb9h=K'.='0-e;pa*.f;[o,M7:_*U!$W_(<+7(80l3X5`f?n0+SJkue9<d9>%j7CJFV,Ujn_&qR2Ip01Q)>Ibi!F`N%*7&Z^[tqG&D9`PCMYI!Z!4>h$b;a,==uHa@lWW4C@;a2dP6_ooOW!MQBXpnjnTtQD9-iYt0]q#1\DW05SiB0D(HJKg&1BCjd@rH%f-)/pua(/!T$WKd\G5c[.CMG+64NLhq#LMb&a%#(k.mT0\VqafFk@lNe(~>endstream
+endobj
+23 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1596
+>>
+stream
+Gat=m95iQE&:j6J'tc*E0!M/H'\Q\p1fu<?Qc?T/U/dFGXXk?Qghm&h;R0#Wr8]C13/6F2LAWl=L))/)s5EQb\L-CtMQf0;\0.h"_A-']on@d"]pZ&3Iq??3W/]F)5(p.>.\dF"L/Xe:s2^YAI;%r/XK#\S?`QoQO6!;+af6tC<+F`JPP`s?XOcj]l8r/I*YNJPjuh>i4Gm(VF#iEon$[XI]dMR'Q/0cd0:o66k)ZFO/K4J6kh>&jIS/:`8mG"7]SOe2?)$_4?1b?#F3+@L65hRK>'4?&OLr*'LA-?_\I<c#.VEF,p9PbIYH;P0:Dtf2ZWuVQgKX!]s7Yj9X[naVC\KdO@pcV)b;9?eada7-N"9G5jU$K3:31=F*9_:pQ=JaYdq!9,R#lWOPT-&=7+.65-$Q]m;Rb,"17!3WB,Srh!_dej7C\M8C8lEdDGkn3*<)7#.uun:/YAq?/uc53/uaKMo8L,@3gh'!m%Ec/A"9_eCW-pT/HMMuZh@FYiFGY6hhqrq)KL<U=Z[LCe6E[.*Ru>mF3:10fhh?+l`qG]f<-&W(#,GYi"t#2:_3<4^X,WbU1>*>==0QQcb@!8`B&jQ+j+k5A5e>1V&.N%*0N>*0:(1gF\#ghb#<SRTUNLj<8N&b\#+J!9m6e/ER+>9EN>7m6.@SM):MZA+,iK\15R[h8X(qo?r(fi`n4DkW*['tZ0IOL/YX+pDN5r$>EFGnS)cjR)@Y%0,Yjf5<+jXMPr<N85O2bEqXdrq`:Kg[cj%UV3<X3OPYiAXA^mT*s5<g8GX5QF0,R59NUR*CPV6jqkR3k8qNC^e-bad&>e2R*a=675X)qj5eN'tb$8[-`^9%g,,%KX+e>"kAihZ,"PF4Oup+Tlt1)NLUjpJG]6.RcnG5[uED%)$OP7D"0Z8c@n@k&;[e6&uT'21\s0hc:I'"&R]@'kS5K-fJtcYq*3qUF$/CVB+M&VS>5BfL+/RgQG:.&*\CE+3]7bdA*N:pg:CWdFlE:$f_dIiN%ciEu:V[#[r3%gf+@$o)r=;I3Kmd1ZZYXp)?ohr"f]g"](C<R_V9dA.a^5/pLL:lX5SFFI#J"=$I^Utq<bjca6)"B!G=1iAkip(ebeN9f:S3(4QMEN5i(AEK2XVO*(CDC/;sDQ/4"VNj(TL-Lu25.sHd&9[@5SfC]qd*,nWdXrZ;'\ChV5%BL.^A%g'^rihEP*R-L;4Zp&`,+RL0P\If5neI..\XhdVVSH1RMNQ,2rd;#$PK3@%0fO?12=,Q$boinlXp!K[iJfg*'lP1D01FWK-Moa*F[(RaFN_/USG,.WqN^]'0O)23)<X3Gf#'[':+TKPj_C(DN6hBeP5^\d2(("pO3FW?l5Cc//`84_.X3L7U%XCE_='Q<O\%>Y67FY`_"%15nXrlP-AJ]`:p$58ntuCI]CS#qLUZB'b#\8KdD@%//VZ$al(;Z.eDH[,?LAo\S`'T/OH+(Tuhp91`/o[a^?TBT$4M#WnJ/8Z*)*B_oj5,aqU:,QpQGA'UfH-r,hn%`K@*JIdEG0$0!@)=Rb5Sb6:=:&3OO!1-B-+MMA#'X8=:')$IlTMU5mY#(Zs<1Pd<>]_N)'6IJ=~>endstream
+endobj
+24 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1011
+>>
+stream
+Gat=j9i'e'&4#^^$=?hcQ.G[(gDj?J-P!1'gpg>&5bLhJP-2a<haq!L]9G-Y<N7N-DoR6tN"(I##DV^/RZOS%Y\P@(8F]59;+6?]nuF_h`W_A2j+b/D3:&s;8#7u`&8cq)mI?;r3PVW;NYJ2SaIhs&2][1F)cDpDf?ff5'=iO0]<K!l`="-/O,8D^+V13jUOXhuEl`<+Djk7I,b'rKlbB,r4GE=GO2nP0XQW;]=,32_8UO&TV@j1L_7ePLg8rnak5@NBN;j9"`"8oH]>]Y4Q`JJ>'(@Xcq2&,.:i:HWm1uWP<#q,k9?A/%9CC+HLAuFHE@R+RlJ-90Y*qeeI.!o*\?sHcD_R8M'P7J'Q<Gtg#^!bZQ<dWprF-a*9M!u0ZA.'NOgLofamJA2b,V'EB,l3TSFTGVqOO*#>Y.;jeD%+k<?Ih<D@(IVnG0cZj-6j48uGreI0`!]BIBdGp0_>OlAd[?A,SD8;J<9K!EHdIZsjH*20#i64-$Gam75:0hOpcY8g&AYKf)6?[TTp(r@PBmdtX`r?]!J%N9R>?r2_`A*6%&lHb6iL?4n&RK=@hU:po9FWl4bMeoOG_*.]o]h"*A!>_]+\E3C^W*&Z]6OT[UXg2uGVAU"+Ikup\mY8HcC]f7su?:IWqCE2qoZa>+Sa*i2)87@qU8:!9^NhR.C:R#iuF6O3'/N2F+;87j#L9*?9#_qNslrPiK"ZoG=Y%#a42nu4&1/F1T97Y'kQE#8Hc98Y>iWp0alkbUnXe0#O7_ph,U]'.t>#e72VDD2jA=b9]$^%GmQgOK]2TJf;_AR_+GIJ&>6WVEG_/(dJMMV_a-n?VFhgC]_.q\BpJOPaF"'oi=6"=b]>0l[Q`t3.?4Ua2(FN#YA#%lV7B%0jTHKI"o`FPPkHq[\:%V.Fa@Jp[1=[1-X'h8;2I@m`3k&gA8eO/fAW;<m&Qr>Q6Z=5R^QGD:nO&T.!L9`kB.H)jk2WJ,/ZG7I;*hoRU.Nni]-lI5`K`0=63Vs']gGhF~>endstream
+endobj
+xref
+0 25
+0000000000 65535 f 
+0000000061 00000 n 
+0000000102 00000 n 
+0000000209 00000 n 
+0000000321 00000 n 
+0000000526 00000 n 
+0000000731 00000 n 
+0000000936 00000 n 
+0000001141 00000 n 
+0000001346 00000 n 
+0000001551 00000 n 
+0000001757 00000 n 
+0000001963 00000 n 
+0000002169 00000 n 
+0000002239 00000 n 
+0000002501 00000 n 
+0000002612 00000 n 
+0000004705 00000 n 
+0000006757 00000 n 
+0000008735 00000 n 
+0000010569 00000 n 
+0000012500 00000 n 
+0000014417 00000 n 
+0000016100 00000 n 
+0000017788 00000 n 
+trailer
+<<
+/ID 
+[<260991a2497b890315bdbedf6167c1d7><260991a2497b890315bdbedf6167c1d7>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 14 0 R
+/Root 13 0 R
+/Size 25
+>>
+startxref
+18891
+%%EOF

--- a/ui/scripts/generate_coverage_pdf.py
+++ b/ui/scripts/generate_coverage_pdf.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Generate a PDF coverage report from Istanbul coverage-final.json."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from reportlab.lib.pagesizes import A4, landscape
+from reportlab.lib.units import mm
+from reportlab.pdfgen import canvas
+
+
+def pct(covered: int, total: int) -> float:
+    return (covered / total * 100.0) if total else 100.0
+
+
+def get_counts(items: dict) -> tuple[int, int]:
+    total = 0
+    covered = 0
+    for hit in items.values():
+        if isinstance(hit, list):
+            total += len(hit)
+            covered += sum(1 for value in hit if value > 0)
+        else:
+            total += 1
+            covered += 1 if hit > 0 else 0
+    return covered, total
+
+
+def relabel_path(path: str) -> str:
+    marker = "TicketingSystem\\ui\\"
+    if marker in path:
+        return path.split(marker, 1)[1].replace("\\", "/")
+    return path.replace("\\", "/")
+
+
+def summarize(coverage_data: dict) -> tuple[list[dict], dict]:
+    rows: list[dict] = []
+    totals = {
+        "statements": [0, 0],
+        "branches": [0, 0],
+        "functions": [0, 0],
+        "lines": [0, 0],
+    }
+
+    for path, payload in sorted(coverage_data.items()):
+        s_cov, s_total = get_counts(payload.get("s", {}))
+        b_cov, b_total = get_counts(payload.get("b", {}))
+        f_cov, f_total = get_counts(payload.get("f", {}))
+        l_cov, l_total = get_counts(payload.get("l", {}))
+
+        totals["statements"][0] += s_cov
+        totals["statements"][1] += s_total
+        totals["branches"][0] += b_cov
+        totals["branches"][1] += b_total
+        totals["functions"][0] += f_cov
+        totals["functions"][1] += f_total
+        totals["lines"][0] += l_cov
+        totals["lines"][1] += l_total
+
+        rows.append(
+            {
+                "file": relabel_path(path),
+                "statements": f"{s_cov}/{s_total} ({pct(s_cov, s_total):.1f}%)",
+                "branches": f"{b_cov}/{b_total} ({pct(b_cov, b_total):.1f}%)",
+                "functions": f"{f_cov}/{f_total} ({pct(f_cov, f_total):.1f}%)",
+                "lines": f"{l_cov}/{l_total} ({pct(l_cov, l_total):.1f}%)",
+            }
+        )
+
+    overall = {
+        name: f"{cov}/{total} ({pct(cov, total):.1f}%)"
+        for name, (cov, total) in totals.items()
+    }
+    return rows, overall
+
+
+def draw_table(pdf: canvas.Canvas, rows: list[dict], overall: dict, input_file: Path, file_count: int):
+    width, height = landscape(A4)
+    left = 10 * mm
+    right = width - 10 * mm
+    y = height - 12 * mm
+    line_height = 6 * mm
+
+    columns = [
+        ("File", 118 * mm),
+        ("Statements", 39 * mm),
+        ("Branches", 39 * mm),
+        ("Functions", 39 * mm),
+        ("Lines", 39 * mm),
+    ]
+
+    def header():
+        nonlocal y
+        pdf.setFont("Helvetica-Bold", 14)
+        pdf.drawString(left, y, "Unit Test Report for Ticketing System")
+        y -= 7 * mm
+
+        pdf.setFont("Helvetica", 9)
+        pdf.drawString(left, y, f"Source: {input_file}")
+        y -= 6 * mm
+
+        pdf.setFont("Helvetica-Bold", 10)
+        pdf.drawString(left, y, "Summary")
+        y -= 5 * mm
+
+        pdf.setFont("Helvetica", 9)
+        pdf.drawString(left, y, f"Total Files: {file_count}")
+        y -= 5 * mm
+        pdf.drawString(left, y, f"Statements: {overall['statements']}")
+        y -= 5 * mm
+        pdf.drawString(left, y, f"Branches: {overall['branches']}")
+        y -= 5 * mm
+        pdf.drawString(left, y, f"Functions: {overall['functions']}")
+        y -= 5 * mm
+        pdf.drawString(left, y, f"Lines: {overall['lines']}")
+        y -= 6 * mm
+
+        pdf.setFont("Helvetica-Bold", 9)
+        x = left
+        for title, col_width in columns:
+            pdf.drawString(x, y, title)
+            x += col_width
+        y -= 2 * mm
+        pdf.line(left, y, right, y)
+        y -= 4 * mm
+
+    header()
+
+    pdf.setFont("Helvetica", 8)
+    for row in rows:
+        if y < 14 * mm:
+            pdf.showPage()
+            y = height - 12 * mm
+            header()
+            pdf.setFont("Helvetica", 8)
+
+        x = left
+        pdf.drawString(x, y, row["file"][:93])
+        x += columns[0][1]
+        pdf.drawString(x, y, row["statements"])
+        x += columns[1][1]
+        pdf.drawString(x, y, row["branches"])
+        x += columns[2][1]
+        pdf.drawString(x, y, row["functions"])
+        x += columns[3][1]
+        pdf.drawString(x, y, row["lines"])
+        y -= line_height
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate PDF from Istanbul coverage-final.json")
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=Path("ui/coverage/coverage-final.json"),
+        help="Path to coverage-final.json",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("ui/coverage/test-coverage-report.pdf"),
+        help="Output PDF path",
+    )
+    args = parser.parse_args()
+
+    with args.input.open("r", encoding="utf-8") as f:
+        coverage_data = json.load(f)
+
+    rows, overall = summarize(coverage_data)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    pdf = canvas.Canvas(str(args.output), pagesize=landscape(A4))
+    draw_table(pdf, rows, overall, args.input, len(rows))
+    pdf.save()
+
+    print(f"Generated PDF: {args.output} ({len(rows)} files)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a human-readable PDF summary of Istanbul coverage data for the UI to make coverage review easier.
- Include a generated PDF report in the repository for CI/artifact access and quick inspection.

### Description
- Add `ui/scripts/generate_coverage_pdf.py`, a CLI script that reads an Istanbul `coverage-final.json` and summarizes statements, branches, functions, and lines into a tabular PDF using `reportlab`.
- Implement coverage summarization helpers `get_counts`, `pct`, `relabel_path`, and `summarize`, and a `draw_table` routine that lays out headers, per-file rows, overall totals, and paginates when needed.
- Script accepts `--input` and `--output` arguments with defaults `ui/coverage/coverage-final.json` and `ui/coverage/test-coverage-report.pdf` respectively, and creates the output directory if missing.
- Add the generated report `ui/coverage/test-coverage-report.pdf` to the repo so the produced artifact is available alongside the script.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7a22104c48332b7d7753346545519)