### PR TITLE
Add optional Zone/District/Region columns to All Tickets table (hidden by default)

### DIFF
--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -201,6 +201,8 @@ const areEqualVisibilityMaps = (left: Record<string, boolean>, right: Record<str
     return leftKeys.every((key) => left[key] === right[key]);
 };
 
+const DEFAULT_HIDDEN_COLUMN_KEYS = new Set(['zoneName', 'districtName', 'regionName']);
+
 const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowClick, searchCurrentTicketsPaginatedApi, refreshingTicketId, statusWorkflows, onRecommendEscalation, showSeverityColumn = false, onRcaClick, permissionPathPrefix = 'myTickets', handleFeedback, issueTypeFilterLabel, zoneOptions = [], issueTypeOptions = [], selectedZone = 'All', selectedRegion = 'All', selectedDistrict = 'All', selectedIssueType = 'All', selectedDivision = 'All', selectedCategory = 'All', selectedSubCategory = 'All', selectedAssignee = 'All', statusFilterOptions = [{ label: 'All', value: 'All' }], selectedStatusFilter = 'All', divisionOptions = [{ label: 'All', value: 'All' }] }) => {
     const { t } = useTranslation();
 
@@ -783,6 +785,51 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
                     );
                 }
             },
+            {
+                title: t('Zone'),
+                columnLabel: t('Zone'),
+                key: 'zoneName',
+                width: '12%',
+                ellipsis: true,
+                render: (_: any, record: TicketRow) => {
+                    const zone = record.zoneName || record.zoneCode || '-';
+                    return (
+                        <Tooltip title={zone} placement="top">
+                            <span>{zone}</span>
+                        </Tooltip>
+                    );
+                }
+            },
+            {
+                title: t('District Name'),
+                columnLabel: t('District Name'),
+                key: 'districtName',
+                width: '14%',
+                ellipsis: true,
+                render: (_: any, record: TicketRow) => {
+                    const district = record.districtName || '-';
+                    return (
+                        <Tooltip title={district} placement="top">
+                            <span>{district}</span>
+                        </Tooltip>
+                    );
+                }
+            },
+            {
+                title: t('Region Name'),
+                columnLabel: t('Region Name'),
+                key: 'regionName',
+                width: '14%',
+                ellipsis: true,
+                render: (_: any, record: TicketRow) => {
+                    const region = record.regionName || '-';
+                    return (
+                        <Tooltip title={region} placement="top">
+                            <span>{region}</span>
+                        </Tooltip>
+                    );
+                }
+            },
             showSeverityColumn
             && {
                 title: t('Severity'),
@@ -1019,7 +1066,7 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
                     nextVisibility[key] = previousVisibility[key];
                     return;
                 }
-                nextVisibility[key] = persisted[key] ?? true;
+                nextVisibility[key] = persisted[key] ?? !DEFAULT_HIDDEN_COLUMN_KEYS.has(key);
             });
 
             if (areEqualVisibilityMaps(previousVisibility, nextVisibility)) {
@@ -1047,7 +1094,7 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
     const toggleColumnVisibility = (columnKey: string) => {
         setColumnVisibility((prev) => ({
             ...prev,
-            [columnKey]: !(prev[columnKey] ?? true),
+            [columnKey]: !(prev[columnKey] ?? !DEFAULT_HIDDEN_COLUMN_KEYS.has(columnKey)),
         }));
     };
 


### PR DESCRIPTION
### Motivation
- Provide location context (zone, district, region) in the All Tickets table while keeping the UI uncluttered by keeping these columns hidden by default.

### Description
- Added three optional columns to the tickets column definitions with keys `zoneName`, `districtName`, and `regionName` and renderers that show tooltip-backed values. (file: `ui/src/components/AllTickets/TicketsTable.tsx`)
- Introduced `DEFAULT_HIDDEN_COLUMN_KEYS` to mark the three location columns as hidden by default for first-time users. (file: `ui/src/components/AllTickets/TicketsTable.tsx`)
- Updated column visibility initialization and toggle logic so the new columns are unchecked/hidden by default unless a persisted user setting overrides them, and visibility continues to persist to `sessionStorage`. (file: `ui/src/components/AllTickets/TicketsTable.tsx`)
- The new columns are integrated into the existing `Show Columns` selector and remain user-toggleable and exportable through the existing mechanisms.

### Testing
- Ran the component unit tests with `cd ui && npm test -- --runTestsByPath src/components/AllTickets/__tests__/TicketsTable.test.tsx --watch=false` and the test suite passed (`11 passed`).
- Verified the modified file `ui/src/components/AllTickets/TicketsTable.tsx` compiles and the table show/hide behavior is covered by the existing tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc685aa1e083329779c081d071af23)