### PR TITLE
Add Subject and Description columns to All Tickets table

### DIFF
--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -754,6 +754,38 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
                     ) : '-' as any,
             },
             {
+                title: t('Subject'),
+                columnLabel: t('Subject'),
+                dataIndex: 'subject',
+                key: 'subject',
+                width: '16%',
+                ellipsis: true,
+                render: (value: string) => {
+                    const subject = value || '-';
+                    return (
+                        <Tooltip title={subject} placement="top">
+                            <span>{subject}</span>
+                        </Tooltip>
+                    );
+                }
+            },
+            {
+                title: t('Description'),
+                columnLabel: t('Description'),
+                dataIndex: 'description',
+                key: 'description',
+                width: '18%',
+                ellipsis: true,
+                render: (value: string) => {
+                    const description = value || '-';
+                    return (
+                        <Tooltip title={description} placement="top">
+                            <span>{description}</span>
+                        </Tooltip>
+                    );
+                }
+            },
+            {
                 title: t('Module'),
                 columnLabel: t('Module'),
                 dataIndex: 'category',


### PR DESCRIPTION
### Motivation

- Users need to see ticket `subject` and `description` directly in the All Tickets table and be able to toggle their visibility from the Hide/Show Columns panel.

### Description

- Added `Subject` and `Description` columns to the All Tickets table column definition in `ui/src/components/AllTickets/TicketsTable.tsx` with tooltip renderers and `'-'` fallbacks for empty values. 
- The columns are keyed as `subject` and `description` so they are included in the existing export and column-visibility logic. 
- The Hide/Show Columns UI is driven from the same `columns` array, so both new headers automatically appear in that list without separate configuration. 

### Testing

- Attempted to run the unit test for the component with `cd ui && npm test -- --runTestsByPath src/components/AllTickets/__tests__/TicketsTable.test.tsx --watchAll=false`, but the test run failed in this environment because `react-scripts` was not found.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bcd4331e208332bfa5bf37f9536a6e)