### PR TITLE
Introduce data-driven RBAC: policy model, evaluation engine, APIs and DB migration

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/controller/PolicyController.java
+++ b/api/src/main/java/com/ticketingSystem/api/controller/PolicyController.java
@@ -1,0 +1,50 @@
+package com.ticketingSystem.api.controller;
+
+import com.ticketingSystem.api.dto.PolicyDto;
+import com.ticketingSystem.api.dto.RolePolicyAssignmentRequest;
+import com.ticketingSystem.api.service.PolicyService;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/policies")
+@CrossOrigin(origins = "http://localhost:3000")
+@AllArgsConstructor
+public class PolicyController {
+    private final PolicyService policyService;
+
+    @PostMapping
+    public ResponseEntity<PolicyDto> createPolicy(@RequestBody PolicyDto dto) {
+        return ResponseEntity.ok(policyService.createPolicy(dto));
+    }
+
+    @PutMapping("/{policyId}")
+    public ResponseEntity<PolicyDto> updatePolicy(@PathVariable Integer policyId, @RequestBody PolicyDto dto) {
+        return ResponseEntity.ok(policyService.updatePolicy(policyId, dto));
+    }
+
+    @GetMapping("/{policyId}")
+    public ResponseEntity<PolicyDto> getPolicy(@PathVariable Integer policyId) {
+        return ResponseEntity.ok(policyService.getPolicy(policyId));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<PolicyDto>> getPolicies(@RequestParam(required = false) String resource) {
+        return ResponseEntity.ok(policyService.getPolicies(resource));
+    }
+
+    @PostMapping("/roles/{roleId}")
+    public ResponseEntity<Void> assignPoliciesToRole(@PathVariable Integer roleId,
+                                                     @RequestBody RolePolicyAssignmentRequest request) {
+        policyService.assignPoliciesToRole(roleId, request.getPolicyIds(), request.getPolicyCodes(), request.getUpdatedBy());
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/roles/{roleId}/effective-access")
+    public ResponseEntity<List<PolicyDto>> getRoleEffectiveAccess(@PathVariable Integer roleId) {
+        return ResponseEntity.ok(policyService.getRoleEffectivePolicies(roleId));
+    }
+}

--- a/api/src/main/java/com/ticketingSystem/api/controller/RoleController.java
+++ b/api/src/main/java/com/ticketingSystem/api/controller/RoleController.java
@@ -1,8 +1,11 @@
 package com.ticketingSystem.api.controller;
 
 import com.ticketingSystem.api.dto.RoleDto;
+import com.ticketingSystem.api.dto.RolePolicyAssignmentRequest;
 import com.ticketingSystem.api.dto.RoleLevelDto;
 import com.ticketingSystem.api.dto.RoleSummaryDto;
+import com.ticketingSystem.api.dto.PolicyDto;
+import com.ticketingSystem.api.service.PolicyService;
 import com.ticketingSystem.api.service.RoleService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.AllArgsConstructor;
@@ -18,6 +21,7 @@ import java.util.Collections;
 @AllArgsConstructor
 public class RoleController {
     private final RoleService roleService;
+    private final PolicyService policyService;
 
     @GetMapping
     public ResponseEntity<List<RoleDto>> getAllRoles() {
@@ -69,5 +73,17 @@ public class RoleController {
                                             @RequestParam(required = false, defaultValue = "false") boolean hard) {
         roleService.deleteRoles(ids, hard);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{roleId}/policies")
+    public ResponseEntity<Void> assignPoliciesToRole(@PathVariable Integer roleId,
+                                                     @RequestBody RolePolicyAssignmentRequest request) {
+        policyService.assignPoliciesToRole(roleId, request.getPolicyIds(), request.getPolicyCodes(), request.getUpdatedBy());
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{roleId}/effective-access")
+    public ResponseEntity<List<PolicyDto>> getRoleEffectiveAccess(@PathVariable Integer roleId) {
+        return ResponseEntity.ok(policyService.getRoleEffectivePolicies(roleId));
     }
 }

--- a/api/src/main/java/com/ticketingSystem/api/controller/TicketController.java
+++ b/api/src/main/java/com/ticketingSystem/api/controller/TicketController.java
@@ -88,7 +88,8 @@ public class TicketController {
                         ticketAssigneeUserId,
                         dto.getStatus(),
                         dto.getRecommendedSeverityStatus(),
-                        ticketCreatorUserId
+                        ticketCreatorUserId,
+                        dto.getZoneCode()
                 ),
                 resolvedUser,
                 session);
@@ -118,7 +119,8 @@ public class TicketController {
                         slaTicketAssigneeUserId,
                         sla.getTicket() != null ? sla.getTicket().getTicketStatus() : null,
                         null,
-                        null
+                        null,
+                        sla.getTicket() != null ? sla.getTicket().getZoneCode() : null
                 ),
                 resolvedUser,
                 session);

--- a/api/src/main/java/com/ticketingSystem/api/dto/PolicyDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/PolicyDto.java
@@ -1,0 +1,19 @@
+package com.ticketingSystem.api.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class PolicyDto {
+    private Integer policyId;
+    private String code;
+    private String resource;
+    private String effect;
+    private String description;
+    private Boolean isActive;
+    private String updatedBy;
+    private List<PolicyRuleDto> rules;
+}

--- a/api/src/main/java/com/ticketingSystem/api/dto/PolicyRuleDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/PolicyRuleDto.java
@@ -1,0 +1,15 @@
+package com.ticketingSystem.api.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PolicyRuleDto {
+    private Integer ruleId;
+    private String conditionKey;
+    private String operator;
+    private String conditionValue;
+    private Integer priority;
+    private Boolean isActive;
+}

--- a/api/src/main/java/com/ticketingSystem/api/dto/RolePolicyAssignmentRequest.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/RolePolicyAssignmentRequest.java
@@ -1,0 +1,14 @@
+package com.ticketingSystem.api.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class RolePolicyAssignmentRequest {
+    private List<Integer> policyIds;
+    private List<String> policyCodes;
+    private String updatedBy;
+}

--- a/api/src/main/java/com/ticketingSystem/api/models/AccessPolicy.java
+++ b/api/src/main/java/com/ticketingSystem/api/models/AccessPolicy.java
@@ -1,0 +1,45 @@
+package com.ticketingSystem.api.models;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "access_policy")
+@Getter
+@Setter
+public class AccessPolicy {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "policy_id")
+    private Integer policyId;
+
+    @Column(name = "code", nullable = false, unique = true, length = 100)
+    private String code;
+
+    @Column(name = "resource", nullable = false, length = 100)
+    private String resource;
+
+    @Column(name = "effect", nullable = false, length = 20)
+    private String effect;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "is_active")
+    private boolean isActive = true;
+
+    @Column(name = "created_on")
+    private LocalDateTime createdOn;
+
+    @Column(name = "updated_on")
+    private LocalDateTime updatedOn;
+
+    @Column(name = "created_by")
+    private String createdBy;
+
+    @Column(name = "updated_by")
+    private String updatedBy;
+}

--- a/api/src/main/java/com/ticketingSystem/api/models/PolicyRule.java
+++ b/api/src/main/java/com/ticketingSystem/api/models/PolicyRule.java
@@ -1,0 +1,35 @@
+package com.ticketingSystem.api.models;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "policy_rule")
+@Getter
+@Setter
+public class PolicyRule {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "rule_id")
+    private Integer ruleId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "policy_id", nullable = false)
+    private AccessPolicy policy;
+
+    @Column(name = "condition_key", nullable = false, length = 100)
+    private String conditionKey;
+
+    @Column(name = "operator", nullable = false, length = 50)
+    private String operator;
+
+    @Column(name = "condition_value", columnDefinition = "text")
+    private String conditionValue;
+
+    @Column(name = "priority")
+    private Integer priority;
+
+    @Column(name = "is_active")
+    private boolean isActive = true;
+}

--- a/api/src/main/java/com/ticketingSystem/api/models/RolePolicyMap.java
+++ b/api/src/main/java/com/ticketingSystem/api/models/RolePolicyMap.java
@@ -1,0 +1,41 @@
+package com.ticketingSystem.api.models;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "role_policy_map")
+@Getter
+@Setter
+public class RolePolicyMap {
+    @EmbeddedId
+    private RolePolicyMapId id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("roleId")
+    @JoinColumn(name = "role_id")
+    private Role role;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("policyId")
+    @JoinColumn(name = "policy_id")
+    private AccessPolicy policy;
+
+    @Column(name = "is_active")
+    private boolean isActive = true;
+
+    @Column(name = "created_on")
+    private LocalDateTime createdOn;
+
+    @Column(name = "updated_on")
+    private LocalDateTime updatedOn;
+
+    @Column(name = "created_by")
+    private String createdBy;
+
+    @Column(name = "updated_by")
+    private String updatedBy;
+}

--- a/api/src/main/java/com/ticketingSystem/api/models/RolePolicyMapId.java
+++ b/api/src/main/java/com/ticketingSystem/api/models/RolePolicyMapId.java
@@ -1,0 +1,25 @@
+package com.ticketingSystem.api.models;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serializable;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class RolePolicyMapId implements Serializable {
+    @Column(name = "role_id")
+    private Integer roleId;
+
+    @Column(name = "policy_id")
+    private Integer policyId;
+}

--- a/api/src/main/java/com/ticketingSystem/api/repository/AccessPolicyRepository.java
+++ b/api/src/main/java/com/ticketingSystem/api/repository/AccessPolicyRepository.java
@@ -1,0 +1,12 @@
+package com.ticketingSystem.api.repository;
+
+import com.ticketingSystem.api.models.AccessPolicy;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AccessPolicyRepository extends JpaRepository<AccessPolicy, Integer> {
+    Optional<AccessPolicy> findByCodeIgnoreCase(String code);
+    List<AccessPolicy> findByResourceIgnoreCaseAndIsActiveTrue(String resource);
+}

--- a/api/src/main/java/com/ticketingSystem/api/repository/PolicyRuleRepository.java
+++ b/api/src/main/java/com/ticketingSystem/api/repository/PolicyRuleRepository.java
@@ -1,0 +1,11 @@
+package com.ticketingSystem.api.repository;
+
+import com.ticketingSystem.api.models.PolicyRule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PolicyRuleRepository extends JpaRepository<PolicyRule, Integer> {
+    List<PolicyRule> findByPolicyPolicyIdAndIsActiveTrueOrderByPriorityAscRuleIdAsc(Integer policyId);
+    void deleteByPolicyPolicyId(Integer policyId);
+}

--- a/api/src/main/java/com/ticketingSystem/api/repository/RolePolicyMapRepository.java
+++ b/api/src/main/java/com/ticketingSystem/api/repository/RolePolicyMapRepository.java
@@ -1,0 +1,13 @@
+package com.ticketingSystem.api.repository;
+
+import com.ticketingSystem.api.models.RolePolicyMap;
+import com.ticketingSystem.api.models.RolePolicyMapId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface RolePolicyMapRepository extends JpaRepository<RolePolicyMap, RolePolicyMapId> {
+    List<RolePolicyMap> findByRoleRoleIdInAndIsActiveTrue(Collection<Integer> roleIds);
+    List<RolePolicyMap> findByRoleRoleIdAndIsActiveTrue(Integer roleId);
+}

--- a/api/src/main/java/com/ticketingSystem/api/service/PolicyDecision.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/PolicyDecision.java
@@ -1,0 +1,7 @@
+package com.ticketingSystem.api.service;
+
+public enum PolicyDecision {
+    ALLOW,
+    DENY,
+    ABSTAIN
+}

--- a/api/src/main/java/com/ticketingSystem/api/service/PolicyEvaluationService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/PolicyEvaluationService.java
@@ -1,0 +1,155 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.dto.LoginPayload;
+import com.ticketingSystem.api.models.AccessPolicy;
+import com.ticketingSystem.api.models.PolicyRule;
+import com.ticketingSystem.api.models.Role;
+import com.ticketingSystem.api.models.RolePolicyMap;
+import com.ticketingSystem.api.repository.PolicyRuleRepository;
+import com.ticketingSystem.api.repository.RolePolicyMapRepository;
+import com.ticketingSystem.api.repository.RoleRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+public class PolicyEvaluationService {
+    private static final String RESOURCE_TICKET = "ticket";
+
+    private final RolePolicyMapRepository rolePolicyMapRepository;
+    private final PolicyRuleRepository policyRuleRepository;
+    private final RoleRepository roleRepository;
+
+    public PolicyEvaluationService(RolePolicyMapRepository rolePolicyMapRepository,
+                                   PolicyRuleRepository policyRuleRepository,
+                                   RoleRepository roleRepository) {
+        this.rolePolicyMapRepository = rolePolicyMapRepository;
+        this.policyRuleRepository = policyRuleRepository;
+        this.roleRepository = roleRepository;
+    }
+
+    public PolicyDecision evaluateTicketView(List<String> roleIdentifiers,
+                                             LoginPayload user,
+                                             TicketAccessContext ticketContext) {
+        Set<Integer> roleIds = resolveRoleIds(roleIdentifiers);
+        if (roleIds.isEmpty()) {
+            return PolicyDecision.ABSTAIN;
+        }
+
+        List<RolePolicyMap> mappings = rolePolicyMapRepository.findByRoleRoleIdInAndIsActiveTrue(roleIds);
+        if (mappings.isEmpty()) {
+            return PolicyDecision.ABSTAIN;
+        }
+
+        boolean hasAllow = false;
+        for (RolePolicyMap mapping : mappings) {
+            AccessPolicy policy = mapping.getPolicy();
+            if (policy == null || !policy.isActive() || policy.getResource() == null
+                    || !RESOURCE_TICKET.equalsIgnoreCase(policy.getResource())) {
+                continue;
+            }
+
+            List<PolicyRule> rules = policyRuleRepository
+                    .findByPolicyPolicyIdAndIsActiveTrueOrderByPriorityAscRuleIdAsc(policy.getPolicyId());
+            boolean matches = rules.isEmpty() || rules.stream().allMatch(rule -> evaluateRule(rule, user, ticketContext));
+            if (!matches) {
+                continue;
+            }
+
+            if ("deny".equalsIgnoreCase(policy.getEffect())) {
+                return PolicyDecision.DENY;
+            }
+            hasAllow = true;
+        }
+        return hasAllow ? PolicyDecision.ALLOW : PolicyDecision.ABSTAIN;
+    }
+
+    private boolean evaluateRule(PolicyRule rule, LoginPayload user, TicketAccessContext ticketContext) {
+        if (rule == null) {
+            return false;
+        }
+        String operator = safe(rule.getOperator()).toUpperCase(Locale.ROOT);
+        String leftValue = resolveLeftValue(safe(rule.getConditionKey()), user, ticketContext);
+        String conditionValue = safe(rule.getConditionValue());
+
+        return switch (operator) {
+            case "ALWAYS_TRUE" -> true;
+            case "EQ" -> leftValue.equalsIgnoreCase(resolveRightValue(conditionValue, user, ticketContext));
+            case "IN" -> splitValues(conditionValue).contains(leftValue.toLowerCase(Locale.ROOT));
+            case "IN_CONTEXT" -> splitValues(resolveRightValue(conditionValue, user, ticketContext))
+                    .contains(leftValue.toLowerCase(Locale.ROOT));
+            default -> false;
+        };
+    }
+
+    private String resolveLeftValue(String key, LoginPayload user, TicketAccessContext ticketContext) {
+        return switch (key) {
+            case "ticket.owner_id" -> safe(ticketContext != null ? ticketContext.ticketOwnerId() : null);
+            case "ticket.assigned_to" -> safe(ticketContext != null ? ticketContext.ticketAssigneeUserId() : null);
+            case "ticket.status" -> safe(ticketContext != null && ticketContext.ticketStatus() != null
+                    ? ticketContext.ticketStatus().name() : null);
+            case "ticket.zone_id" -> safe(ticketContext != null ? ticketContext.ticketZoneId() : null);
+            case "ticket.recommended_severity_status" -> safe(ticketContext != null ? ticketContext.recommendedSeverityStatus() : null);
+            case "user.user_id" -> safe(user != null ? user.getUserId() : null);
+            case "user.zone_code" -> safe(user != null ? user.getZoneCode() : null);
+            default -> "";
+        };
+    }
+
+    private String resolveRightValue(String keyOrLiteral, LoginPayload user, TicketAccessContext ticketContext) {
+        return switch (safe(keyOrLiteral)) {
+            case "user.user_id" -> safe(user != null ? user.getUserId() : null);
+            case "user.zone_ids", "user.zone_code" -> safe(user != null ? user.getZoneCode() : null);
+            case "ticket.status" -> safe(ticketContext != null && ticketContext.ticketStatus() != null
+                    ? ticketContext.ticketStatus().name() : null);
+            case "ticket.zone_id" -> safe(ticketContext != null ? ticketContext.ticketZoneId() : null);
+            default -> safe(keyOrLiteral);
+        };
+    }
+
+    private Set<Integer> resolveRoleIds(List<String> roleIdentifiers) {
+        Set<Integer> roleIds = new LinkedHashSet<>();
+        if (roleIdentifiers == null) {
+            return roleIds;
+        }
+
+        for (String raw : roleIdentifiers) {
+            if (raw == null || raw.isBlank()) {
+                continue;
+            }
+            String value = raw.trim();
+            try {
+                roleIds.add(Integer.parseInt(value));
+                continue;
+            } catch (NumberFormatException ignored) {
+            }
+
+            Optional<Role> roleOptional = roleRepository.findByRoleIgnoreCaseAndIsDeletedFalse(value);
+            roleOptional.map(Role::getRoleId).ifPresent(roleIds::add);
+        }
+        return roleIds;
+    }
+
+    private Set<String> splitValues(String csvOrSingle) {
+        if (csvOrSingle == null || csvOrSingle.isBlank()) {
+            return Set.of();
+        }
+        String normalized = csvOrSingle.trim();
+        if (normalized.startsWith("[") && normalized.endsWith("]")) {
+            normalized = normalized.substring(1, normalized.length() - 1);
+        }
+        String[] parts = normalized.split(",");
+        Set<String> out = new LinkedHashSet<>();
+        for (String part : parts) {
+            String clean = part.replace("\"", "").trim().toLowerCase(Locale.ROOT);
+            if (!clean.isEmpty()) {
+                out.add(clean);
+            }
+        }
+        return out;
+    }
+
+    private String safe(String value) {
+        return value == null ? "" : value.trim();
+    }
+}

--- a/api/src/main/java/com/ticketingSystem/api/service/PolicyService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/PolicyService.java
@@ -1,0 +1,218 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.dto.PolicyDto;
+import com.ticketingSystem.api.dto.PolicyRuleDto;
+import com.ticketingSystem.api.exception.ResourceNotFoundException;
+import com.ticketingSystem.api.models.AccessPolicy;
+import com.ticketingSystem.api.models.PolicyRule;
+import com.ticketingSystem.api.models.Role;
+import com.ticketingSystem.api.models.RolePolicyMap;
+import com.ticketingSystem.api.models.RolePolicyMapId;
+import com.ticketingSystem.api.repository.AccessPolicyRepository;
+import com.ticketingSystem.api.repository.PolicyRuleRepository;
+import com.ticketingSystem.api.repository.RolePolicyMapRepository;
+import com.ticketingSystem.api.repository.RoleRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Service
+public class PolicyService {
+    private final AccessPolicyRepository accessPolicyRepository;
+    private final PolicyRuleRepository policyRuleRepository;
+    private final RolePolicyMapRepository rolePolicyMapRepository;
+    private final RoleRepository roleRepository;
+
+    public PolicyService(AccessPolicyRepository accessPolicyRepository,
+                         PolicyRuleRepository policyRuleRepository,
+                         RolePolicyMapRepository rolePolicyMapRepository,
+                         RoleRepository roleRepository) {
+        this.accessPolicyRepository = accessPolicyRepository;
+        this.policyRuleRepository = policyRuleRepository;
+        this.rolePolicyMapRepository = rolePolicyMapRepository;
+        this.roleRepository = roleRepository;
+    }
+
+    @Transactional
+    public PolicyDto createPolicy(PolicyDto dto) {
+        AccessPolicy policy = new AccessPolicy();
+        policy.setCode(requireText(dto.getCode(), "policy code"));
+        policy.setResource(requireText(dto.getResource(), "resource"));
+        policy.setEffect(defaultText(dto.getEffect(), "allow"));
+        policy.setDescription(dto.getDescription());
+        policy.setActive(dto.getIsActive() == null || dto.getIsActive());
+        LocalDateTime now = LocalDateTime.now();
+        policy.setCreatedOn(now);
+        policy.setUpdatedOn(now);
+        policy.setCreatedBy(defaultText(dto.getUpdatedBy(), "SYSTEM"));
+        policy.setUpdatedBy(defaultText(dto.getUpdatedBy(), "SYSTEM"));
+        AccessPolicy saved = accessPolicyRepository.save(policy);
+        saveRules(saved, dto.getRules());
+        return toDto(saved);
+    }
+
+    @Transactional
+    public PolicyDto updatePolicy(Integer policyId, PolicyDto dto) {
+        AccessPolicy policy = accessPolicyRepository.findById(policyId)
+                .orElseThrow(() -> new ResourceNotFoundException("Policy", policyId));
+        if (dto.getCode() != null && !dto.getCode().isBlank()) {
+            policy.setCode(dto.getCode().trim());
+        }
+        if (dto.getResource() != null && !dto.getResource().isBlank()) {
+            policy.setResource(dto.getResource().trim());
+        }
+        if (dto.getEffect() != null && !dto.getEffect().isBlank()) {
+            policy.setEffect(dto.getEffect().trim());
+        }
+        if (dto.getDescription() != null) {
+            policy.setDescription(dto.getDescription());
+        }
+        if (dto.getIsActive() != null) {
+            policy.setActive(dto.getIsActive());
+        }
+        policy.setUpdatedOn(LocalDateTime.now());
+        policy.setUpdatedBy(defaultText(dto.getUpdatedBy(), "SYSTEM"));
+        AccessPolicy saved = accessPolicyRepository.save(policy);
+
+        if (dto.getRules() != null) {
+            policyRuleRepository.deleteByPolicyPolicyId(policyId);
+            saveRules(saved, dto.getRules());
+        }
+        return toDto(saved);
+    }
+
+    public PolicyDto getPolicy(Integer policyId) {
+        AccessPolicy policy = accessPolicyRepository.findById(policyId)
+                .orElseThrow(() -> new ResourceNotFoundException("Policy", policyId));
+        return toDto(policy);
+    }
+
+    public List<PolicyDto> getPolicies(String resource) {
+        List<AccessPolicy> policies = (resource == null || resource.isBlank())
+                ? accessPolicyRepository.findAll()
+                : accessPolicyRepository.findByResourceIgnoreCaseAndIsActiveTrue(resource.trim());
+        return policies.stream().map(this::toDto).toList();
+    }
+
+    @Transactional
+    public void assignPoliciesToRole(Integer roleId,
+                                     List<Integer> policyIds,
+                                     List<String> policyCodes,
+                                     String updatedBy) {
+        Role role = roleRepository.findById(roleId)
+                .orElseThrow(() -> new ResourceNotFoundException("Role", roleId));
+
+        Set<Integer> resolvedPolicyIds = new LinkedHashSet<>();
+        if (policyIds != null) {
+            resolvedPolicyIds.addAll(policyIds.stream().filter(Objects::nonNull).toList());
+        }
+        if (policyCodes != null) {
+            for (String code : policyCodes) {
+                if (code == null || code.isBlank()) {
+                    continue;
+                }
+                AccessPolicy policy = accessPolicyRepository.findByCodeIgnoreCase(code.trim())
+                        .orElseThrow(() -> new ResourceNotFoundException("Policy code", code.trim()));
+                resolvedPolicyIds.add(policy.getPolicyId());
+            }
+        }
+
+        if (resolvedPolicyIds.isEmpty()) {
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        String actor = defaultText(updatedBy, "SYSTEM");
+
+        for (Integer policyId : resolvedPolicyIds) {
+            AccessPolicy policy = accessPolicyRepository.findById(policyId)
+                    .orElseThrow(() -> new ResourceNotFoundException("Policy", policyId));
+            RolePolicyMapId id = new RolePolicyMapId(role.getRoleId(), policy.getPolicyId());
+            RolePolicyMap mapping = rolePolicyMapRepository.findById(id).orElseGet(() -> {
+                RolePolicyMap created = new RolePolicyMap();
+                created.setId(id);
+                created.setRole(role);
+                created.setPolicy(policy);
+                created.setCreatedOn(now);
+                created.setCreatedBy(actor);
+                return created;
+            });
+            mapping.setRole(role);
+            mapping.setPolicy(policy);
+            mapping.setActive(true);
+            mapping.setUpdatedOn(now);
+            mapping.setUpdatedBy(actor);
+            rolePolicyMapRepository.save(mapping);
+        }
+    }
+
+    public List<PolicyDto> getRoleEffectivePolicies(Integer roleId) {
+        List<RolePolicyMap> mappings = rolePolicyMapRepository.findByRoleRoleIdAndIsActiveTrue(roleId);
+        return mappings.stream()
+                .map(RolePolicyMap::getPolicy)
+                .filter(Objects::nonNull)
+                .map(this::toDto)
+                .toList();
+    }
+
+    private void saveRules(AccessPolicy saved, List<PolicyRuleDto> rules) {
+        if (rules == null) {
+            return;
+        }
+        for (PolicyRuleDto ruleDto : rules) {
+            PolicyRule rule = new PolicyRule();
+            rule.setPolicy(saved);
+            rule.setConditionKey(requireText(ruleDto.getConditionKey(), "conditionKey"));
+            rule.setOperator(requireText(ruleDto.getOperator(), "operator"));
+            rule.setConditionValue(ruleDto.getConditionValue());
+            rule.setPriority(ruleDto.getPriority() != null ? ruleDto.getPriority() : 100);
+            rule.setActive(ruleDto.getIsActive() == null || ruleDto.getIsActive());
+            policyRuleRepository.save(rule);
+        }
+    }
+
+    private PolicyDto toDto(AccessPolicy policy) {
+        PolicyDto dto = new PolicyDto();
+        dto.setPolicyId(policy.getPolicyId());
+        dto.setCode(policy.getCode());
+        dto.setResource(policy.getResource());
+        dto.setEffect(policy.getEffect());
+        dto.setDescription(policy.getDescription());
+        dto.setIsActive(policy.isActive());
+
+        List<PolicyRuleDto> rules = policyRuleRepository
+                .findByPolicyPolicyIdAndIsActiveTrueOrderByPriorityAscRuleIdAsc(policy.getPolicyId())
+                .stream()
+                .map(this::toDto)
+                .toList();
+        dto.setRules(rules);
+        return dto;
+    }
+
+    private PolicyRuleDto toDto(PolicyRule rule) {
+        PolicyRuleDto dto = new PolicyRuleDto();
+        dto.setRuleId(rule.getRuleId());
+        dto.setConditionKey(rule.getConditionKey());
+        dto.setOperator(rule.getOperator());
+        dto.setConditionValue(rule.getConditionValue());
+        dto.setPriority(rule.getPriority());
+        dto.setIsActive(rule.isActive());
+        return dto;
+    }
+
+    private String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " is required");
+        }
+        return value.trim();
+    }
+
+    private String defaultText(String value, String fallback) {
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        return value.trim();
+    }
+}

--- a/api/src/main/java/com/ticketingSystem/api/service/TicketAccessContext.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/TicketAccessContext.java
@@ -7,10 +7,11 @@ public record TicketAccessContext(String ticketOwnerId,
                                   String ticketAssigneeUserId,
                                   TicketStatus ticketStatus,
                                   String recommendedSeverityStatus,
-                                  String ticketCreatedBy) {
+                                  String ticketCreatedBy,
+                                  String ticketZoneId) {
 
     public static TicketAccessContext basic(String ticketOwnerId, String ticketAssigneeUserId) {
-        return new TicketAccessContext(ticketOwnerId, ticketAssigneeUserId, null, null, null);
+        return new TicketAccessContext(ticketOwnerId, ticketAssigneeUserId, null, null, null, null);
     }
 
     public boolean hasStatus(TicketStatus status) {

--- a/api/src/main/java/com/ticketingSystem/api/service/TicketAuthorizationService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/TicketAuthorizationService.java
@@ -14,6 +14,11 @@ import java.util.List;
 
 @Service
 public class TicketAuthorizationService {
+    private final PolicyEvaluationService policyEvaluationService;
+
+    public TicketAuthorizationService(PolicyEvaluationService policyEvaluationService) {
+        this.policyEvaluationService = policyEvaluationService;
+    }
 
     private static final List<String> IT_MANAGER_ROLE_IDENTIFIERS = List.of(
             "it manager",
@@ -39,6 +44,16 @@ public class TicketAuthorizationService {
 
         List<String> roles = resolveRoles(authenticatedUser, session);
         List<String> normalizedRoles = normalizeRoles(roles);
+        PolicyDecision policyDecision = policyEvaluationService.evaluateTicketView(roles, authenticatedUser, context);
+        if (policyDecision == PolicyDecision.DENY) {
+            throw new ResponseStatusException(
+                    HttpStatus.FORBIDDEN,
+                    String.format("Access to ticket %s is denied by policy", ticketId)
+            );
+        }
+        if (policyDecision == PolicyDecision.ALLOW) {
+            return;
+        }
         if (RoleUtils.hasUnrestrictedTicketAccess(roles) || hasRoleBasedAccess(normalizedRoles, context)) {
             return;
         }

--- a/db/queries/create_access_policy_tables.sql
+++ b/db/queries/create_access_policy_tables.sql
@@ -1,0 +1,102 @@
+-- RBAC policy model for data-driven authorization
+
+CREATE TABLE IF NOT EXISTS access_policy (
+    policy_id INT PRIMARY KEY AUTO_INCREMENT,
+    code VARCHAR(100) NOT NULL UNIQUE,
+    resource VARCHAR(100) NOT NULL,
+    effect VARCHAR(20) NOT NULL,
+    description VARCHAR(500),
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_on DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_on DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    created_by VARCHAR(100) DEFAULT 'SYSTEM',
+    updated_by VARCHAR(100) DEFAULT 'SYSTEM'
+);
+
+CREATE TABLE IF NOT EXISTS policy_rule (
+    rule_id INT PRIMARY KEY AUTO_INCREMENT,
+    policy_id INT NOT NULL,
+    condition_key VARCHAR(100) NOT NULL,
+    operator VARCHAR(50) NOT NULL,
+    condition_value TEXT,
+    priority INT NOT NULL DEFAULT 100,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    CONSTRAINT fk_policy_rule_policy
+        FOREIGN KEY (policy_id) REFERENCES access_policy(policy_id)
+        ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS role_policy_map (
+    role_id INT NOT NULL,
+    policy_id INT NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_on DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_on DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    created_by VARCHAR(100) DEFAULT 'SYSTEM',
+    updated_by VARCHAR(100) DEFAULT 'SYSTEM',
+    PRIMARY KEY (role_id, policy_id),
+    CONSTRAINT fk_role_policy_role
+        FOREIGN KEY (role_id) REFERENCES role_permission_config(role_id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_role_policy_policy
+        FOREIGN KEY (policy_id) REFERENCES access_policy(policy_id)
+        ON DELETE CASCADE
+);
+
+CREATE INDEX idx_access_policy_resource_active ON access_policy(resource, is_active);
+CREATE INDEX idx_policy_rule_policy_active_priority ON policy_rule(policy_id, is_active, priority);
+CREATE INDEX idx_role_policy_map_role_active ON role_policy_map(role_id, is_active);
+
+-- Seed starter ticket view policies (idempotent)
+INSERT INTO access_policy (code, resource, effect, description, is_active, created_by, updated_by)
+SELECT 'TICKET_VIEW_ALL', 'ticket', 'allow', 'View all tickets', TRUE, 'SYSTEM', 'SYSTEM'
+WHERE NOT EXISTS (SELECT 1 FROM access_policy WHERE code = 'TICKET_VIEW_ALL');
+
+INSERT INTO access_policy (code, resource, effect, description, is_active, created_by, updated_by)
+SELECT 'TICKET_VIEW_OWN', 'ticket', 'allow', 'View own tickets', TRUE, 'SYSTEM', 'SYSTEM'
+WHERE NOT EXISTS (SELECT 1 FROM access_policy WHERE code = 'TICKET_VIEW_OWN');
+
+INSERT INTO access_policy (code, resource, effect, description, is_active, created_by, updated_by)
+SELECT 'TICKET_VIEW_ASSIGNED', 'ticket', 'allow', 'View assigned tickets', TRUE, 'SYSTEM', 'SYSTEM'
+WHERE NOT EXISTS (SELECT 1 FROM access_policy WHERE code = 'TICKET_VIEW_ASSIGNED');
+
+INSERT INTO access_policy (code, resource, effect, description, is_active, created_by, updated_by)
+SELECT 'TICKET_VIEW_SAME_ZONE', 'ticket', 'allow', 'View tickets in same zone as user', TRUE, 'SYSTEM', 'SYSTEM'
+WHERE NOT EXISTS (SELECT 1 FROM access_policy WHERE code = 'TICKET_VIEW_SAME_ZONE');
+
+-- Seed starter rules for seeded policies (idempotent)
+INSERT INTO policy_rule (policy_id, condition_key, operator, condition_value, priority, is_active)
+SELECT ap.policy_id, 'ticket.owner_id', 'EQ', 'user.user_id', 100, TRUE
+FROM access_policy ap
+WHERE ap.code = 'TICKET_VIEW_OWN'
+  AND NOT EXISTS (
+      SELECT 1 FROM policy_rule pr
+      WHERE pr.policy_id = ap.policy_id
+        AND pr.condition_key = 'ticket.owner_id'
+        AND pr.operator = 'EQ'
+        AND pr.condition_value = 'user.user_id'
+  );
+
+INSERT INTO policy_rule (policy_id, condition_key, operator, condition_value, priority, is_active)
+SELECT ap.policy_id, 'ticket.assigned_to', 'EQ', 'user.user_id', 100, TRUE
+FROM access_policy ap
+WHERE ap.code = 'TICKET_VIEW_ASSIGNED'
+  AND NOT EXISTS (
+      SELECT 1 FROM policy_rule pr
+      WHERE pr.policy_id = ap.policy_id
+        AND pr.condition_key = 'ticket.assigned_to'
+        AND pr.operator = 'EQ'
+        AND pr.condition_value = 'user.user_id'
+  );
+
+INSERT INTO policy_rule (policy_id, condition_key, operator, condition_value, priority, is_active)
+SELECT ap.policy_id, 'ticket.zone_id', 'IN_CONTEXT', 'user.zone_ids', 100, TRUE
+FROM access_policy ap
+WHERE ap.code = 'TICKET_VIEW_SAME_ZONE'
+  AND NOT EXISTS (
+      SELECT 1 FROM policy_rule pr
+      WHERE pr.policy_id = ap.policy_id
+        AND pr.condition_key = 'ticket.zone_id'
+        AND pr.operator = 'IN_CONTEXT'
+        AND pr.condition_value = 'user.zone_ids'
+  );

--- a/docs/rbac-modernization-plan.md
+++ b/docs/rbac-modernization-plan.md
@@ -1,0 +1,268 @@
+# RBAC Modernization Plan (Ticketing System)
+
+## Why this change is needed
+
+Today, role/access behavior is split across JSON permissions, hard-coded IDs/names, and role helper utilities. This makes “create a role and grant ticket access” a backend-change task rather than a configuration task.
+
+Current examples in code:
+
+- Permission bootstrap and mutation are role-record backed, but include hard-coded role ID logic (`USER_PAGE_ROLE_IDS`) in service code.
+- Ticket authorization includes hard-coded role identifiers (`"9"`, `"13"`, `"it manager"`) and condition logic in Java.
+- `RoleUtils` contains static role identifier sets for unrestricted access.
+
+## Target state
+
+Make authorization **data-driven** so admins can manage:
+
+1. Role creation.
+2. Scope of ticket visibility (all tickets vs own/assigned/etc.).
+3. Action-level capabilities (status transitions, comments, assignment, escalation).
+4. Resource-level conditions (e.g., status-specific visibility).
+
+…without backend code changes.
+
+## Recommended design
+
+## 1) Normalize authorization into explicit policy tables
+
+Add tables (or equivalent JSON columns if incremental migration is preferred):
+
+- `access_policy`
+  - `policy_id`, `code`, `resource` (e.g., `ticket`), `effect` (`allow`/`deny`), `description`, `is_active`.
+- `policy_rule`
+  - `rule_id`, `policy_id`, `condition_type`, `condition_key`, `operator`, `condition_value`.
+  - Example: `condition_key=ticket.status`, `operator=IN`, `condition_value=["AWAITING_ESCALATION_APPROVAL"]`.
+  - Zone-based example: `condition_key=ticket.zone_id`, `operator=IN_CONTEXT`, `condition_value="user.zone_ids"`.
+- `role_policy_map`
+  - `role_id`, `policy_id`.
+
+Minimum starter policy set for ticket visibility:
+
+- `TICKET_VIEW_ALL`
+- `TICKET_VIEW_OWN`
+- `TICKET_VIEW_ASSIGNED`
+- `TICKET_VIEW_STATUS_BASED`
+
+This removes hard-coded role IDs/names from service code.
+
+## 2) Keep existing `permissions` JSON for UI features only
+
+Your existing `RolePermission` model (`sidebar`/`pages`) works for menu/page toggles. Keep it for UI-level controls.
+
+Move **domain authorization** (ticket access rules) out of `RoleUtils` and `TicketAuthorizationService` into policy evaluation.
+
+## 3) Introduce a Policy Evaluation Service
+
+Create a dedicated service API:
+
+- `boolean canViewTicket(UserContext user, TicketAccessContext ticket)`
+- `boolean canPerform(String action, UserContext user, TicketAccessContext ticket)`
+
+Behavior:
+
+1. Resolve user roles.
+2. Resolve policies mapped to those roles.
+3. Evaluate policy rules against the ticket context.
+4. Return allow/deny with deterministic precedence (explicit deny > allow).
+
+## 4) Add admin endpoints for configuration
+
+Add APIs to manage policy without redeploy:
+
+- `POST /policies`
+- `PUT /policies/{id}`
+- `POST /roles/{id}/policies`
+- `GET /roles/{id}/effective-access`
+
+This enables role onboarding directly from admin UI or scripts.
+
+## 5) Cache with invalidation
+
+Use in-memory cache for role→policy and policy→rules lookup with invalidation on policy update.
+
+- On role/policy update: evict related cache keys.
+- On startup: warm caches from DB.
+
+## 6) Backward-compatible migration strategy
+
+Phase 1:
+
+- Add policy tables + read path (no write cutover).
+- Mirror current hard-coded behavior into seed policies.
+
+Phase 2:
+
+- Switch `TicketAuthorizationService` to policy evaluator first, with fallback to old checks.
+
+Phase 3:
+
+- Remove hard-coded checks from:
+  - `TicketAuthorizationService`
+  - `RoleUtils`
+  - `PermissionService` role-ID-specific branches
+
+Phase 4:
+
+- Add admin UI for role-policy mapping.
+
+## Practical “all tickets access” flow after migration
+
+1. Create role in `role_permission_config` (existing flow).
+2. Assign policy `TICKET_VIEW_ALL` to that role (new API/UI).
+3. Optional: assign `TICKET_EDIT_ALL`, `TICKET_ASSIGN_ALL`, `TICKET_ESCALATE` policies.
+4. User with that role gets access immediately after cache invalidation.
+
+No backend code edits required.
+
+## Discussion Q&A
+
+### Can I create new policies right now?
+
+Not yet in the **current implementation**. Right now, policy CRUD endpoints and policy tables are a proposed target-state, not live features.
+
+### Can we support zone-based ticket access?
+
+Yes — this is exactly what the policy-rule model is meant to support. The intended rule shape is:
+
+- Resource: `ticket`
+- Policy: `TICKET_VIEW_SAME_ZONE`
+- Rule: `ticket.zone_id IN user.zone_ids`
+
+At evaluation time, the engine reads user context (e.g., `zone_ids`) and ticket context (`zone_id`) and returns allow/deny without hard-coding role IDs in Java.
+
+### What changes are needed for that?
+
+1. Add policy schema (`access_policy`, `policy_rule`, `role_policy_map`).
+2. Extend user context resolver to provide `zone_ids`.
+3. Extend ticket access context to provide `zone_id`.
+4. Implement comparator `IN_CONTEXT` (left field evaluated against right-side context attribute).
+5. Attach `TICKET_VIEW_SAME_ZONE` to any role from admin UI/API.
+
+## Start small: Phase-1 implementation checklist (no hard-coded `role_id`)
+
+If your immediate goal is: “while creating a role, I should not change backend code”, implement these first.
+
+### A) Database changes (minimum)
+
+1. **Create `access_policy`**
+   - Stores reusable policy definitions.
+   - Suggested columns:
+     - `policy_id` (PK)
+     - `code` (unique, e.g., `TICKET_VIEW_ALL`, `TICKET_VIEW_SAME_ZONE`)
+     - `resource` (e.g., `ticket`)
+     - `effect` (`allow` or `deny`)
+     - `description`
+     - `is_active`
+     - audit fields (`created_on`, `created_by`, `updated_on`, `updated_by`)
+
+2. **Create `policy_rule`**
+   - Stores conditions for each policy.
+   - Suggested columns:
+     - `rule_id` (PK)
+     - `policy_id` (FK -> `access_policy.policy_id`)
+     - `condition_key` (e.g., `ticket.status`, `ticket.zone_id`)
+     - `operator` (e.g., `EQ`, `IN`, `IN_CONTEXT`)
+     - `condition_value` (JSON/text; e.g., `["ESCALATED"]` or `user.zone_ids`)
+     - `priority` (optional; for deterministic evaluation order)
+     - `is_active`
+
+3. **Create `role_policy_map`**
+   - Maps role -> policies (many-to-many).
+   - Suggested columns:
+     - `role_id` (FK -> existing `role_permission_config.role_id`)
+     - `policy_id` (FK -> `access_policy.policy_id`)
+     - `is_active`
+     - audit fields
+   - Unique key: (`role_id`, `policy_id`).
+
+4. **(Optional but recommended) Create `user_scope`**
+   - If zone/region is not already reliably available for every user, keep normalized user scope attributes.
+   - Example columns: `user_id`, `scope_type` (`zone`, `region`), `scope_value`.
+
+### B) Service/API changes (minimum)
+
+1. **Policy CRUD APIs** (admin only)
+   - `POST /policies`
+   - `PUT /policies/{id}`
+   - `POST /roles/{id}/policies`
+   - `DELETE /roles/{id}/policies/{policyId}`
+   - `GET /roles/{id}/effective-access`
+
+2. **Role create/update flow**
+   - Existing role creation remains in `role_permission_config`.
+   - Add policy assignment in same workflow (or immediately after create) by writing to `role_policy_map`.
+   - No backend code changes for new role access patterns — only data changes.
+
+3. **Policy Evaluation Service**
+   - Replace hard-coded checks with:
+     - resolve user roles
+     - fetch active policies from `role_policy_map`
+     - fetch active rules from `policy_rule`
+     - evaluate against `TicketAccessContext` + user context
+     - enforce precedence: explicit deny > allow > default deny
+
+4. **Ticket authorization integration**
+   - `TicketAuthorizationService` should call policy evaluator first.
+   - Keep old hard-coded logic only as temporary fallback while migrating.
+
+### C) What gets updated when admin configures access
+
+1. Admin creates/edits a policy -> **`access_policy` updated**.
+2. Admin defines conditions -> **`policy_rule` updated**.
+3. Admin assigns policy to role -> **`role_policy_map` updated**.
+4. Role creation -> existing **`role_permission_config`** row + optional **`role_policy_map`** entries.
+
+No Java constants / no hard-coded role IDs should be required for new access behavior.
+
+### E) Role-to-policy mapping key choice (`policy_id` vs `policy_code`)
+
+Your requirement to map roles using **`policy_id`** is good and suitable for database-level relations.
+
+- **Recommended in DB:** keep `role_policy_map(role_id, policy_id)` as FK-based mapping.
+- **Recommended in APIs/UI:** prefer `policy_code` (human-readable, stable semantic key).
+
+Why this hybrid model is better:
+
+1. `policy_id` is efficient and relationally correct for joins/indexes.
+2. `policy_code` is safer for external clients and config scripts (IDs differ across envs like DEV/UAT/PROD).
+3. You avoid accidental wrong mappings during data migrations/seeding when numeric IDs change.
+
+Suggested API behavior:
+
+- Accept either `policy_id` or `policy_code` in admin APIs.
+- Internally resolve `policy_code -> policy_id` once, then persist only `policy_id` in `role_policy_map`.
+- Enforce unique `access_policy.code` so code-based mapping is deterministic.
+
+So: **keep your requirement**, and add `policy_code` support at API boundary for portability.
+
+### D) First seed policies to support immediately
+
+- `TICKET_VIEW_ALL` (allow, no rule or always-true rule)
+- `TICKET_VIEW_OWN` (`ticket.owner_id EQ user.user_id`)
+- `TICKET_VIEW_ASSIGNED` (`ticket.assigned_to EQ user.user_id`)
+- `TICKET_VIEW_SAME_ZONE` (`ticket.zone_id IN_CONTEXT user.zone_ids`)
+
+With just these, most onboarding cases can be handled by DB/API config only.
+
+## Suggested quick wins (can be done immediately)
+
+1. Replace hard-coded role checks in `TicketAuthorizationService` with a config-backed lookup table.
+2. Stop using role IDs in logic (`"9"`, `"13"`, etc.); use policy codes or role slugs.
+3. Add `GET /roles/{id}/effective-access` for auditability.
+4. Add automated tests for policy combinations (own + assigned + status-based + unrestricted).
+
+## Risks and controls
+
+- **Risk:** policy misconfiguration causing over-permission.
+  - **Control:** default deny, explicit allow, audit logs for policy changes.
+- **Risk:** performance overhead.
+  - **Control:** cache effective permissions per role/user.
+- **Risk:** migration regressions.
+  - **Control:** dual-run mode (old + new evaluator) and compare decisions in logs.
+
+## Success criteria
+
+- New role onboarding requires no code change.
+- “Grant all ticket access” achieved by policy assignment only.
+- Ticket access decisions are explainable via effective policy output.
+- Hard-coded role IDs/names removed from authorization paths.

--- a/docs/rbac-modernization-plan.md
+++ b/docs/rbac-modernization-plan.md
@@ -235,6 +235,33 @@ Suggested API behavior:
 
 So: **keep your requirement**, and add `policy_code` support at API boundary for portability.
 
+### F) `role_policy_map` table vs `policy_ids` column in `role_permission_config`
+
+Short answer: use **`role_policy_map`** (normalized many-to-many table). It is the better long-term and safer option.
+
+Why `role_policy_map` is better:
+
+1. **Relational integrity**
+   - FK constraints prevent orphan policy references.
+2. **Querying + indexing**
+   - Faster and cleaner for joins, filtering, and audit reports.
+3. **Operational flexibility**
+   - Easy activate/deactivate per mapping (`is_active`) without rewriting a full CSV/JSON column.
+4. **Auditability**
+   - Per-assignment timestamps/actor fields are straightforward.
+5. **Scalability**
+   - Handles many roles/policies cleanly as data grows.
+
+When `policy_ids` column in `role_permission_config` may look easier:
+
+- It is quick for an initial prototype.
+- But it creates parsing complexity, weaker validation, harder indexing, and brittle migrations.
+
+Recommendation:
+
+- If you want a production-grade model: **`role_policy_map`**.
+- If you need temporary MVP speed: `policy_ids` can be transitional, but plan migration to `role_policy_map`.
+
 ### D) First seed policies to support immediately
 
 - `TICKET_VIEW_ALL` (allow, no rule or always-true rule)


### PR DESCRIPTION
### Motivation

- Replace scattered, hard-coded ticket access checks with a data-driven policy system so roles and access can be managed via configuration rather than code.
- Provide a policy evaluation engine that supports allow/deny precedence and contextual rules (owner, assignee, zone, status) for ticket visibility.
- Expose admin APIs to create/update policies and assign them to roles so onboarding and access changes do not require backend deployments.

### Description

- Added persistent policy model and mapping including entities `AccessPolicy`, `PolicyRule`, `RolePolicyMap`, and `RolePolicyMapId` with corresponding repositories `AccessPolicyRepository`, `PolicyRuleRepository`, and `RolePolicyMapRepository`.
- Implemented DTOs `PolicyDto`, `PolicyRuleDto`, and `RolePolicyAssignmentRequest` and admin APIs in `PolicyController` plus role endpoints in `RoleController` (`POST /policies`, `PUT /policies/{id}`, `POST /roles/{id}/policies`, `GET /roles/{id}/effective-access`).
- Implemented `PolicyService` to manage policies/rules and role assignments, and `PolicyEvaluationService` with `PolicyDecision` enum to evaluate ticket-view decisions using rules (`EQ`, `IN`, `IN_CONTEXT`, `ALWAYS_TRUE`).
- Integrated policy evaluation into authorization by updating `TicketAuthorizationService` to consult `PolicyEvaluationService` (deny > allow precedence) and extended `TicketAccessContext` and `TicketController` to include ticket zone information required for zone-based rules.
- Added DB migration SQL `db/queries/create_access_policy_tables.sql` to create tables and seed starter ticket view policies and rules, and included a design document `docs/rbac-modernization-plan.md` describing the approach and migration strategy.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be52c2e1c083329f07dee358bfa001)