### PR TITLE
Show status transition labels for status actions and use role-name labels for permissions in Create Role

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/models/TicketStatusWorkflow.java
+++ b/api/src/main/java/com/ticketingSystem/api/models/TicketStatusWorkflow.java
@@ -21,4 +21,10 @@ public class TicketStatusWorkflow {
 
     @Column(name = "TSW_Next_Status")
     private Integer nextStatus;
+
+    @Transient
+    private String currentStatusName;
+
+    @Transient
+    private String nextStatusName;
 }

--- a/api/src/main/java/com/ticketingSystem/api/service/TicketStatusWorkflowService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/TicketStatusWorkflowService.java
@@ -36,7 +36,19 @@ public class TicketStatusWorkflowService {
     }
 
     public List<TicketStatusWorkflow> getAllStatusActions() {
-        return workflowRepository.findAll();
+        List<TicketStatusWorkflow> workflows = workflowRepository.findAll();
+        Map<String, String> statusNamesById = statusMasterRepository.findAll().stream()
+                .collect(Collectors.toMap(Status::getStatusId, Status::getStatusName, (existing, replacement) -> existing));
+
+        for (TicketStatusWorkflow workflow : workflows) {
+            String currentStatusId = workflow.getCurrentStatus() != null ? String.valueOf(workflow.getCurrentStatus()) : null;
+            String nextStatusId = workflow.getNextStatus() != null ? String.valueOf(workflow.getNextStatus()) : null;
+
+            workflow.setCurrentStatusName(currentStatusId != null ? statusNamesById.get(currentStatusId) : null);
+            workflow.setNextStatusName(nextStatusId != null ? statusNamesById.get(nextStatusId) : null);
+        }
+
+        return workflows;
     }
 
     public List<TicketStatusWorkflow> getNextStatusesByCurrentStatus(String statusId) {

--- a/ui/src/pages/CreateRole.tsx
+++ b/ui/src/pages/CreateRole.tsx
@@ -8,13 +8,14 @@ import CancelAndSubmitButtons from '../components/UI/Button/CancelAndSubmitButto
 interface CreateRoleProps {
     roles: string[];
     permissions: any;
+    permissionOptions: { label: string; value: string }[];
     statusActions: any[];
     parameterOptions: { label: string; value: string }[];
     onSubmit: (payload: any) => void;
     onCancel: () => void;
 }
 
-const CreateRole: React.FC<CreateRoleProps> = ({ roles, permissions, statusActions, parameterOptions, onSubmit, onCancel }) => {
+const CreateRole: React.FC<CreateRoleProps> = ({ roles, permissions, permissionOptions, statusActions, parameterOptions, onSubmit, onCancel }) => {
     const { register, handleSubmit, control, watch, setValue, formState: { errors }, reset } = useForm({
         defaultValues: {
             role: '',
@@ -92,21 +93,41 @@ const CreateRole: React.FC<CreateRoleProps> = ({ roles, permissions, statusActio
                         <Autocomplete
                             multiple={!field.value.includes('Custom')}
                             disableCloseOnSelect={!field.value.includes('Custom')}
-                            options={["Custom", ...roles]}
+                            options={["Custom", ...permissionOptions]}
                             value={field.value}
-                            onChange={(_, val) => handlePermChange(val)}
+                            onChange={(_, val) => {
+                                const normalized = (Array.isArray(val) ? val : [val]).map((item: any) =>
+                                    typeof item === 'string' ? item : item.value
+                                );
+                                handlePermChange(normalized);
+                            }}
                             className="w-50"
+                            getOptionLabel={(option: any) => {
+                                if (typeof option === 'string') return option;
+                                return option.label;
+                            }}
+                            isOptionEqualToValue={(option: any, value: any) => {
+                                if (typeof option === 'string' || typeof value === 'string') return option === value;
+                                return option.value === value.value;
+                            }}
                             renderTags={(value, getTagProps) =>
                                 value.length === 0 ? (
                                     <em className="ms-1" style={{ color: '#888' }}>No selection</em>
                                 ) : (
                                     value.map((option, index) => (
-                                        <Chip label={option} {...getTagProps({ index })} />
+                                        <Chip
+                                            label={typeof option === 'string'
+                                                ? (permissionOptions.find((perm) => perm.value === option)?.label || option)
+                                                : option.label}
+                                            {...getTagProps({ index })}
+                                        />
                                     ))
                                 )
                             }
                             renderOption={(props, option) => (
-                                <li {...props} style={{ fontStyle: option === 'Custom' ? 'italic' : 'normal' }}>{option}</li>
+                                <li {...props} style={{ fontStyle: option === 'Custom' ? 'italic' : 'normal' }}>
+                                    {typeof option === 'string' ? option : option.label}
+                                </li>
                             )}
                             renderInput={(params) => (
                                 <TextField
@@ -140,10 +161,15 @@ const CreateRole: React.FC<CreateRoleProps> = ({ roles, permissions, statusActio
                         value={(statusActions || []).filter((a: any) => field.value.includes(String(a.id)))}
                         onChange={(_, val) => field.onChange(val.map((a: any) => String(a.id)))}
                         className="w-50 mb-2"
-                        getOptionLabel={(option: any) => option.action}
+                        getOptionLabel={(option: any) =>
+                            `${option.action} (${option.currentStatusName || option.currentStatus} → ${option.nextStatusName || option.nextStatus})`
+                        }
                         renderTags={(value, getTagProps) =>
                             value.map((option, index) => (
-                                <Chip label={option.action} {...getTagProps({ index })} />
+                                <Chip
+                                    label={`${option.action} (${option.currentStatusName || option.currentStatus} → ${option.nextStatusName || option.nextStatus})`}
+                                    {...getTagProps({ index })}
+                                />
                             ))
                         }
                         renderInput={(params) => <TextField {...params} label="Status Actions" />}

--- a/ui/src/pages/RoleMaster.tsx
+++ b/ui/src/pages/RoleMaster.tsx
@@ -46,6 +46,10 @@ const RoleMaster: React.FC = () => {
     }, []);
 
     const roles = data?.roles ? Object.keys(data.roles) : [];
+    const permissionOptions = (rolesData || []).map((role: any) => ({
+        label: role.role,
+        value: String(role.roleId)
+    }));
     const parameterOptions = getDropdownOptions(parameters || [], 'label', 'parameterId');
 
     const handleCreate = () => {
@@ -110,6 +114,7 @@ const RoleMaster: React.FC = () => {
                 <CreateRole
                     roles={roles}
                     permissions={data?.roles || {}}
+                    permissionOptions={permissionOptions}
                     statusActions={statusActions || []}
                     parameterOptions={parameterOptions}
                     onSubmit={handleCreateSubmit}

--- a/ui/src/pages/__tests__/CreateRole.test.tsx
+++ b/ui/src/pages/__tests__/CreateRole.test.tsx
@@ -21,8 +21,14 @@ jest.mock('@mui/material', () => {
         if (option?.id != null) {
           return String(option.id);
         }
+        if (option?.value != null) {
+          return String(option.value);
+        }
         if (option?.action) {
           return option.action;
+        }
+        if (option?.label) {
+          return option.label;
         }
         return String(option);
       };
@@ -96,6 +102,7 @@ describe('CreateRole', () => {
     const { getByLabelText, getByText, getAllByTestId } = renderWithTheme(
       <CreateRole
         roles={['Admin']}
+        permissionOptions={[{ label: 'Admin', value: '1' }]}
         permissions={{}}
         statusActions={[]}
         parameterOptions={[{ label: 'Param 1', value: '1' }]}
@@ -113,7 +120,7 @@ describe('CreateRole', () => {
     await act(async () => {
       fireEvent.change(permissionsSelect, {
         target: {
-          value: 'Admin',
+          value: '1',
         },
       } as any);
     });
@@ -125,13 +132,13 @@ describe('CreateRole', () => {
     expect(mockSubmit).toHaveBeenCalledWith(expect.objectContaining({
       role: 'Supervisor',
       description: 'Handles escalations',
-      permissionsList: ['Admin'],
+      permissionsList: ['1'],
     }));
   });
 
   it('triggers cancel handler on cancel click', () => {
     const { getByText } = renderWithTheme(
-      <CreateRole roles={[]} permissions={{}} statusActions={[]} parameterOptions={[]} onSubmit={mockSubmit} onCancel={mockCancel} />
+      <CreateRole roles={[]} permissionOptions={[]} permissions={{}} statusActions={[]} parameterOptions={[]} onSubmit={mockSubmit} onCancel={mockCancel} />
     );
     fireEvent.click(getByText('Cancel'));
     expect(mockCancel).toHaveBeenCalled();


### PR DESCRIPTION
### Motivation
- Make Status Actions in the Create Role UI easier to understand by showing the transition context as `Current → Next` instead of just an action ID. 
- Ensure the Permissions dropdown shows human-readable role names while still submitting role IDs to the backend. 
- Provide backend data (status names) to the UI so labels can be rendered reliably without additional client-side lookups.

### Description
- Added transient fields `currentStatusName` and `nextStatusName` to `TicketStatusWorkflow` and populated them in `TicketStatusWorkflowService#getAllStatusActions()` by mapping `status_master` rows to IDs. 
- Updated the `CreateRole` component to accept `permissionOptions: {label,value}` and to render the permissions autocomplete using role names while normalizing selections to role IDs for submission. 
- Updated the `CreateRole` Status Actions autocomplete to show labels in the format `Action (Current → Next)` and to use the new `currentStatusName`/`nextStatusName` fields with fallbacks to IDs. 
- Updated `RoleMaster` to build and pass `permissionOptions` from `rolesData`, and updated `CreateRole` unit tests to reflect the new permission option shape and ensure IDs are submitted.

### Testing
- Ran the frontend unit tests with `npm test -- --runInBand src/pages/__tests__/CreateRole.test.tsx src/pages/__tests__/RoleMaster.test.tsx`, and both test suites passed. 
- Attempted to run the API unit test `./gradlew test --tests com.ticketingSystem.api.service.TicketStatusWorkflowServiceTest`, but it failed in this environment due to a JDK/Gradle class-version mismatch (`Unsupported class file major version 69`). 
- Verified changed files include the model and service (`TicketStatusWorkflow` and `TicketStatusWorkflowService`) and the UI changes (`CreateRole`, `RoleMaster`, and updated tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0506af7748332acab54cbbc914d2d)