### PR TITLE
Add SLA breach filtering to ticket search and UI

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/controller/TicketController.java
+++ b/api/src/main/java/com/ticketingSystem/api/controller/TicketController.java
@@ -240,6 +240,8 @@ public class TicketController {
             @RequestParam(required = false) String districtCode,
             @RequestParam(required = false) String issueTypeId,
             @RequestParam(required = false) String divisionId,
+            @RequestParam(required = false) String breachOption,
+            @RequestParam(required = false) Integer breachInMinutes,
             @RequestParam(required = false, defaultValue = "reported_date") String dateParam,
             @RequestParam(required = false) String fromDate,
             @RequestParam(required = false) String toDate,
@@ -247,8 +249,8 @@ public class TicketController {
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "id") String sortBy,
             @RequestParam(defaultValue = "ASC") String direction) {
-        logger.info("Request to search tickets query={} status={} master={} assignedTo={} assignedBy={} requestorId={} levelId={} priority={} severity={} createdBy={} category={} subCategory={} zoneCode={} regionCode={} districtCode={} issueTypeId={} divisionId={} dateParam={} fromDate={} toDate={} page={} size={} sortBy={} direction={}",
-                query, statusId, master, assignedTo, assignedBy, requestorId, levelId, priority, severity, createdBy, category, subCategory, zoneCode, regionCode, districtCode, issueTypeId, divisionId, dateParam, fromDate, toDate, page, size, sortBy, direction);
+        logger.info("Request to search tickets query={} status={} master={} assignedTo={} assignedBy={} requestorId={} levelId={} priority={} severity={} createdBy={} category={} subCategory={} zoneCode={} regionCode={} districtCode={} issueTypeId={} divisionId={} breachOption={} breachInMinutes={} dateParam={} fromDate={} toDate={} page={} size={} sortBy={} direction={}",
+                query, statusId, master, assignedTo, assignedBy, requestorId, levelId, priority, severity, createdBy, category, subCategory, zoneCode, regionCode, districtCode, issueTypeId, divisionId, breachOption, breachInMinutes, dateParam, fromDate, toDate, page, size, sortBy, direction);
         Page<TicketDto> p = ticketService.searchTickets(
                 query,
                 statusId,
@@ -267,6 +269,8 @@ public class TicketController {
                 districtCode,
                 issueTypeId,
                 divisionId,
+                breachOption,
+                breachInMinutes,
                 dateParam,
                 fromDate,
                 toDate,
@@ -296,11 +300,13 @@ public class TicketController {
             @RequestParam(required = false) String districtCode,
             @RequestParam(required = false) String issueTypeId,
             @RequestParam(required = false) String divisionId,
+            @RequestParam(required = false) String breachOption,
+            @RequestParam(required = false) Integer breachInMinutes,
             @RequestParam(required = false, defaultValue = "reported_date") String dateParam,
             @RequestParam(required = false) String fromDate,
             @RequestParam(required = false) String toDate) {
-        logger.info("Request to export tickets query={} status={} master={} assignedTo={} assignedBy={} requestorId={} levelId={} priority={} severity={} createdBy={} category={} subCategory={} zoneCode={} regionCode={} districtCode={} issueTypeId={} divisionId={} dateParam={} fromDate={} toDate={}",
-                query, statusId, master, assignedTo, assignedBy, requestorId, levelId, priority, severity, createdBy, category, subCategory, zoneCode, regionCode, districtCode, issueTypeId, divisionId, dateParam, fromDate, toDate);
+        logger.info("Request to export tickets query={} status={} master={} assignedTo={} assignedBy={} requestorId={} levelId={} priority={} severity={} createdBy={} category={} subCategory={} zoneCode={} regionCode={} districtCode={} issueTypeId={} divisionId={} breachOption={} breachInMinutes={} dateParam={} fromDate={} toDate={}",
+                query, statusId, master, assignedTo, assignedBy, requestorId, levelId, priority, severity, createdBy, category, subCategory, zoneCode, regionCode, districtCode, issueTypeId, divisionId, breachOption, breachInMinutes, dateParam, fromDate, toDate);
         List<TicketDto> results = ticketService.searchTicketsList(
                 query,
                 statusId,
@@ -319,6 +325,8 @@ public class TicketController {
                 districtCode,
                 issueTypeId,
                 divisionId,
+                breachOption,
+                breachInMinutes,
                 dateParam,
                 fromDate,
                 toDate

--- a/api/src/main/java/com/ticketingSystem/api/repository/TicketRepository.java
+++ b/api/src/main/java/com/ticketingSystem/api/repository/TicketRepository.java
@@ -416,7 +416,7 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
                                                        @Param("toDate") LocalDateTime toDate,
                                                        Pageable pageable);
 
-    @Query("SELECT t FROM Ticket t LEFT JOIN t.status s " +
+    @Query("SELECT t FROM Ticket t LEFT JOIN t.status s LEFT JOIN t.issueType it " +
 //            "WHERE (:statusId IS NULL OR s.statusId = :statusId) " +
 //            "WHERE (:statusId IS NULL OR function(FIND_IN_SET, s.statusId, :statusId) > 0)" +
             "WHERE (:statusIds IS NULL OR s.statusId IN (:statusIds))" +
@@ -432,8 +432,8 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
             "AND (:issueTypeId IS NULL OR t.issueTypeId = :issueTypeId) " +
             "AND (:divisionId IS NULL OR t.division = :divisionId) " +
             "AND (:breachOption IS NULL " +
-            "OR (:breachOption = 'BREACHED' AND EXISTS (SELECT 1 FROM TicketSla ts WHERE ts.ticket = t AND COALESCE(ts.breachedByMinutes, 0) >= 0)) " +
-            "OR (:breachOption = 'BREACH_IN' AND :breachInMinutes IS NOT NULL AND EXISTS (SELECT 1 FROM TicketSla ts WHERE ts.ticket = t AND COALESCE(ts.breachedByMinutes, 0) < 0 AND COALESCE(ts.breachedByMinutes, 0) >= (0 - :breachInMinutes)))) " +
+            "OR (:breachOption = 'BREACHED' AND COALESCE(it.slaFlag, false) = true AND EXISTS (SELECT 1 FROM TicketSla ts WHERE ts.ticket = t AND COALESCE(ts.breachedByMinutes, 0) >= 0)) " +
+            "OR (:breachOption = 'BREACH_IN' AND :breachInMinutes IS NOT NULL AND COALESCE(it.slaFlag, false) = true AND EXISTS (SELECT 1 FROM TicketSla ts WHERE ts.ticket = t AND COALESCE(ts.breachedByMinutes, 0) < 0 AND COALESCE(ts.breachedByMinutes, 0) >= (0 - :breachInMinutes)))) " +
             "AND ((:assignedTo IS NULL AND :assignedBy IS NULL AND :requestorId IS NULL AND :createdBy IS NULL) " +
             "OR (:assignedTo IS NOT NULL AND (LOWER(t.assignedTo) = LOWER(:assignedTo) OR (:alternateAssignedTo IS NOT NULL AND LOWER(t.assignedTo) = LOWER(:alternateAssignedTo)))) " +
             "OR (:assignedBy IS NOT NULL AND LOWER(t.assignedBy) = LOWER(:assignedBy)) " +
@@ -473,7 +473,7 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
                                @Param("toDate") LocalDateTime toDate,
                                Pageable pageable);
 
-    @Query("SELECT t FROM Ticket t LEFT JOIN t.status s " +
+    @Query("SELECT t FROM Ticket t LEFT JOIN t.status s LEFT JOIN t.issueType it " +
             "WHERE (:statusIds IS NULL OR s.statusId IN (:statusIds))" +
             "AND (:master IS NULL OR t.isMaster = :master) " +
             "AND (:levelId IS NULL OR t.levelId = :levelId) " +
@@ -487,8 +487,8 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
             "AND (:issueTypeId IS NULL OR t.issueTypeId = :issueTypeId) " +
             "AND (:divisionId IS NULL OR t.division = :divisionId) " +
             "AND (:breachOption IS NULL " +
-            "OR (:breachOption = 'BREACHED' AND EXISTS (SELECT 1 FROM TicketSla ts WHERE ts.ticket = t AND COALESCE(ts.breachedByMinutes, 0) >= 0)) " +
-            "OR (:breachOption = 'BREACH_IN' AND :breachInMinutes IS NOT NULL AND EXISTS (SELECT 1 FROM TicketSla ts WHERE ts.ticket = t AND COALESCE(ts.breachedByMinutes, 0) < 0 AND COALESCE(ts.breachedByMinutes, 0) >= (0 - :breachInMinutes)))) " +
+            "OR (:breachOption = 'BREACHED' AND COALESCE(it.slaFlag, false) = true AND EXISTS (SELECT 1 FROM TicketSla ts WHERE ts.ticket = t AND COALESCE(ts.breachedByMinutes, 0) >= 0)) " +
+            "OR (:breachOption = 'BREACH_IN' AND :breachInMinutes IS NOT NULL AND COALESCE(it.slaFlag, false) = true AND EXISTS (SELECT 1 FROM TicketSla ts WHERE ts.ticket = t AND COALESCE(ts.breachedByMinutes, 0) < 0 AND COALESCE(ts.breachedByMinutes, 0) >= (0 - :breachInMinutes)))) " +
             "AND ((:assignedTo IS NULL AND :assignedBy IS NULL AND :requestorId IS NULL AND :createdBy IS NULL) " +
             "OR (:assignedTo IS NOT NULL AND (LOWER(t.assignedTo) = LOWER(:assignedTo) OR (:alternateAssignedTo IS NOT NULL AND LOWER(t.assignedTo) = LOWER(:alternateAssignedTo)))) " +
             "OR (:assignedBy IS NOT NULL AND LOWER(t.assignedBy) = LOWER(:assignedBy)) " +

--- a/api/src/main/java/com/ticketingSystem/api/repository/TicketRepository.java
+++ b/api/src/main/java/com/ticketingSystem/api/repository/TicketRepository.java
@@ -431,6 +431,9 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
             "AND (:districtCode IS NULL OR t.districtCode = :districtCode) " +
             "AND (:issueTypeId IS NULL OR t.issueTypeId = :issueTypeId) " +
             "AND (:divisionId IS NULL OR t.division = :divisionId) " +
+            "AND (:breachOption IS NULL " +
+            "OR (:breachOption = 'BREACHED' AND EXISTS (SELECT 1 FROM TicketSla ts WHERE ts.ticket = t AND COALESCE(ts.breachedByMinutes, 0) >= 0)) " +
+            "OR (:breachOption = 'BREACH_IN' AND :breachInMinutes IS NOT NULL AND EXISTS (SELECT 1 FROM TicketSla ts WHERE ts.ticket = t AND COALESCE(ts.breachedByMinutes, 0) < 0 AND COALESCE(ts.breachedByMinutes, 0) >= (0 - :breachInMinutes)))) " +
             "AND ((:assignedTo IS NULL AND :assignedBy IS NULL AND :requestorId IS NULL AND :createdBy IS NULL) " +
             "OR (:assignedTo IS NOT NULL AND (LOWER(t.assignedTo) = LOWER(:assignedTo) OR (:alternateAssignedTo IS NOT NULL AND LOWER(t.assignedTo) = LOWER(:alternateAssignedTo)))) " +
             "OR (:assignedBy IS NOT NULL AND LOWER(t.assignedBy) = LOWER(:assignedBy)) " +
@@ -463,6 +466,8 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
                                @Param("districtCode") String districtCode,
                                @Param("issueTypeId") String issueTypeId,
                                @Param("divisionId") String divisionId,
+                               @Param("breachOption") String breachOption,
+                               @Param("breachInMinutes") Integer breachInMinutes,
                                @Param("dateParam") String dateParam,
                                @Param("fromDate") LocalDateTime fromDate,
                                @Param("toDate") LocalDateTime toDate,
@@ -481,6 +486,9 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
             "AND (:districtCode IS NULL OR t.districtCode = :districtCode) " +
             "AND (:issueTypeId IS NULL OR t.issueTypeId = :issueTypeId) " +
             "AND (:divisionId IS NULL OR t.division = :divisionId) " +
+            "AND (:breachOption IS NULL " +
+            "OR (:breachOption = 'BREACHED' AND EXISTS (SELECT 1 FROM TicketSla ts WHERE ts.ticket = t AND COALESCE(ts.breachedByMinutes, 0) >= 0)) " +
+            "OR (:breachOption = 'BREACH_IN' AND :breachInMinutes IS NOT NULL AND EXISTS (SELECT 1 FROM TicketSla ts WHERE ts.ticket = t AND COALESCE(ts.breachedByMinutes, 0) < 0 AND COALESCE(ts.breachedByMinutes, 0) >= (0 - :breachInMinutes)))) " +
             "AND ((:assignedTo IS NULL AND :assignedBy IS NULL AND :requestorId IS NULL AND :createdBy IS NULL) " +
             "OR (:assignedTo IS NOT NULL AND (LOWER(t.assignedTo) = LOWER(:assignedTo) OR (:alternateAssignedTo IS NOT NULL AND LOWER(t.assignedTo) = LOWER(:alternateAssignedTo)))) " +
             "OR (:assignedBy IS NOT NULL AND LOWER(t.assignedBy) = LOWER(:assignedBy)) " +
@@ -513,6 +521,8 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
                                    @Param("districtCode") String districtCode,
                                    @Param("issueTypeId") String issueTypeId,
                                    @Param("divisionId") String divisionId,
+                                   @Param("breachOption") String breachOption,
+                                   @Param("breachInMinutes") Integer breachInMinutes,
                                    @Param("dateParam") String dateParam,
                                    @Param("fromDate") LocalDateTime fromDate,
                                    @Param("toDate") LocalDateTime toDate);

--- a/api/src/main/java/com/ticketingSystem/api/service/TicketService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/TicketService.java
@@ -522,10 +522,22 @@ public class TicketService {
         };
     }
 
+    private String normalizeBreachOption(String breachOption) {
+        if (breachOption == null || breachOption.isBlank()) {
+            return null;
+        }
+
+        return switch (breachOption.trim().toUpperCase()) {
+            case "BREACHED", "BREACH_IN" -> breachOption.trim().toUpperCase();
+            default -> null;
+        };
+    }
+
     public Page<TicketDto> searchTickets(String query, String statusId, Boolean master,
                                          String assignedTo, String assignedBy, String requestorId, String levelId, String priority,
                                          String severity, String createdBy, String category, String subCategory,
                                          String zoneCode, String regionCode, String districtCode, String issueTypeId, String divisionId,
+                                         String breachOption, Integer breachInMinutes,
                                          String dateParam, String fromDate, String toDate, Pageable pageable) {
         ArrayList<String> statusIds = (statusId == null || statusId.isBlank())
                 ? null
@@ -568,6 +580,8 @@ public class TicketService {
 
         String alternateAssignedTo = resolveAlternateAssignedTo(assignedTo);
         String normalizedDateParam = normalizeDateParam(dateParam);
+        String normalizedBreachOption = normalizeBreachOption(breachOption);
+        Integer normalizedBreachInMinutes = breachInMinutes != null ? Math.max(0, breachInMinutes) : null;
         Page<Ticket> page = ticketRepository.searchTickets(
                 query,
                 statusIds,
@@ -587,6 +601,8 @@ public class TicketService {
                 districtCode,
                 issueTypeId,
                 divisionId,
+                normalizedBreachOption,
+                normalizedBreachInMinutes,
                 normalizedDateParam,
                 from,
                 to,
@@ -599,6 +615,7 @@ public class TicketService {
                                              String assignedTo, String assignedBy, String requestorId, String levelId, String priority,
                                              String severity, String createdBy, String category, String subCategory,
                                              String zoneCode, String regionCode, String districtCode, String issueTypeId, String divisionId,
+                                             String breachOption, Integer breachInMinutes,
                                              String dateParam, String fromDate, String toDate) {
         ArrayList<String> statusIds = (statusId == null || statusId.isBlank())
                 ? null
@@ -634,6 +651,8 @@ public class TicketService {
 
         String alternateAssignedTo = resolveAlternateAssignedTo(assignedTo);
         String normalizedDateParam = normalizeDateParam(dateParam);
+        String normalizedBreachOption = normalizeBreachOption(breachOption);
+        Integer normalizedBreachInMinutes = breachInMinutes != null ? Math.max(0, breachInMinutes) : null;
 
         return ticketRepository.searchTicketsList(
                         query,
@@ -654,6 +673,8 @@ public class TicketService {
                         districtCode,
                         issueTypeId,
                         divisionId,
+                        normalizedBreachOption,
+                        normalizedBreachInMinutes,
                         normalizedDateParam,
                         from,
                         to)

--- a/ui/src/components/AllTickets/TicketsList.tsx
+++ b/ui/src/components/AllTickets/TicketsList.tsx
@@ -255,12 +255,22 @@ const TicketsList: React.FC<TicketsListProps> = ({
         [districtsResponse],
     );
 
-    const issueTypeOptions: DropdownOption[] = useMemo(
-        () => [{ label: "All", value: "All" }, ...((issueTypesResponse as any)?.data ?? issueTypesResponse ?? []).map((issueType: any) => ({
-            label: issueType.issueTypeLabel ?? "",
-            value: String(issueType.issueTypeId ?? ""),
-        }))],
-        [issueTypesResponse],
+    const issueTypeOptions: DropdownOption[] = useMemo(() => {
+        const allIssueTypes = ((issueTypesResponse as any)?.data ?? issueTypesResponse ?? []) as any[];
+        const shouldRestrictToSlaEnabled = breachOption === "BREACHED" || breachOption === "BREACH_IN";
+        const filteredIssueTypes = shouldRestrictToSlaEnabled
+            ? allIssueTypes.filter((issueType: any) => issueType?.slaFlag === true || issueType?.slaFlag === 1 || issueType?.slaFlag === "1")
+            : allIssueTypes;
+
+        return [
+            { label: "All", value: "All" },
+            ...filteredIssueTypes.map((issueType: any) => ({
+                label: issueType.issueTypeLabel ?? "",
+                value: String(issueType.issueTypeId ?? ""),
+            })),
+        ];
+    },
+    [breachOption, issueTypesResponse],
     );
 
     const divisionOptions: DropdownOption[] = useMemo(
@@ -614,6 +624,18 @@ const TicketsList: React.FC<TicketsListProps> = ({
             setWorkflowMap(workflowData);
         }
     }, [workflowData]);
+
+    useEffect(() => {
+        if (selectedIssueType === "All") {
+            return;
+        }
+
+        const existsInOptions = issueTypeOptions.some((option) => option.value === selectedIssueType);
+        if (!existsInOptions) {
+            setSelectedIssueType("All");
+            setPage(1);
+        }
+    }, [issueTypeOptions, selectedIssueType]);
 
     useEffect(() => {
         callSearch();

--- a/ui/src/components/AllTickets/TicketsList.tsx
+++ b/ui/src/components/AllTickets/TicketsList.tsx
@@ -48,6 +48,9 @@ export interface TicketsListFilterState {
     selectedAssignee: string;
     selectedDivision: string;
     selectedDateParam: string;
+    breachOption: string;
+    breachInHours: number;
+    breachInMinutes: number;
     allowedStatuses?: string[];
 }
 
@@ -76,6 +79,8 @@ export interface TicketsListSearchOverrides {
     districtCode?: string;
     issueTypeId?: string;
     divisionId?: string;
+    breachOption?: string;
+    breachInMinutes?: number;
 }
 
 interface TicketsListProps {
@@ -192,6 +197,9 @@ const TicketsList: React.FC<TicketsListProps> = ({
     const [selectedIssueType, setSelectedIssueType] = useState<string>("All");
     const [selectedDivision, setSelectedDivision] = useState<string>("All");
     const [selectedAssignee, setSelectedAssignee] = useState<string>("All");
+    const [breachOption, setBreachOption] = useState<string>("All");
+    const [breachInHours, setBreachInHours] = useState<number>(0);
+    const [breachInMinutes, setBreachInMinutes] = useState<number>(0);
 
     const debouncedSearch = useDebounce(search, 300);
 
@@ -288,6 +296,9 @@ const TicketsList: React.FC<TicketsListProps> = ({
         setSelectedIssueType("All");
         setSelectedDivision("All");
         setSelectedAssignee("All");
+        setBreachOption("All");
+        setBreachInHours(0);
+        setBreachInMinutes(0);
         setPage(1);
         resetSubCategories();
         loadSubCategories();
@@ -320,6 +331,9 @@ const TicketsList: React.FC<TicketsListProps> = ({
             selectedAssignee,
             selectedDivision,
             selectedDateParam,
+            breachOption,
+            breachInHours,
+            breachInMinutes,
         }),
         [
             search,
@@ -338,6 +352,9 @@ const TicketsList: React.FC<TicketsListProps> = ({
             selectedAssignee,
             selectedDivision,
             selectedDateParam,
+            breachOption,
+            breachInHours,
+            breachInMinutes,
         ],
     );
 
@@ -386,6 +403,13 @@ const TicketsList: React.FC<TicketsListProps> = ({
             const issueTypeParam = mergedOverrides.issueTypeId ?? normalizedIssueType;
             const assignedToParam = mergedOverrides.assignedTo ?? normalizedAssignee;
             const divisionParam = mergedOverrides.divisionId ?? normalizedDivision;
+            const breachOptionParam = mergedOverrides.breachOption ?? (breachOption === "All" ? undefined : breachOption);
+            const computedBreachInMinutes = Math.max(0, (breachInHours * 60) + breachInMinutes);
+            const breachInMinutesParam = mergedOverrides.breachInMinutes ?? (
+                breachOptionParam === "BREACH_IN" && computedBreachInMinutes > 0
+                    ? computedBreachInMinutes
+                    : undefined
+            );
 
             return searchTicketsPaginatedApiHandler(() => {
                 console.log({ allowedStatusSuccess })
@@ -413,6 +437,8 @@ const TicketsList: React.FC<TicketsListProps> = ({
                     districtParam,
                     issueTypeParam,
                     divisionParam,
+                    breachOptionParam,
+                    breachInMinutesParam,
                 )
             }
             );
@@ -435,6 +461,9 @@ const TicketsList: React.FC<TicketsListProps> = ({
             normalizedIssueType,
             normalizedDivision,
             normalizedAssignee,
+            breachOption,
+            breachInHours,
+            breachInMinutes,
             page,
             pageSize,
             sortBy,
@@ -495,6 +524,15 @@ const TicketsList: React.FC<TicketsListProps> = ({
 
     const handleDivisionChange = (value: string) => {
         setSelectedDivision(value);
+        setPage(1);
+    };
+
+    const handleBreachOptionChange = (value: string) => {
+        setBreachOption(value);
+        if (value !== "BREACH_IN") {
+            setBreachInHours(0);
+            setBreachInMinutes(0);
+        }
         setPage(1);
     };
 
@@ -598,6 +636,9 @@ const TicketsList: React.FC<TicketsListProps> = ({
         selectedIssueType,
         selectedDivision,
         selectedAssignee,
+        breachOption,
+        breachInHours,
+        breachInMinutes,
         allowedStatusSuccess,
     ]);
 
@@ -720,6 +761,48 @@ const TicketsList: React.FC<TicketsListProps> = ({
                         value={selectedAssignee}
                         onChange={handleAssigneeChange}
                     />
+
+                    <DropdownController
+                        label="Breach Option"
+                        value={breachOption}
+                        className="col-3 px-1"
+                        onChange={handleBreachOptionChange}
+                        options={[
+                            { label: "All", value: "All" },
+                            { label: "Breached", value: "BREACHED" },
+                            { label: "Breach In", value: "BREACH_IN" },
+                        ]}
+                    />
+
+                    {breachOption === "BREACH_IN" && (
+                        <>
+                            <GenericInput
+                                label="Breach In (Hours)"
+                                className="col-3 px-1"
+                                type="number"
+                                value={String(breachInHours)}
+                                onChange={(e) => {
+                                    const nextVal = Number(e.target.value);
+                                    setBreachInHours(Number.isFinite(nextVal) ? Math.max(0, Math.floor(nextVal)) : 0);
+                                    setPage(1);
+                                }}
+                                placeholder="0"
+                            />
+                            <GenericInput
+                                label="Breach In (Minutes)"
+                                className="col-3 px-1"
+                                type="number"
+                                value={String(breachInMinutes)}
+                                onChange={(e) => {
+                                    const nextVal = Number(e.target.value);
+                                    const normalized = Number.isFinite(nextVal) ? Math.max(0, Math.floor(nextVal)) : 0;
+                                    setBreachInMinutes(Math.min(59, normalized));
+                                    setPage(1);
+                                }}
+                                placeholder="0"
+                            />
+                        </>
+                    )}
 
                     <DropdownController
                         label={t("Date Parameter")}

--- a/ui/src/services/TicketService.ts
+++ b/ui/src/services/TicketService.ts
@@ -118,6 +118,8 @@ export function searchTicketsPaginated(
     districtCode?: string,
     issueTypeId?: string,
     divisionId?: string,
+    breachOption?: string,
+    breachInMinutes?: number,
 ) {
     const params = new URLSearchParams({ query, page: String(page), size: String(size) });
     if (statusName) params.append('status', statusName);
@@ -140,6 +142,8 @@ export function searchTicketsPaginated(
     if (districtCode) params.append('districtCode', districtCode);
     if (issueTypeId) params.append('issueTypeId', issueTypeId);
     if (divisionId) params.append('divisionId', divisionId);
+    if (breachOption) params.append('breachOption', breachOption);
+    if (breachInMinutes !== undefined) params.append('breachInMinutes', String(breachInMinutes));
     return axios.get(`${BASE_URL}/tickets/search?${params.toString()}`);
 }
 


### PR DESCRIPTION
### Motivation
- Enable searching and exporting tickets based on SLA breach status and upcoming breaches within a time window to support SLA monitoring and reporting. 
- Surface breach controls in the tickets UI so users can filter for already-breached tickets or those breaching within a configured number of minutes. 

### Description
- Added two new query parameters `breachOption` and `breachInMinutes` to the tickets REST endpoints (`/tickets/search` and `/tickets/search/export`) and updated controller logging to include them. 
- Extended repository queries (`searchTickets` and `searchTicketsList`) to apply breach filtering using an EXISTS subquery on `TicketSla` and `breachedByMinutes` to support `BREACHED` and `BREACH_IN` semantics. 
- Wired parameters through the service layer with input normalization via `normalizeBreachOption`, sanitization of `breachInMinutes`, and propagation to repository calls. 
- Updated frontend list UI to add `Breach Option` dropdown and conditional inputs for `Breach In (Hours)` and `Breach In (Minutes)`, converted to total minutes and passed to the API, and updated client API helper `searchTicketsPaginated` to append the new params. 

### Testing
- Ran backend unit and integration tests with `mvn test` and verified the test suite completed successfully. 
- Built and ran frontend checks with `yarn test` and `yarn build` and confirmed the frontend tests and build succeeded. 
- Manually exercised the new UI filters against the API in a local environment to confirm the parameters are sent and results filtered as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c13e9774d483328ad14f1a4528453a)