### PR TITLE
Make Nagios ticket SLA endpoint public (remove credential validation)

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/controller/NagiosMonitoringController.java
+++ b/api/src/main/java/com/ticketingSystem/api/controller/NagiosMonitoringController.java
@@ -3,7 +3,6 @@ package com.ticketingSystem.api.controller;
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaRequestDto;
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaSnapshotDto;
 import com.ticketingSystem.api.service.NagiosTicketSlaService;
-import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,7 +18,8 @@ public class NagiosMonitoringController {
     }
 
     @PostMapping("/ticket-sla")
-    public NagiosTicketSlaSnapshotDto getTicketSlaSnapshot(@RequestBody @Valid NagiosTicketSlaRequestDto request) {
-        return nagiosTicketSlaService.fetchSnapshot(request);
+    public NagiosTicketSlaSnapshotDto getTicketSlaSnapshot(@RequestBody(required = false) NagiosTicketSlaRequestDto request) {
+        Integer limit = request != null ? request.getLimit() : null;
+        return nagiosTicketSlaService.fetchSnapshot(limit);
     }
 }

--- a/api/src/main/java/com/ticketingSystem/api/dto/nagios/NagiosTicketSlaRequestDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/nagios/NagiosTicketSlaRequestDto.java
@@ -1,31 +1,7 @@
 package com.ticketingSystem.api.dto.nagios;
 
-import jakarta.validation.constraints.NotBlank;
-
 public class NagiosTicketSlaRequestDto {
-    @NotBlank
-    private String clientId;
-
-    @NotBlank
-    private String clientSecret;
-
     private Integer limit;
-
-    public String getClientId() {
-        return clientId;
-    }
-
-    public void setClientId(String clientId) {
-        this.clientId = clientId;
-    }
-
-    public String getClientSecret() {
-        return clientSecret;
-    }
-
-    public void setClientSecret(String clientSecret) {
-        this.clientSecret = clientSecret;
-    }
 
     public Integer getLimit() {
         return limit;

--- a/api/src/main/java/com/ticketingSystem/api/service/NagiosTicketSlaService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/NagiosTicketSlaService.java
@@ -1,16 +1,13 @@
 package com.ticketingSystem.api.service;
 
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaRecordDto;
-import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaRequestDto;
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaSnapshotDto;
 import com.ticketingSystem.api.models.Ticket;
 import com.ticketingSystem.api.models.TicketSla;
 import com.ticketingSystem.api.repository.TicketSlaRepository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -23,18 +20,13 @@ public class NagiosTicketSlaService {
     private static final int DEFAULT_RECORD_LIMIT = 200;
 
     private final TicketSlaRepository ticketSlaRepository;
-    private final ClientCredentialService clientCredentialService;
 
-    public NagiosTicketSlaService(TicketSlaRepository ticketSlaRepository,
-                                  ClientCredentialService clientCredentialService) {
+    public NagiosTicketSlaService(TicketSlaRepository ticketSlaRepository) {
         this.ticketSlaRepository = ticketSlaRepository;
-        this.clientCredentialService = clientCredentialService;
     }
 
-    public NagiosTicketSlaSnapshotDto fetchSnapshot(NagiosTicketSlaRequestDto request) {
-        validateCredentials(request.getClientId(), request.getClientSecret());
-
-        int normalizedLimit = normalizeLimit(request.getLimit());
+    public NagiosTicketSlaSnapshotDto fetchSnapshot(Integer limit) {
+        int normalizedLimit = normalizeLimit(limit);
         List<TicketSla> ticketSlas = ticketSlaRepository.findAll(PageRequest.of(0, normalizedLimit, Sort.by(Sort.Direction.DESC, "dueAt")))
                 .getContent();
 
@@ -50,13 +42,6 @@ public class NagiosTicketSlaService {
                 ticketSlas.size(),
                 ticketSlas.stream().map(this::toRecord).toList()
         );
-    }
-
-    private void validateCredentials(String clientId, String clientSecret) {
-        boolean valid = clientCredentialService.authenticate(clientId, clientSecret).isPresent();
-        if (!valid) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid client credentials");
-        }
     }
 
     private BigDecimal calculateCompliance(long totalRecords, long breachedRecords) {

--- a/api/src/test/java/com/ticketingSystem/api/controller/NagiosMonitoringControllerTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/controller/NagiosMonitoringControllerTest.java
@@ -19,7 +19,8 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -58,11 +59,9 @@ class NagiosMonitoringControllerTest {
                 List.of()
         );
         NagiosTicketSlaRequestDto request = new NagiosTicketSlaRequestDto();
-        request.setClientId("nagios-client");
-        request.setClientSecret("nagios-secret");
         request.setLimit(25);
 
-        when(nagiosTicketSlaService.fetchSnapshot(any(NagiosTicketSlaRequestDto.class))).thenReturn(dto);
+        when(nagiosTicketSlaService.fetchSnapshot(eq(25))).thenReturn(dto);
 
         mockMvc.perform(post("/ext/nagios/ticket-sla")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -72,5 +71,25 @@ class NagiosMonitoringControllerTest {
                 .andExpect(jsonPath("$.totalRecords").value(10))
                 .andExpect(jsonPath("$.breachedRecords").value(2))
                 .andExpect(jsonPath("$.compliancePercentage").value(80.0));
+    }
+
+    @Test
+    void getTicketSlaSnapshotAllowsMissingBody() throws Exception {
+        NagiosTicketSlaSnapshotDto dto = new NagiosTicketSlaSnapshotDto(
+                "ticketing-system",
+                Instant.parse("2026-03-31T10:15:30Z"),
+                0L,
+                0L,
+                BigDecimal.valueOf(100.0),
+                0,
+                List.of()
+        );
+
+        when(nagiosTicketSlaService.fetchSnapshot(isNull())).thenReturn(dto);
+
+        mockMvc.perform(post("/ext/nagios/ticket-sla")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.service").value("ticketing-system"));
     }
 }

--- a/api/src/test/java/com/ticketingSystem/api/service/NagiosTicketSlaServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/NagiosTicketSlaServiceTest.java
@@ -1,8 +1,6 @@
 package com.ticketingSystem.api.service;
 
-import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaRequestDto;
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaSnapshotDto;
-import com.ticketingSystem.api.models.ClientCredential;
 import com.ticketingSystem.api.models.Ticket;
 import com.ticketingSystem.api.models.TicketSla;
 import com.ticketingSystem.api.models.TicketStatus;
@@ -15,13 +13,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -31,14 +26,11 @@ class NagiosTicketSlaServiceTest {
     @Mock
     private TicketSlaRepository ticketSlaRepository;
 
-    @Mock
-    private ClientCredentialService clientCredentialService;
-
     @InjectMocks
     private NagiosTicketSlaService nagiosTicketSlaService;
 
     @Test
-    void fetchSnapshotReturnsMappedResponseWhenCredentialsAreValid() {
+    void fetchSnapshotReturnsMappedResponse() {
         Ticket ticket = new Ticket();
         ticket.setId("ticket-id");
         ticket.setTicketNumber("T-123");
@@ -52,18 +44,12 @@ class NagiosTicketSlaServiceTest {
         ticketSla.setResolutionTimeMinutes(100L);
 
         Page<TicketSla> page = new PageImpl<>(List.of(ticketSla));
-        NagiosTicketSlaRequestDto request = new NagiosTicketSlaRequestDto();
-        request.setClientId("nagios-client");
-        request.setClientSecret("nagios-secret");
-        request.setLimit(10);
 
-        when(clientCredentialService.authenticate("nagios-client", "nagios-secret"))
-                .thenReturn(Optional.of(new ClientCredential()));
         when(ticketSlaRepository.findAll(any(Pageable.class))).thenReturn(page);
         when(ticketSlaRepository.count()).thenReturn(10L);
         when(ticketSlaRepository.countByBreachedByMinutesGreaterThan(0L)).thenReturn(2L);
 
-        NagiosTicketSlaSnapshotDto snapshot = nagiosTicketSlaService.fetchSnapshot(request);
+        NagiosTicketSlaSnapshotDto snapshot = nagiosTicketSlaService.fetchSnapshot(10);
 
         assertThat(snapshot.totalRecords()).isEqualTo(10L);
         assertThat(snapshot.breachedRecords()).isEqualTo(2L);
@@ -74,16 +60,16 @@ class NagiosTicketSlaServiceTest {
     }
 
     @Test
-    void fetchSnapshotRejectsInvalidCredentials() {
-        NagiosTicketSlaRequestDto request = new NagiosTicketSlaRequestDto();
-        request.setClientId("nagios-client");
-        request.setClientSecret("wrong");
+    void fetchSnapshotUsesDefaultLimitWhenNotProvided() {
+        Page<TicketSla> page = new PageImpl<>(List.of());
 
-        when(clientCredentialService.authenticate("nagios-client", "wrong"))
-                .thenReturn(Optional.empty());
+        when(ticketSlaRepository.findAll(any(Pageable.class))).thenReturn(page);
+        when(ticketSlaRepository.count()).thenReturn(0L);
+        when(ticketSlaRepository.countByBreachedByMinutesGreaterThan(0L)).thenReturn(0L);
 
-        assertThatThrownBy(() -> nagiosTicketSlaService.fetchSnapshot(request))
-                .isInstanceOf(ResponseStatusException.class)
-                .hasMessageContaining("401 UNAUTHORIZED");
+        NagiosTicketSlaSnapshotDto snapshot = nagiosTicketSlaService.fetchSnapshot(null);
+
+        assertThat(snapshot.totalRecords()).isZero();
+        assertThat(snapshot.compliancePercentage().doubleValue()).isEqualTo(100.0d);
     }
 }


### PR DESCRIPTION
### Motivation
- Allow external Nagios to call the ticket SLA endpoint as a public API without providing `clientId`/`clientSecret` so users can first verify data availability. 
- Simplify the request shape to a single optional `limit` so callers can optionally control paging without needing credentials.

### Description
- Removed client credential validation from `NagiosTicketSlaService` and changed its `fetchSnapshot` signature to accept an `Integer limit` rather than a DTO with credentials. 
- Simplified `NagiosTicketSlaRequestDto` to only contain an optional `limit` and removed credential fields and validation annotations. 
- Updated `NagiosMonitoringController` to accept an optional request body (`@RequestBody(required = false)`) and pass the `limit` to the service so the endpoint can be invoked with no body. 
- Updated unit tests (`NagiosTicketSlaServiceTest` and `NagiosMonitoringControllerTest`) to reflect the unauthenticated flow and added a controller test that verifies the endpoint works with a missing body.

### Testing
- Ran unit tests for the modified classes with `cd /workspace/TicketingSystem/api && ./gradlew test --tests "com.ticketingSystem.api.service.NagiosTicketSlaServiceTest" --tests "com.ticketingSystem.api.controller.NagiosMonitoringControllerTest"`. 
- Tests could not be executed in this environment due to a build error: `Unsupported class file major version 69`, so the updated tests compile/run couldn't be verified here. 
- Existing and updated unit test logic targets successful unauthenticated responses and default limit behavior (tests updated accordingly).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df27293ba88332ad9fab5ead878960)