### PR TITLE
Add public Nagios SLA summary endpoint with aggregate metrics

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/controller/NagiosMonitoringController.java
+++ b/api/src/main/java/com/ticketingSystem/api/controller/NagiosMonitoringController.java
@@ -2,8 +2,12 @@ package com.ticketingSystem.api.controller;
 
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaRequestDto;
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaSnapshotDto;
+import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaSummaryDto;
 import com.ticketingSystem.api.service.NagiosTicketSlaService;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/public/nagios")
@@ -24,5 +28,12 @@ public class NagiosMonitoringController {
     public NagiosTicketSlaSnapshotDto getTicketSlaSnapshot() {
 //        Integer limit = request != null ? request.getLimit() : null;
         return nagiosTicketSlaService.fetchSnapshot(50);
+    }
+
+    @GetMapping("/ticket-sla/summary")
+    public NagiosTicketSlaSummaryDto getTicketSlaSummary(
+            @RequestParam(value = "fromDate", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fromDate,
+            @RequestParam(value = "toDate", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate toDate) {
+        return nagiosTicketSlaService.fetchSummary(fromDate, toDate);
     }
 }

--- a/api/src/main/java/com/ticketingSystem/api/dto/nagios/NagiosTicketSlaSummaryAggregateDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/nagios/NagiosTicketSlaSummaryAggregateDto.java
@@ -1,0 +1,12 @@
+package com.ticketingSystem.api.dto.nagios;
+
+import java.time.LocalDateTime;
+
+public record NagiosTicketSlaSummaryAggregateDto(long totalTickets,
+                                                 long breachedTickets,
+                                                 Double averageResolutionTimeMinutes,
+                                                 Double averageResponseTimeMinutes,
+                                                 Double averageBreachMinutes,
+                                                 LocalDateTime minReportedDate,
+                                                 LocalDateTime maxReportedDate) {
+}

--- a/api/src/main/java/com/ticketingSystem/api/dto/nagios/NagiosTicketSlaSummaryDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/nagios/NagiosTicketSlaSummaryDto.java
@@ -1,0 +1,19 @@
+package com.ticketingSystem.api.dto.nagios;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDateTime;
+
+public record NagiosTicketSlaSummaryDto(String service,
+                                        Instant generatedAt,
+                                        LocalDateTime fromDate,
+                                        LocalDateTime toDate,
+                                        long totalTickets,
+                                        long breachedTickets,
+                                        long nonBreachedTickets,
+                                        BigDecimal breachPercentage,
+                                        BigDecimal compliancePercentage,
+                                        BigDecimal averageResolutionTimeMinutes,
+                                        BigDecimal averageResponseTimeMinutes,
+                                        BigDecimal averageBreachMinutes) {
+}

--- a/api/src/main/java/com/ticketingSystem/api/repository/TicketSlaRepository.java
+++ b/api/src/main/java/com/ticketingSystem/api/repository/TicketSlaRepository.java
@@ -1,10 +1,13 @@
 package com.ticketingSystem.api.repository;
 
+import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaSummaryAggregateDto;
 import com.ticketingSystem.api.models.TicketSla;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,6 +20,24 @@ public interface TicketSlaRepository extends JpaRepository<TicketSla, String> {
 
     @Query("SELECT DISTINCT sla FROM TicketSla sla LEFT JOIN FETCH sla.ticket WHERE sla.breachedByMinutes IS NOT NULL AND sla.breachedByMinutes > 0")
     List<TicketSla> findBreachedWithTicket();
+
+    @Query("""
+            SELECT new com.ticketingSystem.api.dto.nagios.NagiosTicketSlaSummaryAggregateDto(
+                COUNT(sla),
+                COALESCE(SUM(CASE WHEN COALESCE(sla.breachedByMinutes, 0) > 0 THEN 1 ELSE 0 END), 0),
+                AVG(sla.resolutionTimeMinutes),
+                AVG(sla.responseTimeMinutes),
+                AVG(CASE WHEN COALESCE(sla.breachedByMinutes, 0) > 0 THEN sla.breachedByMinutes ELSE NULL END),
+                MIN(t.reportedDate),
+                MAX(t.reportedDate)
+            )
+            FROM TicketSla sla
+            JOIN sla.ticket t
+            WHERE (:fromDate IS NULL OR t.reportedDate >= :fromDate)
+              AND t.reportedDate < :toDateExclusive
+            """)
+    NagiosTicketSlaSummaryAggregateDto fetchSummary(@Param("fromDate") LocalDateTime fromDate,
+                                                    @Param("toDateExclusive") LocalDateTime toDateExclusive);
 
     long countByBreachedByMinutesGreaterThan(Long breachedByMinutes);
 }

--- a/api/src/main/java/com/ticketingSystem/api/service/NagiosTicketSlaService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/NagiosTicketSlaService.java
@@ -2,6 +2,8 @@ package com.ticketingSystem.api.service;
 
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaRecordDto;
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaSnapshotDto;
+import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaSummaryAggregateDto;
+import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaSummaryDto;
 import com.ticketingSystem.api.models.Ticket;
 import com.ticketingSystem.api.models.TicketSla;
 import com.ticketingSystem.api.repository.TicketSlaRepository;
@@ -12,6 +14,8 @@ import org.springframework.stereotype.Service;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -44,6 +48,42 @@ public class NagiosTicketSlaService {
         );
     }
 
+    public NagiosTicketSlaSummaryDto fetchSummary(LocalDate fromDate, LocalDate toDate) {
+        LocalDate effectiveToDate = toDate != null ? toDate : LocalDate.now();
+        LocalDateTime fromDateTime = fromDate != null ? fromDate.atStartOfDay() : null;
+        LocalDateTime toDateInclusive = effectiveToDate.atTime(23, 59, 59);
+        LocalDateTime toDateExclusive = effectiveToDate.plusDays(1).atStartOfDay();
+
+        NagiosTicketSlaSummaryAggregateDto aggregate = ticketSlaRepository.fetchSummary(fromDateTime, toDateExclusive);
+
+        long totalTickets = aggregate.totalTickets();
+        long breachedTickets = aggregate.breachedTickets();
+        long nonBreachedTickets = Math.max(totalTickets - breachedTickets, 0);
+
+        BigDecimal breachPercentage = calculatePercentage(breachedTickets, totalTickets);
+        BigDecimal compliancePercentage = calculatePercentage(nonBreachedTickets, totalTickets);
+
+        LocalDateTime responseFromDate = fromDateTime != null ? fromDateTime : aggregate.minReportedDate();
+        if (responseFromDate == null) {
+            responseFromDate = toDateInclusive;
+        }
+
+        return new NagiosTicketSlaSummaryDto(
+                "ticketing-system",
+                Instant.now(),
+                responseFromDate,
+                toDateInclusive,
+                totalTickets,
+                breachedTickets,
+                nonBreachedTickets,
+                breachPercentage,
+                compliancePercentage,
+                toBigDecimal(aggregate.averageResolutionTimeMinutes()),
+                toBigDecimal(aggregate.averageResponseTimeMinutes()),
+                toBigDecimal(aggregate.averageBreachMinutes())
+        );
+    }
+
     private BigDecimal calculateCompliance(long totalRecords, long breachedRecords) {
         if (totalRecords == 0) {
             return BigDecimal.valueOf(100);
@@ -52,6 +92,22 @@ public class NagiosTicketSlaService {
                 .multiply(BigDecimal.valueOf(100))
                 .divide(BigDecimal.valueOf(totalRecords), 2, RoundingMode.HALF_UP);
         return compliant.max(BigDecimal.ZERO);
+    }
+
+    private BigDecimal calculatePercentage(long numerator, long denominator) {
+        if (denominator <= 0) {
+            return BigDecimal.ZERO;
+        }
+        return BigDecimal.valueOf(numerator)
+                .multiply(BigDecimal.valueOf(100))
+                .divide(BigDecimal.valueOf(denominator), 2, RoundingMode.HALF_UP);
+    }
+
+    private BigDecimal toBigDecimal(Double value) {
+        if (value == null) {
+            return BigDecimal.ZERO;
+        }
+        return BigDecimal.valueOf(value).setScale(2, RoundingMode.HALF_UP);
     }
 
     private NagiosTicketSlaRecordDto toRecord(TicketSla ticketSla) {


### PR DESCRIPTION
### Motivation
- Provide a lightweight controller method that returns SLA summary metrics for monitoring without fetching all ticket SLA records.
- Return total tickets, date range, breached count, breach percentage, non-breached count and average times so external systems (Nagios) can consume a single aggregated payload.
- Default `toDate` to the current date to make ad-hoc polling simpler.

### Description
- Added a new public endpoint `GET /public/nagios/ticket-sla/summary` that accepts optional `fromDate` and `toDate` query parameters (ISO `yyyy-MM-dd`) and delegates to `NagiosTicketSlaService.fetchSummary(...)`.
- Introduced response DTOs `NagiosTicketSlaSummaryDto` and `NagiosTicketSlaSummaryAggregateDto` to model the summary payload and the DB-aggregate projection respectively.
- Added a DB-level aggregate query `TicketSlaRepository.fetchSummary(...)` that computes total tickets, breached tickets, average resolution/response/breach minutes and min/max reported dates for the requested range.
- Implemented `NagiosTicketSlaService.fetchSummary(...)` to normalize date bounds, call the aggregate repo method, compute breach/compliance percentages and format averages for the API response.

### Testing
- Attempted to compile the API module with `./api/gradlew -p api compileJava`, which failed due to an environment/toolchain mismatch (`Unsupported class file major version 69`).
- No other automated tests were executed in this environment due to the compile/tooling failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df419626a88332a1bd6fddffdbc932)