### PR TITLE
Close child ticket and record history when linking to master; show master status in UI

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/service/TicketService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/TicketService.java
@@ -1612,14 +1612,47 @@ public class TicketService {
             return mapWithStatusId(ticket);
         }
 
+        String previousStatusId = resolveCurrentStatusId(ticket);
+        String closedStatusId = workflowService.getStatusIdByCode(TicketStatus.CLOSED.name());
         ticket.setMasterId(masterId);
+        ticket.setTicketStatus(TicketStatus.CLOSED);
+        if (closedStatusId != null && !closedStatusId.isBlank()) {
+            statusMasterRepository.findById(closedStatusId).ifPresent(ticket::setStatus);
+        }
+        if (ticket.getFeedbackStatus() == null) {
+            ticket.setFeedbackStatus(FeedbackStatus.PENDING);
+        }
         if (updatedBy != null && !updatedBy.isBlank()) {
             ticket.setUpdatedBy(updatedBy);
         }
         ticket.setLastModified(LocalDateTime.now());
+        ticket.setLastModifiedStatusDate(LocalDateTime.now());
 
         Ticket saved = ticketRepository.save(ticket);
-        addLinkingHistory(saved, updatedBy, String.format("Linked to master ticket %s", masterId));
+        String actor = updatedBy != null && !updatedBy.isBlank() ? updatedBy : saved.getUpdatedBy();
+        assignmentHistoryService.addHistory(
+                saved.getId(),
+                actor,
+                saved.getAssignedTo(),
+                saved.getLevelId(),
+                String.format("Linked to master ticket %s", masterId)
+        );
+
+        String currentStatusId = resolveCurrentStatusId(saved);
+        Boolean slaFlag = currentStatusId != null
+                ? workflowService.getSlaFlagByStatusAndIssueType(currentStatusId, saved.getIssueTypeId())
+                : null;
+        String fromStatusId = previousStatusId != null ? previousStatusId : currentStatusId;
+        String toStatusId = currentStatusId != null ? currentStatusId : previousStatusId;
+        statusHistoryService.addHistory(
+                saved.getId(),
+                actor,
+                fromStatusId,
+                toStatusId,
+                slaFlag,
+                "duplicate/related"
+        );
+
         runNotificationAfterCommit(() -> sendRequestorMasterLinkNotification(saved, masterTicket, updatedBy));
         return mapWithStatusId(saved);
     }

--- a/api/src/test/java/com/ticketingSystem/api/service/TicketServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/TicketServiceTest.java
@@ -706,6 +706,54 @@ class TicketServiceTest {
         verify(ticketRepository).save(existing);
     }
 
+    @Test
+    void linkToMaster_closesChildTicket_andAddsDuplicateRelatedRemarkInStatusHistory() {
+        String childId = "T-CHILD";
+        String masterId = "T-MASTER";
+
+        Ticket child = buildExistingTicket(childId, "agent1");
+        child.setIssueTypeId("ISSUE-1");
+        child.setFeedbackStatus(null);
+        child.setMaster(false);
+
+        Ticket master = buildExistingTicket(masterId, "agent2");
+        master.setMaster(true);
+
+        Status closedStatus = new Status();
+        closedStatus.setStatusId("CLOSED_ID");
+        closedStatus.setStatusCode(TicketStatus.CLOSED.name());
+        closedStatus.setStatusName("Closed");
+        closedStatus.setLabel("Closed");
+
+        when(ticketRepository.findById(childId)).thenReturn(Optional.of(child));
+        when(ticketRepository.findById(masterId)).thenReturn(Optional.of(master));
+        when(workflowService.getStatusIdByCode(TicketStatus.CLOSED.name())).thenReturn("CLOSED_ID");
+        when(statusMasterRepository.findById("CLOSED_ID")).thenReturn(Optional.of(closedStatus));
+        when(workflowService.getSlaFlagByStatusAndIssueType("CLOSED_ID", "ISSUE-1")).thenReturn(Boolean.FALSE);
+        when(ticketRepository.save(any(Ticket.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        TicketDto result = ticketService.linkToMaster(childId, masterId, "agent-linker");
+
+        assertThat(result.getMasterId()).isEqualTo(masterId);
+        assertThat(result.getTicketStatus()).isEqualTo(TicketStatus.CLOSED);
+
+        verify(statusHistoryService).addHistory(
+                eq(childId),
+                eq("agent-linker"),
+                eq("OPEN_ID"),
+                eq("CLOSED_ID"),
+                eq(Boolean.FALSE),
+                eq("duplicate/related")
+        );
+        verify(assignmentHistoryService).addHistory(
+                eq(childId),
+                eq("agent-linker"),
+                eq("agent1"),
+                eq("L1"),
+                eq("Linked to master ticket T-MASTER")
+        );
+    }
+
     private Ticket buildExistingTicket(String ticketId, String assignee) {
         Ticket ticket = new Ticket();
         ticket.setId(ticketId);

--- a/ui/src/components/TicketView/TicketView.tsx
+++ b/ui/src/components/TicketView/TicketView.tsx
@@ -161,6 +161,7 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
   const [uploadKey, setUploadKey] = useState(0);
   const [sla, setSla] = useState<TicketSla | null>(null);
   const [masterSla, setMasterSla] = useState<TicketSla | null>(null);
+  const [masterTicketStatus, setMasterTicketStatus] = useState<string>('');
   const [feedbackOpen, setFeedbackOpen] = useState(false);
   const [hasFeedback, setHasFeedback] = useState(false);
   // const [statusWorkflows, setStatusWorkflows] = useState<Record<string, TicketStatusWorkflow[]>>({});
@@ -531,8 +532,17 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
     const masterTicketId = ticket?.masterId;
     if (!masterTicketId || masterTicketId === ticketId) {
       setMasterSla(prev => (prev === null ? prev : null));
+      setMasterTicketStatus('');
       return;
     }
+
+    getTicket(masterTicketId)
+      .then(res => {
+        const payload = res.data?.body?.data ?? res.data;
+        const status = payload?.statusLabel || payload?.statusName || payload?.ticketStatus || '';
+        setMasterTicketStatus(status);
+      })
+      .catch(() => setMasterTicketStatus(''));
 
     getTicketSla(masterTicketId)
       .then(res => {
@@ -1127,7 +1137,22 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
             sx={{ mb: 2, cursor: 'pointer' }}
             onClick={() => navigate(`/tickets/${ticket.masterId}`)}
           >
-            Linked to master ticket ID {ticket.masterId}. Click to view master ticket.
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+              <Typography variant="body2">
+                Linked to master ticket ID {ticket.masterId}. Click to view master ticket.
+              </Typography>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+                <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                  Master Ticket Status:
+                </Typography>
+                <Chip
+                  label={masterTicketStatus || 'N/A'}
+                  color="warning"
+                  size="small"
+                  sx={{ fontWeight: 700, letterSpacing: 0.3 }}
+                />
+              </Box>
+            </Box>
           </Alert>
         )
       }


### PR DESCRIPTION
### Motivation

- Ensure that when a ticket is linked to a master it is closed and its state is recorded consistently for SLA and audit purposes.
- Record assignment and status transition history entries for traceability when linking a child ticket to a master.
- Surface the master ticket's current status in the ticket view to give quick visibility to agents.

### Description

- Updated `TicketService.linkToMaster` to set the child `masterId`, force `ticketStatus` to `CLOSED`, set the concrete closed `Status` via `workflowService.getStatusIdByCode`, set `feedbackStatus` to `PENDING` when null, and update `lastModifiedStatusDate` before saving.
- Replaced the old linking history call with `assignmentHistoryService.addHistory` to record the linking action and added `statusHistoryService.addHistory` to log the status transition with the SLA flag resolved via `workflowService.getSlaFlagByStatusAndIssueType` and using `resolveCurrentStatusId` for from/to resolution.
- Kept sending the requestor master-link notification via `runNotificationAfterCommit`, and preserved saving behavior through `ticketRepository.save(...)`.
- Added UI changes in `TicketView.tsx` to maintain a `masterTicketStatus` state, fetch the master ticket via `getTicket(...)`, and display the master status in the master-link `Alert` as a `Chip`.

### Testing

- Added unit test `linkToMaster_closesChildTicket_andAddsDuplicateRelatedRemarkInStatusHistory` in `TicketServiceTest` and ran `TicketServiceTest`, which validated that the child ticket is closed and both `assignmentHistoryService.addHistory` and `statusHistoryService.addHistory` are invoked; the test passed.
- Existing unit `markAsMaster_setsMasterFlagsAndClearsMasterId` was run and passed as part of the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e07cb8a93483329749ebb0c7506128)