### PR TITLE
Enhance Nagios ticket SLA summary APIs with severity and detailed breakdown metrics

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/controller/NagiosMonitoringController.java
+++ b/api/src/main/java/com/ticketingSystem/api/controller/NagiosMonitoringController.java
@@ -41,6 +41,6 @@ public class NagiosMonitoringController {
     public NagiosTicketSlaSummaryDto getTicketSlaSummaryDetailed(
             @RequestParam(value = "fromDate", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fromDate,
             @RequestParam(value = "toDate", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate toDate) {
-        return nagiosTicketSlaService.fetchSummary(fromDate, toDate);
+        return nagiosTicketSlaService.fetchSummaryDetailed(fromDate, toDate);
     }
 }

--- a/api/src/main/java/com/ticketingSystem/api/dto/nagios/NagiosGroupedCountView.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/nagios/NagiosGroupedCountView.java
@@ -1,0 +1,7 @@
+package com.ticketingSystem.api.dto.nagios;
+
+public interface NagiosGroupedCountView {
+    String getGroupValue();
+
+    Long getTotalCount();
+}

--- a/api/src/main/java/com/ticketingSystem/api/dto/nagios/NagiosSeveritySlaAggregateView.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/nagios/NagiosSeveritySlaAggregateView.java
@@ -1,0 +1,13 @@
+package com.ticketingSystem.api.dto.nagios;
+
+public interface NagiosSeveritySlaAggregateView {
+    String getSeverity();
+
+    Long getTotalCount();
+
+    Long getBreachCount();
+
+    Double getAverageResolutionTimeMinutes();
+
+    Double getAverageResponseTimeMinutes();
+}

--- a/api/src/main/java/com/ticketingSystem/api/dto/nagios/NagiosSeveritySlaMetricsDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/nagios/NagiosSeveritySlaMetricsDto.java
@@ -1,0 +1,10 @@
+package com.ticketingSystem.api.dto.nagios;
+
+import java.math.BigDecimal;
+
+public record NagiosSeveritySlaMetricsDto(long totalCount,
+                                          long breachCount,
+                                          BigDecimal breachPercentage,
+                                          BigDecimal averageResolutionTimeMinutes,
+                                          BigDecimal averageResponseTimeMinutes) {
+}

--- a/api/src/main/java/com/ticketingSystem/api/dto/nagios/NagiosTicketSlaSummaryDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/nagios/NagiosTicketSlaSummaryDto.java
@@ -3,6 +3,7 @@ package com.ticketingSystem.api.dto.nagios;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.util.Map;
 
 public record NagiosTicketSlaSummaryDto(String service,
                                         Instant generatedAt,
@@ -15,5 +16,7 @@ public record NagiosTicketSlaSummaryDto(String service,
                                         BigDecimal compliancePercentage,
                                         BigDecimal averageResolutionTimeMinutes,
                                         BigDecimal averageResponseTimeMinutes,
-                                        BigDecimal averageBreachMinutes) {
+                                        BigDecimal averageBreachMinutes,
+                                        Map<String, NagiosSeveritySlaMetricsDto> severitySummary,
+                                        Map<String, Long> detailedBreakdown) {
 }

--- a/api/src/main/java/com/ticketingSystem/api/repository/TicketSlaRepository.java
+++ b/api/src/main/java/com/ticketingSystem/api/repository/TicketSlaRepository.java
@@ -1,6 +1,8 @@
 package com.ticketingSystem.api.repository;
 
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaSummaryAggregateDto;
+import com.ticketingSystem.api.dto.nagios.NagiosSeveritySlaAggregateView;
+import com.ticketingSystem.api.dto.nagios.NagiosGroupedCountView;
 import com.ticketingSystem.api.models.TicketSla;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -38,6 +40,47 @@ public interface TicketSlaRepository extends JpaRepository<TicketSla, String> {
             """)
     NagiosTicketSlaSummaryAggregateDto fetchSummary(@Param("fromDate") LocalDateTime fromDate,
                                                     @Param("toDateExclusive") LocalDateTime toDateExclusive);
+
+    @Query(value = """
+            SELECT
+                t.severity AS severity,
+                COUNT(sla.id) AS totalCount,
+                COALESCE(SUM(CASE WHEN COALESCE(sla.breached_by_minutes, 0) > 0 THEN 1 ELSE 0 END), 0) AS breachCount,
+                AVG(sla.resolution_time_minutes) AS averageResolutionTimeMinutes,
+                AVG(sla.response_time_minutes) AS averageResponseTimeMinutes
+            FROM ticket_sla sla
+            JOIN tickets t ON t.ticket_id = sla.ticket_id
+            WHERE (:fromDate IS NULL OR t.reported_date >= :fromDate)
+              AND t.reported_date < :toDateExclusive
+            GROUP BY t.severity
+            """, nativeQuery = true)
+    List<NagiosSeveritySlaAggregateView> fetchSummaryBySeverity(@Param("fromDate") LocalDateTime fromDate,
+                                                                @Param("toDateExclusive") LocalDateTime toDateExclusive);
+
+    @Query(value = """
+            SELECT COALESCE(NULLIF(TRIM(t.category), ''), 'Unknown') AS groupValue,
+                   COUNT(sla.id) AS totalCount
+            FROM ticket_sla sla
+            JOIN tickets t ON t.ticket_id = sla.ticket_id
+            WHERE (:fromDate IS NULL OR t.reported_date >= :fromDate)
+              AND t.reported_date < :toDateExclusive
+            GROUP BY COALESCE(NULLIF(TRIM(t.category), ''), 'Unknown')
+            """, nativeQuery = true)
+    List<NagiosGroupedCountView> fetchModuleCounts(@Param("fromDate") LocalDateTime fromDate,
+                                                   @Param("toDateExclusive") LocalDateTime toDateExclusive);
+
+    @Query(value = """
+            SELECT COALESCE(NULLIF(TRIM(it.name), ''), 'Unknown') AS groupValue,
+                   COUNT(sla.id) AS totalCount
+            FROM ticket_sla sla
+            JOIN tickets t ON t.ticket_id = sla.ticket_id
+            LEFT JOIN issue_type_master it ON it.issue_type_id = t.issue_type_id
+            WHERE (:fromDate IS NULL OR t.reported_date >= :fromDate)
+              AND t.reported_date < :toDateExclusive
+            GROUP BY COALESCE(NULLIF(TRIM(it.name), ''), 'Unknown')
+            """, nativeQuery = true)
+    List<NagiosGroupedCountView> fetchIssueTypeCounts(@Param("fromDate") LocalDateTime fromDate,
+                                                      @Param("toDateExclusive") LocalDateTime toDateExclusive);
 
     long countByBreachedByMinutesGreaterThan(Long breachedByMinutes);
 }

--- a/api/src/main/java/com/ticketingSystem/api/service/NagiosTicketSlaService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/NagiosTicketSlaService.java
@@ -2,6 +2,8 @@ package com.ticketingSystem.api.service;
 
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaRecordDto;
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaSnapshotDto;
+import com.ticketingSystem.api.dto.nagios.NagiosSeveritySlaAggregateView;
+import com.ticketingSystem.api.dto.nagios.NagiosSeveritySlaMetricsDto;
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaSummaryAggregateDto;
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaSummaryDto;
 import com.ticketingSystem.api.models.Ticket;
@@ -16,7 +18,9 @@ import java.math.RoundingMode;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 public class NagiosTicketSlaService {
@@ -80,7 +84,9 @@ public class NagiosTicketSlaService {
                 compliancePercentage,
                 toBigDecimal(aggregate.averageResolutionTimeMinutes()),
                 toBigDecimal(aggregate.averageResponseTimeMinutes()),
-                toBigDecimal(aggregate.averageBreachMinutes())
+                toBigDecimal(aggregate.averageBreachMinutes()),
+                buildSeveritySummary(fromDateTime, toDateExclusive),
+                Map.of()
         );
     }
 
@@ -117,8 +123,78 @@ public class NagiosTicketSlaService {
                 compliancePercentage,
                 toBigDecimal(aggregate.averageResolutionTimeMinutes()),
                 toBigDecimal(aggregate.averageResponseTimeMinutes()),
-                toBigDecimal(aggregate.averageBreachMinutes())
+                toBigDecimal(aggregate.averageBreachMinutes()),
+                buildSeveritySummary(fromDateTime, toDateExclusive),
+                buildDetailedBreakdown(fromDateTime, toDateExclusive)
         );
+    }
+
+    private Map<String, NagiosSeveritySlaMetricsDto> buildSeveritySummary(LocalDateTime fromDateTime,
+                                                                          LocalDateTime toDateExclusive) {
+        Map<String, NagiosSeveritySlaMetricsDto> severitySummary = new LinkedHashMap<>();
+        severitySummary.put("S1", defaultSeverityMetrics());
+        severitySummary.put("S2", defaultSeverityMetrics());
+        severitySummary.put("S3", defaultSeverityMetrics());
+        severitySummary.put("S4", defaultSeverityMetrics());
+
+        List<NagiosSeveritySlaAggregateView> severityAggregates = ticketSlaRepository.fetchSummaryBySeverity(fromDateTime, toDateExclusive);
+        for (NagiosSeveritySlaAggregateView aggregate : severityAggregates) {
+            String normalizedSeverity = normalizeSeverity(aggregate.getSeverity());
+            if (normalizedSeverity == null) {
+                continue;
+            }
+
+            long totalCount = aggregate.getTotalCount() != null ? aggregate.getTotalCount() : 0L;
+            long breachCount = aggregate.getBreachCount() != null ? aggregate.getBreachCount() : 0L;
+
+            severitySummary.put(
+                    normalizedSeverity,
+                    new NagiosSeveritySlaMetricsDto(
+                            totalCount,
+                            breachCount,
+                            calculatePercentage(breachCount, totalCount),
+                            toBigDecimal(aggregate.getAverageResolutionTimeMinutes()),
+                            toBigDecimal(aggregate.getAverageResponseTimeMinutes())
+                    )
+            );
+        }
+        return severitySummary;
+    }
+
+    private Map<String, Long> buildDetailedBreakdown(LocalDateTime fromDateTime, LocalDateTime toDateExclusive) {
+        Map<String, Long> detailedBreakdown = new LinkedHashMap<>();
+
+        ticketSlaRepository.fetchModuleCounts(fromDateTime, toDateExclusive)
+                .forEach(row -> detailedBreakdown.put("Module - " + row.getGroupValue(), row.getTotalCount()));
+
+        ticketSlaRepository.fetchIssueTypeCounts(fromDateTime, toDateExclusive)
+                .forEach(row -> detailedBreakdown.put("Issue Type - " + row.getGroupValue(), row.getTotalCount()));
+
+        return detailedBreakdown;
+    }
+
+    private NagiosSeveritySlaMetricsDto defaultSeverityMetrics() {
+        return new NagiosSeveritySlaMetricsDto(0L, 0L, BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO);
+    }
+
+    private String normalizeSeverity(String severity) {
+        if (severity == null) {
+            return null;
+        }
+        String normalized = severity.toUpperCase();
+        if (normalized.contains("S1")) {
+            return "S1";
+        }
+        if (normalized.contains("S2")) {
+            return "S2";
+        }
+        if (normalized.contains("S3")) {
+            return "S3";
+        }
+        if (normalized.contains("S4")) {
+            return "S4";
+        }
+        return null;
     }
 
     private BigDecimal calculateCompliance(long totalRecords, long breachedRecords) {


### PR DESCRIPTION
### Motivation
- Provide per-severity SLA metrics (total, breach count, breach %) and average timings for S1/S2/S3/S4 and expose richer details for the detailed summary endpoint. 
- Surface counts grouped by module and issue type using the specific key format `Module - <module_name>` and `Issue Type - <issue_type>`. 
- Ensure the detailed endpoint uses a dedicated service path so it can return the enriched data set.

### Description
- Wired the `GET /public/nagios/ticket-sla/summary-detailed` controller to call `fetchSummaryDetailed(...)` so the detailed endpoint returns the enriched payload. 
- Extended `NagiosTicketSlaSummaryDto` to include `severitySummary` (`Map<String, NagiosSeveritySlaMetricsDto>`) and `detailedBreakdown` (`Map<String, Long>`). 
- Added projection and DTO types: `NagiosSeveritySlaAggregateView`, `NagiosGroupedCountView`, and `NagiosSeveritySlaMetricsDto`. 
- Added repository queries: `fetchSummaryBySeverity(...)` (per-severity aggregates), `fetchModuleCounts(...)` (module/category counts), and `fetchIssueTypeCounts(...)` (issue-type counts), and implemented service logic that builds per-severity metrics (totalCount, breachCount, breachPercentage, averageResolutionTimeMinutes, averageResponseTimeMinutes), zero-fills missing severities S1..S4, normalizes severity strings (maps values containing `S1`/`S2`/`S3`/`S4`), and produces detailed breakdown keys in the required formats.

### Testing
- Attempted to run controller tests with `api/gradlew -p api test --tests com.ticketingSystem.api.controller.NagiosMonitoringControllerTest`, but the build failed in this environment due to a Java/Gradle runtime compatibility error (`Unsupported class file major version 69`).
- No other automated tests were executed in this environment due to the above build failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f45a6cc88332b57655e712010004)