### PR TITLE
Flatten Nagios severity SLA summary keys by severity

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/dto/nagios/NagiosTicketSlaSummaryDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/nagios/NagiosTicketSlaSummaryDto.java
@@ -1,5 +1,8 @@
 package com.ticketingSystem.api.dto.nagios;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -17,6 +20,11 @@ public record NagiosTicketSlaSummaryDto(String service,
                                         BigDecimal averageResolutionTimeMinutes,
                                         BigDecimal averageResponseTimeMinutes,
                                         BigDecimal averageBreachMinutes,
+                                        @JsonIgnore
                                         Map<String, Object> severitySummary,
                                         Map<String, Long> detailedBreakdown) {
+    @JsonAnyGetter
+    public Map<String, Object> flattenedSeveritySummary() {
+        return severitySummary;
+    }
 }

--- a/api/src/main/java/com/ticketingSystem/api/dto/nagios/NagiosTicketSlaSummaryDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/nagios/NagiosTicketSlaSummaryDto.java
@@ -17,6 +17,6 @@ public record NagiosTicketSlaSummaryDto(String service,
                                         BigDecimal averageResolutionTimeMinutes,
                                         BigDecimal averageResponseTimeMinutes,
                                         BigDecimal averageBreachMinutes,
-                                        Map<String, NagiosSeveritySlaMetricsDto> severitySummary,
+                                        Map<String, Object> severitySummary,
                                         Map<String, Long> detailedBreakdown) {
 }

--- a/api/src/main/java/com/ticketingSystem/api/service/NagiosTicketSlaService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/NagiosTicketSlaService.java
@@ -178,11 +178,11 @@ public class NagiosTicketSlaService {
                                     BigDecimal breachPercentage,
                                     BigDecimal averageResolutionTimeMinutes,
                                     BigDecimal averageResponseTimeMinutes) {
-        severitySummary.put("totalCount" + severity, totalCount);
-        severitySummary.put("breachCount" + severity, breachCount);
-        severitySummary.put("breachPercentage" + severity, breachPercentage);
-        severitySummary.put("averageResolutionTimeMinutes" + severity, averageResolutionTimeMinutes);
-        severitySummary.put("averageResponseTimeMinutes" + severity, averageResponseTimeMinutes);
+        severitySummary.put(severity + "TotalCount", totalCount);
+        severitySummary.put(severity + "BreachCount", breachCount);
+        severitySummary.put(severity + "BreachPercentage", breachPercentage);
+        severitySummary.put(severity + "AverageResolutionTimeMinutes", averageResolutionTimeMinutes);
+        severitySummary.put(severity + "AverageResponseTimeMinutes", averageResponseTimeMinutes);
     }
 
     private String normalizeSeverity(String severity) {

--- a/api/src/main/java/com/ticketingSystem/api/service/NagiosTicketSlaService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/NagiosTicketSlaService.java
@@ -3,7 +3,6 @@ package com.ticketingSystem.api.service;
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaRecordDto;
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaSnapshotDto;
 import com.ticketingSystem.api.dto.nagios.NagiosSeveritySlaAggregateView;
-import com.ticketingSystem.api.dto.nagios.NagiosSeveritySlaMetricsDto;
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaSummaryAggregateDto;
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaSummaryDto;
 import com.ticketingSystem.api.models.Ticket;
@@ -129,13 +128,13 @@ public class NagiosTicketSlaService {
         );
     }
 
-    private Map<String, NagiosSeveritySlaMetricsDto> buildSeveritySummary(LocalDateTime fromDateTime,
-                                                                          LocalDateTime toDateExclusive) {
-        Map<String, NagiosSeveritySlaMetricsDto> severitySummary = new LinkedHashMap<>();
-        severitySummary.put("S1", defaultSeverityMetrics());
-        severitySummary.put("S2", defaultSeverityMetrics());
-        severitySummary.put("S3", defaultSeverityMetrics());
-        severitySummary.put("S4", defaultSeverityMetrics());
+    private Map<String, Object> buildSeveritySummary(LocalDateTime fromDateTime,
+                                                     LocalDateTime toDateExclusive) {
+        Map<String, Object> severitySummary = new LinkedHashMap<>();
+        putSeverityMetrics(severitySummary, "S1", 0L, 0L, BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO);
+        putSeverityMetrics(severitySummary, "S2", 0L, 0L, BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO);
+        putSeverityMetrics(severitySummary, "S3", 0L, 0L, BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO);
+        putSeverityMetrics(severitySummary, "S4", 0L, 0L, BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO);
 
         List<NagiosSeveritySlaAggregateView> severityAggregates = ticketSlaRepository.fetchSummaryBySeverity(fromDateTime, toDateExclusive);
         for (NagiosSeveritySlaAggregateView aggregate : severityAggregates) {
@@ -147,15 +146,14 @@ public class NagiosTicketSlaService {
             long totalCount = aggregate.getTotalCount() != null ? aggregate.getTotalCount() : 0L;
             long breachCount = aggregate.getBreachCount() != null ? aggregate.getBreachCount() : 0L;
 
-            severitySummary.put(
+            putSeverityMetrics(
+                    severitySummary,
                     normalizedSeverity,
-                    new NagiosSeveritySlaMetricsDto(
-                            totalCount,
-                            breachCount,
-                            calculatePercentage(breachCount, totalCount),
-                            toBigDecimal(aggregate.getAverageResolutionTimeMinutes()),
-                            toBigDecimal(aggregate.getAverageResponseTimeMinutes())
-                    )
+                    totalCount,
+                    breachCount,
+                    calculatePercentage(breachCount, totalCount),
+                    toBigDecimal(aggregate.getAverageResolutionTimeMinutes()),
+                    toBigDecimal(aggregate.getAverageResponseTimeMinutes())
             );
         }
         return severitySummary;
@@ -173,8 +171,18 @@ public class NagiosTicketSlaService {
         return detailedBreakdown;
     }
 
-    private NagiosSeveritySlaMetricsDto defaultSeverityMetrics() {
-        return new NagiosSeveritySlaMetricsDto(0L, 0L, BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO);
+    private void putSeverityMetrics(Map<String, Object> severitySummary,
+                                    String severity,
+                                    long totalCount,
+                                    long breachCount,
+                                    BigDecimal breachPercentage,
+                                    BigDecimal averageResolutionTimeMinutes,
+                                    BigDecimal averageResponseTimeMinutes) {
+        severitySummary.put("totalCount" + severity, totalCount);
+        severitySummary.put("breachCount" + severity, breachCount);
+        severitySummary.put("breachPercentage" + severity, breachPercentage);
+        severitySummary.put("averageResolutionTimeMinutes" + severity, averageResolutionTimeMinutes);
+        severitySummary.put("averageResponseTimeMinutes" + severity, averageResponseTimeMinutes);
     }
 
     private String normalizeSeverity(String severity) {


### PR DESCRIPTION
### Motivation
- The response should not return nested objects for per-severity metrics; instead each metric key must include the severity suffix (e.g. `totalCountS1`) or otherwise be represented as flat key/value pairs.

### Description
- Changed `NagiosTicketSlaSummaryDto` field `severitySummary` from `Map<String, NagiosSeveritySlaMetricsDto>` to `Map<String, Object>` to allow flattened key/value entries.
- Reworked `NagiosTicketSlaService.buildSeveritySummary` to emit flattened keys for each severity (S1–S4) and each metric attribute using suffixed keys such as `totalCountS1`, `breachCountS1`, `breachPercentageS1`, `averageResolutionTimeMinutesS1`, and `averageResponseTimeMinutesS1`.
- Added helper `putSeverityMetrics` to populate default zero values for all S1–S4 keys and to overwrite them with actual aggregate values when available.
- Removed usage of nested `NagiosSeveritySlaMetricsDto` in the summary builder so the service produces normal key/value pairs rather than nested metric objects.

### Testing
- Attempted to compile the API module with `./gradlew -q compileJava`, which failed in this environment due to a Java/Gradle toolchain mismatch (`Unsupported class file major version 69`).
- No automated tests were executed successfully because the compilation step could not complete in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb1478c8e0833293c76bfb29c399fe)