### PR TITLE
Add proper status history entry when linking a ticket to a master

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/service/TicketService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/TicketService.java
@@ -1630,6 +1630,9 @@ public class TicketService {
 
         Ticket saved = ticketRepository.save(ticket);
         String actor = updatedBy != null && !updatedBy.isBlank() ? updatedBy : saved.getUpdatedBy();
+        if (actor == null || actor.isBlank()) {
+            actor = "SYSTEM";
+        }
         assignmentHistoryService.addHistory(
                 saved.getId(),
                 actor,
@@ -1650,7 +1653,7 @@ public class TicketService {
                 fromStatusId,
                 toStatusId,
                 slaFlag,
-                "duplicate/related"
+                "Linked to a Master ticket"
         );
 
         runNotificationAfterCommit(() -> sendRequestorMasterLinkNotification(saved, masterTicket, updatedBy));

--- a/api/src/test/java/com/ticketingSystem/api/service/TicketServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/TicketServiceTest.java
@@ -707,7 +707,7 @@ class TicketServiceTest {
     }
 
     @Test
-    void linkToMaster_closesChildTicket_andAddsDuplicateRelatedRemarkInStatusHistory() {
+    void linkToMaster_closesChildTicket_andAddsMasterLinkRemarkInStatusHistory() {
         String childId = "T-CHILD";
         String masterId = "T-MASTER";
 
@@ -743,7 +743,7 @@ class TicketServiceTest {
                 eq("OPEN_ID"),
                 eq("CLOSED_ID"),
                 eq(Boolean.FALSE),
-                eq("duplicate/related")
+                eq("Linked to a Master ticket")
         );
         verify(assignmentHistoryService).addHistory(
                 eq(childId),


### PR DESCRIPTION
### Motivation
- When a ticket is linked to a master ticket the code closed the ticket but added a generic `"duplicate/related"` remark to status history and could leave the history `updatedBy` empty in edge cases, so the status history visible in the UI was not informative or properly attributed.

### Description
- Changed `TicketService.linkToMaster` to use a non-empty actor for history entries by preferring `updatedBy` and falling back to `SYSTEM` when no actor is available via `actor = "SYSTEM"`.
- Replaced the status history remark for master-link actions from `"duplicate/related"` to `"Linked to a Master ticket"` in `TicketService.linkToMaster`.
- Updated the unit test `TicketServiceTest` to reflect the new remark and renamed the test to `linkToMaster_closesChildTicket_andAddsMasterLinkRemarkInStatusHistory`.
- Modified `api/src/main/java/com/ticketingSystem/api/service/TicketService.java` and `api/src/test/java/com/ticketingSystem/api/service/TicketServiceTest.java` to implement and assert the new behavior.

### Testing
- Ran the targeted unit test command `./gradlew test --tests com.ticketingSystem.api.service.TicketServiceTest.linkToMaster_closesChildTicket_andAddsMasterLinkRemarkInStatusHistory`, which could not complete in this environment due to a Gradle/JDK mismatch producing `Unsupported class file major version 69` (test run failed).
- No other automated tests were executed in this environment due to the same build/tooling limitation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9f440b1148332969127948f1ccb32)