### PR TITLE
Refactor closed-status handling into applyClosedStatus and add transaction to linkToMaster

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/service/TicketService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/TicketService.java
@@ -733,9 +733,7 @@ public class TicketService {
             }
         }
         if (updatedStatus == TicketStatus.CLOSED) {
-            if (existing.getFeedbackStatus() == null) {
-                existing.setFeedbackStatus(FeedbackStatus.PENDING);
-            }
+            applyClosedStatus(existing);
         }
         if (updated.getSubCategory() != null) {
             existing.setSubCategory(updated.getSubCategory());
@@ -1588,6 +1586,7 @@ public class TicketService {
         return mapWithStatusId(ticket);
     }
 
+    @Transactional
     public TicketDto linkToMaster(String id, String masterId, String updatedBy) {
         if (masterId == null || masterId.isBlank()) {
             throw new InvalidRequestException("Master ticket id is required.");
@@ -1613,15 +1612,8 @@ public class TicketService {
         }
 
         String previousStatusId = resolveCurrentStatusId(ticket);
-        String closedStatusId = workflowService.getStatusIdByCode(TicketStatus.CLOSED.name());
         ticket.setMasterId(masterId);
-        ticket.setTicketStatus(TicketStatus.CLOSED);
-        if (closedStatusId != null && !closedStatusId.isBlank()) {
-            statusMasterRepository.findById(closedStatusId).ifPresent(ticket::setStatus);
-        }
-        if (ticket.getFeedbackStatus() == null) {
-            ticket.setFeedbackStatus(FeedbackStatus.PENDING);
-        }
+        applyClosedStatus(ticket);
         if (updatedBy != null && !updatedBy.isBlank()) {
             ticket.setUpdatedBy(updatedBy);
         }
@@ -1658,6 +1650,20 @@ public class TicketService {
 
         runNotificationAfterCommit(() -> sendRequestorMasterLinkNotification(saved, masterTicket, updatedBy));
         return mapWithStatusId(saved);
+    }
+
+    private void applyClosedStatus(Ticket ticket) {
+        if (ticket == null) {
+            return;
+        }
+        ticket.setTicketStatus(TicketStatus.CLOSED);
+        String closedStatusId = workflowService.getStatusIdByCode(TicketStatus.CLOSED.name());
+        if (closedStatusId != null && !closedStatusId.isBlank()) {
+            statusMasterRepository.findById(closedStatusId).ifPresent(ticket::setStatus);
+        }
+        if (ticket.getFeedbackStatus() == null) {
+            ticket.setFeedbackStatus(FeedbackStatus.PENDING);
+        }
     }
 
     public TicketDto unlinkFromMaster(String id, String updatedBy) {


### PR DESCRIPTION
### Motivation
- Remove duplicated logic for applying the `CLOSED` ticket state and ensure consistent setting of status and feedback across code paths.
- Make `linkToMaster` operate within a transactional boundary to ensure persistence consistency when linking tickets to a master.
- Centralize null-safety checks when applying closed state to avoid NPEs and improve maintainability.

### Description
- Extracted the duplicated closed-state logic into a new private helper `applyClosedStatus(Ticket ticket)` that sets `TicketStatus.CLOSED`, resolves and applies the status master id, and sets `FeedbackStatus.PENDING` when appropriate.
- Replaced the inline closed-state code in the ticket update path and in `linkToMaster` with calls to `applyClosedStatus(...)` and added a null-guard inside the helper.
- Added `@Transactional` to the `linkToMaster` method to ensure the link and related updates are persisted atomically.

### Testing
- Executed the project's automated unit test suite with `mvn test`, and all tests passed. 
- Ran integration tests that exercise ticket linking and status transitions, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee5ab564b08332af61e789f8d84708)