### PR TITLE
Add Ticket CR feature: entities, services, controllers, ID generator and DB migration

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/controller/CrStatusMasterController.java
+++ b/api/src/main/java/com/ticketingSystem/api/controller/CrStatusMasterController.java
@@ -1,0 +1,26 @@
+package com.ticketingSystem.api.controller;
+
+import com.ticketingSystem.api.models.CrStatusMaster;
+import com.ticketingSystem.api.service.CrStatusMasterService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/cr-status-master")
+@CrossOrigin(origins = "http://localhost:3000")
+@RequiredArgsConstructor
+public class CrStatusMasterController {
+
+    private final CrStatusMasterService crStatusMasterService;
+
+    @GetMapping
+    public ResponseEntity<List<CrStatusMaster>> getStatuses() {
+        return ResponseEntity.ok(crStatusMasterService.getAllStatuses());
+    }
+}

--- a/api/src/main/java/com/ticketingSystem/api/controller/TicketCrController.java
+++ b/api/src/main/java/com/ticketingSystem/api/controller/TicketCrController.java
@@ -1,0 +1,36 @@
+package com.ticketingSystem.api.controller;
+
+import com.ticketingSystem.api.dto.TicketCrCreateRequestDto;
+import com.ticketingSystem.api.dto.TicketCrDto;
+import com.ticketingSystem.api.service.TicketCrService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/ticket-cr")
+@CrossOrigin(origins = "http://localhost:3000")
+@RequiredArgsConstructor
+public class TicketCrController {
+
+    private final TicketCrService ticketCrService;
+
+    @PostMapping
+    public ResponseEntity<TicketCrDto> create(@RequestBody TicketCrCreateRequestDto request) {
+        TicketCrDto created = ticketCrService.create(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @GetMapping("/{ticketCrId}")
+    public ResponseEntity<TicketCrDto> getById(@PathVariable String ticketCrId) {
+        return ResponseEntity.ok(ticketCrService.getById(ticketCrId));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<TicketCrDto>> getAll() {
+        return ResponseEntity.ok(ticketCrService.getAll());
+    }
+}

--- a/api/src/main/java/com/ticketingSystem/api/dto/TicketCrCreateRequestDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/TicketCrCreateRequestDto.java
@@ -1,0 +1,20 @@
+package com.ticketingSystem.api.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TicketCrCreateRequestDto {
+    private String ticketId;
+    private String statusId;
+    private String crStatusId;
+    private String subject;
+    private String description;
+    private String requestedBy;
+    private String assignedTo;
+    private String assignedBy;
+    private String remarks;
+    private String createdBy;
+    private String updatedBy;
+}

--- a/api/src/main/java/com/ticketingSystem/api/dto/TicketCrDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/TicketCrDto.java
@@ -1,0 +1,29 @@
+package com.ticketingSystem.api.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class TicketCrDto {
+    private String ticketCrId;
+    private String ticketId;
+    private String statusId;
+    private String statusName;
+    private String statusCode;
+    private String crStatusId;
+    private String crStatusName;
+    private String crStatusCode;
+    private String subject;
+    private String description;
+    private String requestedBy;
+    private String assignedTo;
+    private String assignedBy;
+    private String remarks;
+    private LocalDateTime createdDate;
+    private String createdBy;
+    private LocalDateTime updatedOn;
+    private String updatedBy;
+}

--- a/api/src/main/java/com/ticketingSystem/api/models/CrStatusMaster.java
+++ b/api/src/main/java/com/ticketingSystem/api/models/CrStatusMaster.java
@@ -1,0 +1,43 @@
+package com.ticketingSystem.api.models;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "cr_status_master")
+@Getter
+@Setter
+public class CrStatusMaster {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "cr_status_id")
+    private String crStatusId;
+
+    @Column(name = "cr_status_name", nullable = false)
+    private String crStatusName;
+
+    @Column(name = "cr_status_code", nullable = false, unique = true)
+    private String crStatusCode;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "color")
+    private String color;
+
+    @Column(name = "created_on", insertable = false, updatable = false)
+    private LocalDateTime createdOn;
+
+    @Column(name = "updated_on", insertable = false, updatable = false)
+    private LocalDateTime updatedOn;
+
+    @Column(name = "created_by", insertable = false, updatable = false)
+    private String createdBy;
+
+    @Column(name = "updated_by", insertable = false, updatable = false)
+    private String updatedBy;
+}

--- a/api/src/main/java/com/ticketingSystem/api/models/TicketCr.java
+++ b/api/src/main/java/com/ticketingSystem/api/models/TicketCr.java
@@ -1,0 +1,72 @@
+package com.ticketingSystem.api.models;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "ticket_cr")
+@Getter
+@Setter
+public class TicketCr {
+
+    @Id
+    @Column(name = "ticket_cr_id", nullable = false, length = 20)
+    private String ticketCrId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ticket_id", referencedColumnName = "ticket_id", nullable = false)
+    private Ticket ticket;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "status_id", referencedColumnName = "status_id", nullable = false)
+    private Status status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cr_status_id", referencedColumnName = "cr_status_id", nullable = false)
+    private CrStatusMaster crStatus;
+
+    @Column(name = "subject")
+    private String subject;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "requested_by")
+    private String requestedBy;
+
+    @Column(name = "assigned_to")
+    private String assignedTo;
+
+    @Column(name = "assigned_by")
+    private String assignedBy;
+
+    @Column(name = "remarks", columnDefinition = "TEXT")
+    private String remarks;
+
+    @Column(name = "created_date", nullable = false)
+    private LocalDateTime createdDate;
+
+    @Column(name = "created_by", nullable = false)
+    private String createdBy;
+
+    @Column(name = "updated_on", nullable = false)
+    private LocalDateTime updatedOn;
+
+    @Column(name = "updated_by")
+    private String updatedBy;
+
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdDate = now;
+        this.updatedOn = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedOn = LocalDateTime.now();
+    }
+}

--- a/api/src/main/java/com/ticketingSystem/api/models/TicketCrSequence.java
+++ b/api/src/main/java/com/ticketingSystem/api/models/TicketCrSequence.java
@@ -1,0 +1,31 @@
+package com.ticketingSystem.api.models;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "ticket_cr_sequences", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"sequence_date"})
+})
+@Getter
+@Setter
+@NoArgsConstructor
+public class TicketCrSequence {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "sequence_date", nullable = false)
+    private LocalDate sequenceDate;
+
+    @Column(name = "last_value", nullable = false)
+    private long lastValue;
+
+    @Version
+    private long version;
+}

--- a/api/src/main/java/com/ticketingSystem/api/models/TicketCrSequence.java
+++ b/api/src/main/java/com/ticketingSystem/api/models/TicketCrSequence.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDate;
+import java.util.UUID;
 
 @Entity
 @Table(name = "ticket_cr_sequences", uniqueConstraints = {
@@ -17,8 +18,8 @@ import java.time.LocalDate;
 public class TicketCrSequence {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @Column(name = "id", nullable = false, length = 20)
+    private String id;
 
     @Column(name = "sequence_date", nullable = false)
     private LocalDate sequenceDate;
@@ -28,4 +29,11 @@ public class TicketCrSequence {
 
     @Version
     private long version;
+
+    @PrePersist
+    private void assignIdIfMissing() {
+        if (id == null || id.isBlank()) {
+            id = UUID.randomUUID().toString().replace("-", "").substring(0, 20);
+        }
+    }
 }

--- a/api/src/main/java/com/ticketingSystem/api/repository/CrStatusMasterRepository.java
+++ b/api/src/main/java/com/ticketingSystem/api/repository/CrStatusMasterRepository.java
@@ -1,0 +1,7 @@
+package com.ticketingSystem.api.repository;
+
+import com.ticketingSystem.api.models.CrStatusMaster;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CrStatusMasterRepository extends JpaRepository<CrStatusMaster, String> {
+}

--- a/api/src/main/java/com/ticketingSystem/api/repository/TicketCrRepository.java
+++ b/api/src/main/java/com/ticketingSystem/api/repository/TicketCrRepository.java
@@ -1,0 +1,7 @@
+package com.ticketingSystem.api.repository;
+
+import com.ticketingSystem.api.models.TicketCr;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TicketCrRepository extends JpaRepository<TicketCr, String> {
+}

--- a/api/src/main/java/com/ticketingSystem/api/repository/TicketCrSequenceRepository.java
+++ b/api/src/main/java/com/ticketingSystem/api/repository/TicketCrSequenceRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Lock;
 import java.time.LocalDate;
 import java.util.Optional;
 
-public interface TicketCrSequenceRepository extends JpaRepository<TicketCrSequence, Long> {
+public interface TicketCrSequenceRepository extends JpaRepository<TicketCrSequence, String> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<TicketCrSequence> findBySequenceDate(LocalDate sequenceDate);

--- a/api/src/main/java/com/ticketingSystem/api/repository/TicketCrSequenceRepository.java
+++ b/api/src/main/java/com/ticketingSystem/api/repository/TicketCrSequenceRepository.java
@@ -1,0 +1,15 @@
+package com.ticketingSystem.api.repository;
+
+import com.ticketingSystem.api.models.TicketCrSequence;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface TicketCrSequenceRepository extends JpaRepository<TicketCrSequence, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<TicketCrSequence> findBySequenceDate(LocalDate sequenceDate);
+}

--- a/api/src/main/java/com/ticketingSystem/api/service/CrStatusMasterService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/CrStatusMasterService.java
@@ -1,0 +1,19 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.models.CrStatusMaster;
+import com.ticketingSystem.api.repository.CrStatusMasterRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CrStatusMasterService {
+
+    private final CrStatusMasterRepository crStatusMasterRepository;
+
+    public List<CrStatusMaster> getAllStatuses() {
+        return crStatusMasterRepository.findAll();
+    }
+}

--- a/api/src/main/java/com/ticketingSystem/api/service/TicketCrIdGenerator.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/TicketCrIdGenerator.java
@@ -1,0 +1,47 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.models.TicketCrSequence;
+import com.ticketingSystem.api.repository.TicketCrSequenceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+
+@Service
+@RequiredArgsConstructor
+public class TicketCrIdGenerator {
+
+    private static final String ID_PREFIX = "CR";
+    private static final DateTimeFormatter MONTH_FORMATTER = DateTimeFormatter.ofPattern("yyyyMM");
+    private static final int COUNTER_LENGTH = 5;
+
+    private final TicketCrSequenceRepository ticketCrSequenceRepository;
+
+    @Transactional
+    public String generateTicketCrId() {
+        YearMonth currentMonth = YearMonth.now();
+        LocalDate monthStart = currentMonth.atDay(1);
+
+        TicketCrSequence sequence = ticketCrSequenceRepository
+                .findBySequenceDate(monthStart)
+                .orElseGet(() -> {
+                    TicketCrSequence created = new TicketCrSequence();
+                    created.setSequenceDate(monthStart);
+                    created.setLastValue(0);
+                    return created;
+                });
+
+        long nextValue = sequence.getLastValue() + 1;
+        sequence.setLastValue(nextValue);
+        ticketCrSequenceRepository.save(sequence);
+
+        return String.format("%s-%s-%s", ID_PREFIX, currentMonth.format(MONTH_FORMATTER), formatCounter(nextValue));
+    }
+
+    private String formatCounter(long sequenceNumber) {
+        return String.format("%0" + COUNTER_LENGTH + "d", sequenceNumber);
+    }
+}

--- a/api/src/main/java/com/ticketingSystem/api/service/TicketCrService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/TicketCrService.java
@@ -1,0 +1,95 @@
+package com.ticketingSystem.api.service;
+
+import com.ticketingSystem.api.dto.TicketCrCreateRequestDto;
+import com.ticketingSystem.api.dto.TicketCrDto;
+import com.ticketingSystem.api.models.CrStatusMaster;
+import com.ticketingSystem.api.models.Status;
+import com.ticketingSystem.api.models.Ticket;
+import com.ticketingSystem.api.models.TicketCr;
+import com.ticketingSystem.api.repository.CrStatusMasterRepository;
+import com.ticketingSystem.api.repository.StatusMasterRepository;
+import com.ticketingSystem.api.repository.TicketCrRepository;
+import com.ticketingSystem.api.repository.TicketRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TicketCrService {
+
+    private final TicketCrRepository ticketCrRepository;
+    private final TicketRepository ticketRepository;
+    private final StatusMasterRepository statusMasterRepository;
+    private final CrStatusMasterRepository crStatusMasterRepository;
+    private final TicketCrIdGenerator ticketCrIdGenerator;
+
+    public TicketCrDto create(TicketCrCreateRequestDto request) {
+        Ticket ticket = ticketRepository.findById(request.getTicketId())
+                .orElseThrow(() -> new EntityNotFoundException("Ticket not found: " + request.getTicketId()));
+
+        Status status = statusMasterRepository.findById(request.getStatusId())
+                .orElseThrow(() -> new EntityNotFoundException("Status not found: " + request.getStatusId()));
+
+        CrStatusMaster crStatus = crStatusMasterRepository.findById(request.getCrStatusId())
+                .orElseThrow(() -> new EntityNotFoundException("CR status not found: " + request.getCrStatusId()));
+
+        TicketCr ticketCr = new TicketCr();
+        ticketCr.setTicketCrId(ticketCrIdGenerator.generateTicketCrId());
+        ticketCr.setTicket(ticket);
+        ticketCr.setStatus(status);
+        ticketCr.setCrStatus(crStatus);
+        ticketCr.setSubject(request.getSubject());
+        ticketCr.setDescription(request.getDescription());
+        ticketCr.setRequestedBy(request.getRequestedBy());
+        ticketCr.setAssignedTo(request.getAssignedTo());
+        ticketCr.setAssignedBy(request.getAssignedBy());
+        ticketCr.setRemarks(request.getRemarks());
+        ticketCr.setCreatedBy(request.getCreatedBy());
+        ticketCr.setUpdatedBy(request.getUpdatedBy());
+
+        return toDto(ticketCrRepository.save(ticketCr));
+    }
+
+    public TicketCrDto getById(String ticketCrId) {
+        TicketCr ticketCr = ticketCrRepository.findById(ticketCrId)
+                .orElseThrow(() -> new EntityNotFoundException("Ticket CR not found: " + ticketCrId));
+        return toDto(ticketCr);
+    }
+
+    public List<TicketCrDto> getAll() {
+        return ticketCrRepository.findAll().stream().map(this::toDto).toList();
+    }
+
+    private TicketCrDto toDto(TicketCr ticketCr) {
+        TicketCrDto dto = new TicketCrDto();
+        dto.setTicketCrId(ticketCr.getTicketCrId());
+        dto.setTicketId(ticketCr.getTicket() != null ? ticketCr.getTicket().getId() : null);
+
+        if (ticketCr.getStatus() != null) {
+            dto.setStatusId(ticketCr.getStatus().getStatusId());
+            dto.setStatusName(ticketCr.getStatus().getStatusName());
+            dto.setStatusCode(ticketCr.getStatus().getStatusCode());
+        }
+
+        if (ticketCr.getCrStatus() != null) {
+            dto.setCrStatusId(ticketCr.getCrStatus().getCrStatusId());
+            dto.setCrStatusName(ticketCr.getCrStatus().getCrStatusName());
+            dto.setCrStatusCode(ticketCr.getCrStatus().getCrStatusCode());
+        }
+
+        dto.setSubject(ticketCr.getSubject());
+        dto.setDescription(ticketCr.getDescription());
+        dto.setRequestedBy(ticketCr.getRequestedBy());
+        dto.setAssignedTo(ticketCr.getAssignedTo());
+        dto.setAssignedBy(ticketCr.getAssignedBy());
+        dto.setRemarks(ticketCr.getRemarks());
+        dto.setCreatedDate(ticketCr.getCreatedDate());
+        dto.setCreatedBy(ticketCr.getCreatedBy());
+        dto.setUpdatedOn(ticketCr.getUpdatedOn());
+        dto.setUpdatedBy(ticketCr.getUpdatedBy());
+        return dto;
+    }
+}

--- a/api/src/main/resources/db/migration/V10__create_ticket_cr_tables.sql
+++ b/api/src/main/resources/db/migration/V10__create_ticket_cr_tables.sql
@@ -13,15 +13,15 @@ CREATE TABLE IF NOT EXISTS cr_status_master (
 CREATE TABLE IF NOT EXISTS ticket_cr_sequences (
     id VARCHAR(20) PRIMARY KEY,
     sequence_date DATE NOT NULL UNIQUE,
-    last_value BIGINT NOT NULL,
+    `last_value` BIGINT NOT NULL,
     version BIGINT NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS ticket_cr (
     ticket_cr_id VARCHAR(20) PRIMARY KEY,
     ticket_id VARCHAR(255) NOT NULL,
-    status_id VARCHAR(255) NOT NULL,
-    cr_status_id VARCHAR(255) NOT NULL,
+    status_id INT NOT NULL,
+    cr_status_id VARCHAR(10) NOT NULL,
     subject VARCHAR(500),
     description TEXT,
     requested_by VARCHAR(255),
@@ -37,6 +37,6 @@ CREATE TABLE IF NOT EXISTS ticket_cr (
     CONSTRAINT fk_ticket_cr_cr_status FOREIGN KEY (cr_status_id) REFERENCES cr_status_master(cr_status_id)
 );
 
-CREATE INDEX IF NOT EXISTS idx_ticket_cr_ticket_id ON ticket_cr(ticket_id);
-CREATE INDEX IF NOT EXISTS idx_ticket_cr_status_id ON ticket_cr(status_id);
-CREATE INDEX IF NOT EXISTS idx_ticket_cr_cr_status_id ON ticket_cr(cr_status_id);
+CREATE INDEX idx_ticket_cr_ticket_id ON ticket_cr(ticket_id);
+CREATE INDEX idx_ticket_cr_status_id ON ticket_cr(status_id);
+CREATE INDEX idx_ticket_cr_cr_status_id ON ticket_cr(cr_status_id);

--- a/api/src/main/resources/db/migration/V10__create_ticket_cr_tables.sql
+++ b/api/src/main/resources/db/migration/V10__create_ticket_cr_tables.sql
@@ -1,0 +1,42 @@
+CREATE TABLE IF NOT EXISTS cr_status_master (
+    cr_status_id VARCHAR(255) PRIMARY KEY,
+    cr_status_name VARCHAR(255) NOT NULL,
+    cr_status_code VARCHAR(255) NOT NULL UNIQUE,
+    description VARCHAR(1000),
+    color VARCHAR(100),
+    created_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_by VARCHAR(255) NOT NULL DEFAULT 'SYSTEM',
+    updated_by VARCHAR(255) NOT NULL DEFAULT 'SYSTEM'
+);
+
+CREATE TABLE IF NOT EXISTS ticket_cr_sequences (
+    id BIGSERIAL PRIMARY KEY,
+    sequence_date DATE NOT NULL UNIQUE,
+    last_value BIGINT NOT NULL,
+    version BIGINT NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS ticket_cr (
+    ticket_cr_id VARCHAR(20) PRIMARY KEY,
+    ticket_id VARCHAR(255) NOT NULL,
+    status_id VARCHAR(255) NOT NULL,
+    cr_status_id VARCHAR(255) NOT NULL,
+    subject VARCHAR(500),
+    description TEXT,
+    requested_by VARCHAR(255),
+    assigned_to VARCHAR(255),
+    assigned_by VARCHAR(255),
+    remarks TEXT,
+    created_date TIMESTAMP NOT NULL,
+    created_by VARCHAR(255) NOT NULL,
+    updated_on TIMESTAMP NOT NULL,
+    updated_by VARCHAR(255),
+    CONSTRAINT fk_ticket_cr_ticket FOREIGN KEY (ticket_id) REFERENCES tickets(ticket_id),
+    CONSTRAINT fk_ticket_cr_status FOREIGN KEY (status_id) REFERENCES status_master(status_id),
+    CONSTRAINT fk_ticket_cr_cr_status FOREIGN KEY (cr_status_id) REFERENCES cr_status_master(cr_status_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ticket_cr_ticket_id ON ticket_cr(ticket_id);
+CREATE INDEX IF NOT EXISTS idx_ticket_cr_status_id ON ticket_cr(status_id);
+CREATE INDEX IF NOT EXISTS idx_ticket_cr_cr_status_id ON ticket_cr(cr_status_id);

--- a/api/src/main/resources/db/migration/V10__create_ticket_cr_tables.sql
+++ b/api/src/main/resources/db/migration/V10__create_ticket_cr_tables.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS cr_status_master (
 );
 
 CREATE TABLE IF NOT EXISTS ticket_cr_sequences (
-    id BIGSERIAL PRIMARY KEY,
+    id VARCHAR(20) PRIMARY KEY,
     sequence_date DATE NOT NULL UNIQUE,
     last_value BIGINT NOT NULL,
     version BIGINT NOT NULL DEFAULT 0


### PR DESCRIPTION
### Motivation
- Introduce a Change Request (CR) feature for tickets to capture CR-specific metadata and lifecycle information. 
- Provide a master list of CR statuses to drive UI/state and ensure referential integrity with tickets. 
- Add a stable, human-friendly CR identifier format and sequencing to prevent collisions across concurrent creations.

### Description
- Add new JPA entities `TicketCr`, `CrStatusMaster`, and `TicketCrSequence` with mappings, lifecycle callbacks, and constraints to represent CR records, CR statuses, and per-month sequence state. 
- Implement repositories `TicketCrRepository`, `CrStatusMasterRepository`, and `TicketCrSequenceRepository` (with a `PESSIMISTIC_WRITE` locked finder) to persist and safely increment sequence numbers. 
- Add services `TicketCrService`, `CrStatusMasterService`, and `TicketCrIdGenerator` where the ID generator produces IDs like `CR-YYYYMM-00001` and updates the `ticket_cr_sequences` row transactionally. 
- Provide REST controllers `TicketCrController` and `CrStatusMasterController` and DTOs `TicketCrDto` / `TicketCrCreateRequestDto` to expose endpoints for creating, fetching, and listing CRs and CR statuses. 
- Add Flyway migration `V10__create_ticket_cr_tables.sql` to create `cr_status_master`, `ticket_cr_sequences`, and `ticket_cr` tables with foreign keys and indexes.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee5b271dd08332b349b8d77b37dac0)