### PR TITLE
Add isAssignedBackFromFci flag and "Assigned back from FCI" filter

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/controller/TicketController.java
+++ b/api/src/main/java/com/ticketingSystem/api/controller/TicketController.java
@@ -226,6 +226,7 @@ public class TicketController {
             @RequestParam String query,
             @RequestParam(required = false, name = "status") String statusId,
             @RequestParam(required = false) Boolean master,
+            @RequestParam(required = false) Boolean assignedBackFromFci,
             @RequestParam(required = false) String assignedTo,
             @RequestParam(required = false) String assignedBy,
             @RequestParam(required = false) String requestorId,
@@ -249,12 +250,13 @@ public class TicketController {
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "id") String sortBy,
             @RequestParam(defaultValue = "ASC") String direction) {
-        logger.info("Request to search tickets query={} status={} master={} assignedTo={} assignedBy={} requestorId={} levelId={} priority={} severity={} createdBy={} category={} subCategory={} zoneCode={} regionCode={} districtCode={} issueTypeId={} divisionId={} breachOption={} breachInMinutes={} dateParam={} fromDate={} toDate={} page={} size={} sortBy={} direction={}",
-                query, statusId, master, assignedTo, assignedBy, requestorId, levelId, priority, severity, createdBy, category, subCategory, zoneCode, regionCode, districtCode, issueTypeId, divisionId, breachOption, breachInMinutes, dateParam, fromDate, toDate, page, size, sortBy, direction);
+        logger.info("Request to search tickets query={} status={} master={} assignedBackFromFci={} assignedTo={} assignedBy={} requestorId={} levelId={} priority={} severity={} createdBy={} category={} subCategory={} zoneCode={} regionCode={} districtCode={} issueTypeId={} divisionId={} breachOption={} breachInMinutes={} dateParam={} fromDate={} toDate={} page={} size={} sortBy={} direction={}",
+                query, statusId, master, assignedBackFromFci, assignedTo, assignedBy, requestorId, levelId, priority, severity, createdBy, category, subCategory, zoneCode, regionCode, districtCode, issueTypeId, divisionId, breachOption, breachInMinutes, dateParam, fromDate, toDate, page, size, sortBy, direction);
         Page<TicketDto> p = ticketService.searchTickets(
                 query,
                 statusId,
                 master,
+                assignedBackFromFci,
                 assignedTo,
                 assignedBy,
                 requestorId,
@@ -286,6 +288,7 @@ public class TicketController {
             @RequestParam(defaultValue = "") String query,
             @RequestParam(required = false, name = "status") String statusId,
             @RequestParam(required = false) Boolean master,
+            @RequestParam(required = false) Boolean assignedBackFromFci,
             @RequestParam(required = false) String assignedTo,
             @RequestParam(required = false) String assignedBy,
             @RequestParam(required = false) String requestorId,
@@ -305,12 +308,13 @@ public class TicketController {
             @RequestParam(required = false, defaultValue = "reported_date") String dateParam,
             @RequestParam(required = false) String fromDate,
             @RequestParam(required = false) String toDate) {
-        logger.info("Request to export tickets query={} status={} master={} assignedTo={} assignedBy={} requestorId={} levelId={} priority={} severity={} createdBy={} category={} subCategory={} zoneCode={} regionCode={} districtCode={} issueTypeId={} divisionId={} breachOption={} breachInMinutes={} dateParam={} fromDate={} toDate={}",
-                query, statusId, master, assignedTo, assignedBy, requestorId, levelId, priority, severity, createdBy, category, subCategory, zoneCode, regionCode, districtCode, issueTypeId, divisionId, breachOption, breachInMinutes, dateParam, fromDate, toDate);
+        logger.info("Request to export tickets query={} status={} master={} assignedBackFromFci={} assignedTo={} assignedBy={} requestorId={} levelId={} priority={} severity={} createdBy={} category={} subCategory={} zoneCode={} regionCode={} districtCode={} issueTypeId={} divisionId={} breachOption={} breachInMinutes={} dateParam={} fromDate={} toDate={}",
+                query, statusId, master, assignedBackFromFci, assignedTo, assignedBy, requestorId, levelId, priority, severity, createdBy, category, subCategory, zoneCode, regionCode, districtCode, issueTypeId, divisionId, breachOption, breachInMinutes, dateParam, fromDate, toDate);
         List<TicketDto> results = ticketService.searchTicketsList(
                 query,
                 statusId,
                 master,
+                assignedBackFromFci,
                 assignedTo,
                 assignedBy,
                 requestorId,

--- a/api/src/main/java/com/ticketingSystem/api/dto/TicketDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/TicketDto.java
@@ -66,6 +66,8 @@ public class TicketDto {
     private String updatedBy;
     @JsonProperty("isMaster")
     private boolean isMaster;
+    @JsonProperty("isAssignedBackFromFci")
+    private boolean isAssignedBackFromFci;
     private String masterId;
     private LocalDateTime lastModified;
     private LocalDateTime resolvedAt;

--- a/api/src/main/java/com/ticketingSystem/api/mapper/DtoMapper.java
+++ b/api/src/main/java/com/ticketingSystem/api/mapper/DtoMapper.java
@@ -140,6 +140,7 @@ public class DtoMapper {
         dto.setLevelId(ticket.getLevelId());
         dto.setUpdatedBy(ticket.getUpdatedBy());
         dto.setMaster(ticket.isMaster());
+        dto.setAssignedBackFromFci(ticket.isAssignedBackFromFci());
         dto.setMasterId(ticket.getMasterId() != null ? String.valueOf(ticket.getMasterId()) : null);
         dto.setLastModified(ticket.getLastModified());
         dto.setResolvedAt(ticket.getResolvedAt());

--- a/api/src/main/java/com/ticketingSystem/api/models/Ticket.java
+++ b/api/src/main/java/com/ticketingSystem/api/models/Ticket.java
@@ -94,6 +94,10 @@ public class Ticket {
     private boolean isMaster;
     @Column(name = "master_id")
     private String masterId;
+
+    @JsonProperty("isAssignedBackFromFci")
+    @Column(name = "is_assigned_back_from_fci")
+    private boolean isAssignedBackFromFci;
     @Column(name = "last_modified")
     private LocalDateTime lastModified;
 

--- a/api/src/main/java/com/ticketingSystem/api/repository/TicketRepository.java
+++ b/api/src/main/java/com/ticketingSystem/api/repository/TicketRepository.java
@@ -421,6 +421,7 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
 //            "WHERE (:statusId IS NULL OR function(FIND_IN_SET, s.statusId, :statusId) > 0)" +
             "WHERE (:statusIds IS NULL OR s.statusId IN (:statusIds))" +
             "AND (:master IS NULL OR t.isMaster = :master) " +
+            "AND (:assignedBackFromFci IS NULL OR t.isAssignedBackFromFci = :assignedBackFromFci) " +
             "AND (:levelId IS NULL OR t.levelId = :levelId) " +
             "AND (:priority IS NULL OR t.priority = :priority) " +
             "AND (:severities IS NULL OR t.severity IN (:severities)) " +
@@ -453,7 +454,7 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
             "OR LOWER(t.subject) LIKE LOWER(CONCAT('%', :query, '%')) " +
             "OR LOWER(t.id) LIKE LOWER(CONCAT('%', :query, '%')) )")
     Page<Ticket> searchTickets(@Param("query") String query, @Param("statusIds") ArrayList<String> statusName,
-                               @Param("master") Boolean master, @Param("assignedTo") String assignedTo,
+                               @Param("master") Boolean master, @Param("assignedBackFromFci") Boolean assignedBackFromFci, @Param("assignedTo") String assignedTo,
                                @Param("alternateAssignedTo") String alternateAssignedTo,
                                @Param("assignedBy") String assignedBy, @Param("requestorId") String requestorId,
                                @Param("levelId") String levelId, @Param("priority") String priority,
@@ -476,6 +477,7 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
     @Query("SELECT t FROM Ticket t LEFT JOIN t.status s LEFT JOIN t.issueType it " +
             "WHERE (:statusIds IS NULL OR s.statusId IN (:statusIds))" +
             "AND (:master IS NULL OR t.isMaster = :master) " +
+            "AND (:assignedBackFromFci IS NULL OR t.isAssignedBackFromFci = :assignedBackFromFci) " +
             "AND (:levelId IS NULL OR t.levelId = :levelId) " +
             "AND (:priority IS NULL OR t.priority = :priority) " +
             "AND (:severities IS NULL OR t.severity IN (:severities)) " +
@@ -508,7 +510,7 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
             "OR LOWER(t.subject) LIKE LOWER(CONCAT('%', :query, '%')) " +
             "OR LOWER(t.id) LIKE LOWER(CONCAT('%', :query, '%')) )")
     List<Ticket> searchTicketsList(@Param("query") String query, @Param("statusIds") ArrayList<String> statusName,
-                                   @Param("master") Boolean master, @Param("assignedTo") String assignedTo,
+                                   @Param("master") Boolean master, @Param("assignedBackFromFci") Boolean assignedBackFromFci, @Param("assignedTo") String assignedTo,
                                    @Param("alternateAssignedTo") String alternateAssignedTo,
                                    @Param("assignedBy") String assignedBy, @Param("requestorId") String requestorId,
                                    @Param("levelId") String levelId, @Param("priority") String priority,

--- a/api/src/main/java/com/ticketingSystem/api/service/TicketService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/TicketService.java
@@ -533,7 +533,7 @@ public class TicketService {
         };
     }
 
-    public Page<TicketDto> searchTickets(String query, String statusId, Boolean master,
+    public Page<TicketDto> searchTickets(String query, String statusId, Boolean master, Boolean assignedBackFromFci,
                                          String assignedTo, String assignedBy, String requestorId, String levelId, String priority,
                                          String severity, String createdBy, String category, String subCategory,
                                          String zoneCode, String regionCode, String districtCode, String issueTypeId, String divisionId,
@@ -586,6 +586,7 @@ public class TicketService {
                 query,
                 statusIds,
                 master,
+                assignedBackFromFci,
                 assignedTo,
                 alternateAssignedTo,
                 assignedBy,
@@ -611,7 +612,7 @@ public class TicketService {
         return page.map(this::mapWithStatusId);
     }
 
-    public List<TicketDto> searchTicketsList(String query, String statusId, Boolean master,
+    public List<TicketDto> searchTicketsList(String query, String statusId, Boolean master, Boolean assignedBackFromFci,
                                              String assignedTo, String assignedBy, String requestorId, String levelId, String priority,
                                              String severity, String createdBy, String category, String subCategory,
                                              String zoneCode, String regionCode, String districtCode, String issueTypeId, String divisionId,
@@ -658,6 +659,7 @@ public class TicketService {
                         query,
                         statusIds,
                         master,
+                        assignedBackFromFci,
                         assignedTo,
                         alternateAssignedTo,
                         assignedBy,
@@ -768,6 +770,9 @@ public class TicketService {
         boolean assignmentChanged = assignmentChangeAllowed && !Objects.equals(updated.getAssignedTo(), previousAssignedTo);
         if (assignmentChangeAllowed) {
             existing.setAssignedTo(updated.getAssignedTo());
+        if (assignmentChanged && previousStatus == TicketStatus.PENDING_WITH_FCI) {
+            existing.setAssignedBackFromFci(true);
+        }
             if (assignmentChanged && existing.getAssignedTo() != null && updatedStatus == null && updatedStatusId == null) {
                 existing.setTicketStatus(TicketStatus.ASSIGNED);
                 String assignId = workflowService.getStatusIdByCode(TicketStatus.ASSIGNED.name());

--- a/api/src/main/resources/db/migration/V11__add_assigned_back_from_fci_flag.sql
+++ b/api/src/main/resources/db/migration/V11__add_assigned_back_from_fci_flag.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tickets
+    ADD COLUMN IF NOT EXISTS is_assigned_back_from_fci BOOLEAN NOT NULL DEFAULT FALSE;

--- a/ui/src/components/AllTickets/TicketsList.tsx
+++ b/ui/src/components/AllTickets/TicketsList.tsx
@@ -35,6 +35,7 @@ export interface TicketsListFilterState {
     search: string;
     statusFilter: string;
     masterOnly: boolean;
+    assignedBackFromFciOnly: boolean;
     levelFilter?: string;
     sortBy: "reportedDate" | "lastModified";
     sortDirection: "asc" | "desc";
@@ -58,6 +59,7 @@ export interface TicketsListSearchOverrides {
     query?: string;
     statusName?: string;
     master?: boolean;
+    assignedBackFromFci?: boolean;
     page?: number;
     size?: number;
     assignedTo?: string;
@@ -102,6 +104,7 @@ interface TicketsListProps {
     getViewTicketProps?: (selectedTicketId: string | null) => Partial<React.ComponentProps<typeof ViewTicket>>;
     allowAll: boolean;
     headerRightContent?: React.ReactNode;
+    showAssignedBackFromFciToggle?: boolean;
 }
 
 const priorityConfig: Record<string, { color: string; count: number; label: string }> = {
@@ -124,7 +127,8 @@ const TicketsList: React.FC<TicketsListProps> = ({
     tableOptions,
     getViewTicketProps,
     allowAll,
-    headerRightContent
+    headerRightContent,
+    showAssignedBackFromFciToggle = false,
 }) => {
     const { t } = useTranslation();
     const { data: allowedStatusData, pending: allowedStatusPending, success: allowedStatusSuccess, apiHandler: allowedStatusApiHandler } = useApi<any>();
@@ -162,6 +166,7 @@ const TicketsList: React.FC<TicketsListProps> = ({
     const [filteredTicketCount, setFilteredTicketCount] = useState(0);
     const [statusFilter, setStatusFilter] = useState("All");
     const [masterOnly, setMasterOnly] = useState(false);
+    const [assignedBackFromFciOnly, setAssignedBackFromFciOnly] = useState(false);
     const userDetails = getCurrentUserDetails();
     const levels = userDetails?.levels || [];
     const normalizedOfficeType = String(userDetails?.officeType ?? "").trim().toUpperCase();
@@ -294,6 +299,7 @@ const TicketsList: React.FC<TicketsListProps> = ({
         setStatusFilter("All");
         setMasterOnly(false);
         setLevelFilter(undefined);
+        setAssignedBackFromFciOnly(false);
         setSortBy("reportedDate");
         setDateRange({ preset: "ALL" });
         setSelectedDateParam("reported_date");
@@ -328,6 +334,7 @@ const TicketsList: React.FC<TicketsListProps> = ({
             search,
             statusFilter,
             masterOnly,
+            assignedBackFromFciOnly,
             levelFilter,
             sortBy,
             sortDirection,
@@ -349,6 +356,7 @@ const TicketsList: React.FC<TicketsListProps> = ({
             search,
             statusFilter,
             masterOnly,
+            assignedBackFromFciOnly,
             levelFilter,
             sortBy,
             sortDirection,
@@ -387,6 +395,9 @@ const TicketsList: React.FC<TicketsListProps> = ({
             }
 
             const masterParam = overrides?.master !== undefined ? overrides.master : masterOnly ? true : undefined;
+            const assignedBackFromFciParam = overrides?.assignedBackFromFci !== undefined
+                ? overrides.assignedBackFromFci
+                : assignedBackFromFciOnly ? true : undefined;
 
             const requestOverrides = buildSearchOverrides ? buildSearchOverrides({ ...filterState, page: effectivePage, allowedStatuses: allowedStatusData }) : {};
             const mergedOverrides: TicketsListSearchOverrides = {
@@ -427,6 +438,7 @@ const TicketsList: React.FC<TicketsListProps> = ({
                     queryParam,
                     statusParamU,
                     masterParam,
+                    assignedBackFromFciParam,
                     pageParam,
                     sizeParam,
                     assignedToParam,
@@ -912,6 +924,21 @@ const TicketsList: React.FC<TicketsListProps> = ({
                                 variant={masterOnly ? "filled" : "outlined"}
                                 onClick={() => {
                                     setMasterOnly((prev) => !prev);
+                                    setPage(1);
+                                }}
+                            />
+                        </div>
+                    )}
+
+                    {/* ASSIGNED BACK FROM FCI FILTER */}
+                    {showAssignedBackFromFciToggle && (
+                        <div className="col-auto">
+                            <Chip
+                                label={t("Assigned back from FCI")}
+                                color={assignedBackFromFciOnly ? "primary" : "default"}
+                                variant={assignedBackFromFciOnly ? "filled" : "outlined"}
+                                onClick={() => {
+                                    setAssignedBackFromFciOnly((prev) => !prev);
                                     setPage(1);
                                 }}
                             />

--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -46,6 +46,7 @@ export interface TicketRow {
     priority: string;
     priorityId: string;
     isMaster: boolean;
+    isAssignedBackFromFci?: boolean;
     userId?: string;
     requestorName?: string;
     requestorEmailId?: string;

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -351,4 +351,6 @@
     }
   },
   "Change Requests": "Change Requests"
+,
+  "Assigned back from FCI": "Assigned back from FCI"
 }

--- a/ui/src/locales/hi/translation.json
+++ b/ui/src/locales/hi/translation.json
@@ -343,4 +343,6 @@
     }
   },
   "Change Requests": "चेंज रिक्वेस्ट्स"
+,
+  "Assigned back from FCI": "एफसीआई से वापस असाइन किया गया"
 }

--- a/ui/src/pages/AllTickets.tsx
+++ b/ui/src/pages/AllTickets.tsx
@@ -38,6 +38,7 @@ const AllTickets: React.FC = () => {
             onTicketSelectChange={handleTicketSelectChange}
             allowAll={true}
             headerRightContent={devMode ? <SlaCalculationTrigger buttonLabel="Trigger SLA Calculation" /> : undefined}
+            showAssignedBackFromFciToggle
         />
     );
 };

--- a/ui/src/services/TicketService.ts
+++ b/ui/src/services/TicketService.ts
@@ -98,6 +98,7 @@ export function searchTicketsPaginated(
     query: string,
     statusName?: string,
     master?: string,
+    assignedBackFromFci?: boolean,
     page: number = 0,
     size: number = 5,
     assignedTo?: string,
@@ -124,6 +125,7 @@ export function searchTicketsPaginated(
     const params = new URLSearchParams({ query, page: String(page), size: String(size) });
     if (statusName) params.append('status', statusName);
     if (master !== undefined) params.append('master', String(master));
+    if (assignedBackFromFci !== undefined) params.append('assignedBackFromFci', String(assignedBackFromFci));
     if (assignedTo) params.append('assignedTo', assignedTo);
     if (levelId) params.append('levelId', levelId);
     if (assignedBy) params.append('assignedBy', assignedBy);

--- a/ui/src/services/__tests__/services.test.ts
+++ b/ui/src/services/__tests__/services.test.ts
@@ -655,6 +655,7 @@ describe("TicketService", () => {
       "query",
       "OPEN",
       true,
+      true,
       2,
       10,
       "assignee",
@@ -680,6 +681,7 @@ describe("TicketService", () => {
     expect(url).toContain("query=query");
     expect(url).toContain("status=OPEN");
     expect(url).toContain("master=true");
+    expect(url).toContain("assignedBackFromFci=true");
     expect(url).toContain("page=2");
     expect(url).toContain("size=10");
     expect(url).toContain("assignedTo=assignee");

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -58,6 +58,7 @@ export interface Ticket {
     priority: string;
     priorityId?: string;
     isMaster: boolean;
+    isAssignedBackFromFci?: boolean;
     masterId?: string;
     userId?: string;
     requestorName?: string;


### PR DESCRIPTION
### Motivation
- Introduce a boolean flag to track when a ticket that was `On Hold (Pending with FCI)` is assigned back so it can be filtered and reported. 

### Description
- Add a Flyway migration `api/src/main/resources/db/migration/V11__add_assigned_back_from_fci_flag.sql` that creates `tickets.is_assigned_back_from_fci` with default `false` and add the field to the JPA `Ticket` model (`Ticket.java`) and `TicketDto` with mapping in `DtoMapper.java`.
- Set `isAssignedBackFromFci` to `true` in the ticket update path when an assignment change happens and the previous status was `PENDING_WITH_FCI` by modifying `TicketService.updateTicket` to set the flag on that condition.
- Wire an optional `assignedBackFromFci` search filter end-to-end by adding the parameter to the controller (`TicketController`), service signatures (`TicketService.searchTickets` / `searchTicketsList`), and repository queries (`TicketRepository.searchTickets` / `searchTicketsList`) so API search/export endpoints can filter on the flag.
- Frontend changes include adding a toggle chip `Assigned back from FCI` to the `All Tickets` view by extending `TicketsList` (state, search override, and chip UI), passing the new query param via `ui/src/services/TicketService.ts`, adding the field to UI types (`ui/src/types/index.ts` and `TicketsTable`), and adding EN/HI i18n strings in `ui/src/locales/*/translation.json`.
- Update a frontend unit test to assert the new query parameter is appended in `src/services/__tests__/services.test.ts`.

### Testing
- Ran frontend unit tests for ticket-related service behavior with `npm test -- --runTestsByPath src/services/__tests__/services.test.ts --watch=false`, which passed (all tests in that file passed). 
- Attempted to run backend unit tests (`./gradlew test --tests com.ticketingSystem.api.service.TicketServiceTest`) but the build failed in this environment due to a Gradle/JDK incompatibility (`Unsupported class file major version 69`), so backend tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef5397ab2c8332a07d3ce809ae70e3)