### PR TITLE
Add conditional "Send for CR Approval" button to TicketView

### DIFF
--- a/ui/src/components/TicketView/TicketView.tsx
+++ b/ui/src/components/TicketView/TicketView.tsx
@@ -392,6 +392,14 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
     [availableStatusActions]
   );
 
+  const sendForCrApprovalAction = useMemo(
+    () => availableStatusActions.find((action: TicketStatusWorkflow) => {
+      const nextStatusName = getStatusNameById(String(action.nextStatus)) || '';
+      return nextStatusName.toLowerCase() === 'change request';
+    }) || null,
+    [availableStatusActions]
+  );
+
   const handleSlaDownloadMenuOpen = useCallback((event: React.MouseEvent<HTMLElement>) => {
     setSlaDownloadAnchor(event.currentTarget);
   }, []);
@@ -898,6 +906,11 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
   const shouldShowClose = Boolean(closeAction && isResolvedStatus && isRequester);
   const shouldShowReopen = Boolean(reopenAction && isResolvedStatus && isRequester);
   const shouldShowRestore = Boolean(restoreAction && isCancelledStatus);
+  const shouldShowSendForCrApproval = Boolean(
+    sendForCrApprovalAction &&
+    ticket?.isAssignedBackFromFci &&
+    normalisedStatusName !== 'change request'
+  );
   const canShowFeedbackAction = ticket?.feedbackStatus !== 'NOT_PROVIDED';
   const shouldShowFeedbackButton = isClosedStatus && isRequester && canShowFeedbackAction;
   const shouldShowSubmitRcaButton = showSubmitRCAButton && rcaStatus === 'PENDING';
@@ -1052,7 +1065,8 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
         shouldShowSubmitRcaButton ||
         shouldShowViewRcaButton ||
         (!ticket?.isMaster && shouldShowLinkToMasterTicketButton) ||
-        shouldShowAssignMasterTicketButton) && <Box
+        shouldShowAssignMasterTicketButton ||
+        shouldShowSendForCrApproval) && <Box
           sx={{
             backgroundColor: '#e8f5e9',
             borderRadius: 1,
@@ -1088,6 +1102,11 @@ const TicketView: React.FC<TicketViewProps> = ({ ticketId, showHistory = false, 
               {shouldShowRestore && (
                 <Button size="small" variant="contained" color="success" onClick={() => handleStatusActionClick(restoreAction)}>
                   {t('Restore Ticket')}
+                </Button>
+              )}
+              {shouldShowSendForCrApproval && (
+                <Button size="small" variant="contained" color="success" onClick={() => handleStatusActionClick(sendForCrApprovalAction)}>
+                  {t('Send for CR Approval')}
                 </Button>
               )}
               {shouldShowFeedbackButton && (


### PR DESCRIPTION
### Motivation
- Expose a “Send for CR Approval” action on the ticket header when a ticket has been assigned back from SCI/FCI and the current user’s role is allowed to move the ticket into the Change Request status. 
- Reuse the existing status-workflow driven pattern so the new action follows the same role-based gating and remark/action pipeline as other header buttons. 

### Description
- Added a new workflow lookup `sendForCrApprovalAction` that finds an available status action whose `nextStatus` resolves to `Change Request` via `getStatusNameById` in `ui/src/components/TicketView/TicketView.tsx`. 
- Added `shouldShowSendForCrApproval` guard which requires `ticket?.isAssignedBackFromFci` to be true, the current normalized status to not be `change request`, and `sendForCrApprovalAction` to exist. 
- Rendered a `Send for CR Approval` `Button` in the existing header action area and wired it to the existing `handleStatusActionClick(...)` flow so it reuses the same remark and status-change handling as other workflow buttons. 
- File changed: `ui/src/components/TicketView/TicketView.tsx`.

### Testing
- Ran the component unit test command `npm test -- --runInBand src/components/TicketView/__tests__/TicketView.test.tsx`, but the test runner could not execute in this environment because `react-scripts` is not available, so tests did not complete. 
- No other automated tests were executed in this environment; the change follows existing patterns used by other workflow buttons to minimize behavioral regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4e7ce12ac833280aabd8abb3718a9)