### PR TITLE
Add CR status workflow and Approve/Reject actions on View CR page

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/controller/TicketCrController.java
+++ b/api/src/main/java/com/ticketingSystem/api/controller/TicketCrController.java
@@ -2,6 +2,8 @@ package com.ticketingSystem.api.controller;
 
 import com.ticketingSystem.api.dto.TicketCrCreateRequestDto;
 import com.ticketingSystem.api.dto.TicketCrDto;
+import com.ticketingSystem.api.dto.TicketCrStatusWorkflowDto;
+import com.ticketingSystem.api.dto.TicketCrUpdateStatusRequestDto;
 import com.ticketingSystem.api.service.TicketCrService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -27,6 +29,17 @@ public class TicketCrController {
     @GetMapping("/{ticketCrId}")
     public ResponseEntity<TicketCrDto> getById(@PathVariable String ticketCrId) {
         return ResponseEntity.ok(ticketCrService.getById(ticketCrId));
+    }
+
+
+    @GetMapping("/actions/{crStatusId}")
+    public ResponseEntity<List<TicketCrStatusWorkflowDto>> getAvailableActions(@PathVariable String crStatusId) {
+        return ResponseEntity.ok(ticketCrService.getAvailableActions(crStatusId));
+    }
+
+    @PatchMapping("/{ticketCrId}/status")
+    public ResponseEntity<TicketCrDto> updateStatus(@PathVariable String ticketCrId, @RequestBody TicketCrUpdateStatusRequestDto request) {
+        return ResponseEntity.ok(ticketCrService.updateStatus(ticketCrId, request));
     }
 
     @GetMapping

--- a/api/src/main/java/com/ticketingSystem/api/dto/TicketCrStatusWorkflowDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/TicketCrStatusWorkflowDto.java
@@ -1,0 +1,11 @@
+package com.ticketingSystem.api.dto;
+
+import lombok.Data;
+
+@Data
+public class TicketCrStatusWorkflowDto {
+    private String id;
+    private String action;
+    private String currentStatusId;
+    private String nextStatusId;
+}

--- a/api/src/main/java/com/ticketingSystem/api/dto/TicketCrStatusWorkflowDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/TicketCrStatusWorkflowDto.java
@@ -4,7 +4,7 @@ import lombok.Data;
 
 @Data
 public class TicketCrStatusWorkflowDto {
-    private String id;
+    private String crswId;
     private String action;
     private String currentStatusId;
     private String nextStatusId;

--- a/api/src/main/java/com/ticketingSystem/api/dto/TicketCrUpdateStatusRequestDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/TicketCrUpdateStatusRequestDto.java
@@ -4,7 +4,7 @@ import lombok.Data;
 
 @Data
 public class TicketCrUpdateStatusRequestDto {
-    private String workflowId;
+    private String crswId;
     private String remarks;
     private String updatedBy;
 }

--- a/api/src/main/java/com/ticketingSystem/api/dto/TicketCrUpdateStatusRequestDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/TicketCrUpdateStatusRequestDto.java
@@ -1,0 +1,10 @@
+package com.ticketingSystem.api.dto;
+
+import lombok.Data;
+
+@Data
+public class TicketCrUpdateStatusRequestDto {
+    private String workflowId;
+    private String remarks;
+    private String updatedBy;
+}

--- a/api/src/main/java/com/ticketingSystem/api/models/TicketCrStatusWorkflow.java
+++ b/api/src/main/java/com/ticketingSystem/api/models/TicketCrStatusWorkflow.java
@@ -1,0 +1,43 @@
+package com.ticketingSystem.api.models;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "ticket_cr_status_workflow")
+@Getter
+@Setter
+public class TicketCrStatusWorkflow {
+    @Id
+    @Column(name = "crsf_id", nullable = false, length = 20)
+    private String id;
+
+    @Column(name = "action", nullable = false)
+    private String action;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "current_status_id", referencedColumnName = "cr_status_id", nullable = false)
+    private CrStatusMaster currentStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "next_status_id", referencedColumnName = "cr_status_id", nullable = false)
+    private CrStatusMaster nextStatus;
+
+    @Column(name = "created_on", nullable = false)
+    private LocalDateTime createdOn;
+
+    @Column(name = "updated_on", nullable = false)
+    private LocalDateTime updatedOn;
+
+    @Column(name = "created_by", nullable = false)
+    private String createdBy;
+
+    @Column(name = "updated_by", nullable = false)
+    private String updatedBy;
+
+    @Column(name = "active", nullable = false)
+    private Boolean active;
+}

--- a/api/src/main/java/com/ticketingSystem/api/models/TicketCrStatusWorkflow.java
+++ b/api/src/main/java/com/ticketingSystem/api/models/TicketCrStatusWorkflow.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @Setter
 public class TicketCrStatusWorkflow {
     @Id
-    @Column(name = "crsf_id", nullable = false, length = 20)
+    @Column(name = "crsw_id", nullable = false, length = 20)
     private String id;
 
     @Column(name = "action", nullable = false)

--- a/api/src/main/java/com/ticketingSystem/api/repository/TicketCrStatusWorkflowRepository.java
+++ b/api/src/main/java/com/ticketingSystem/api/repository/TicketCrStatusWorkflowRepository.java
@@ -1,0 +1,10 @@
+package com.ticketingSystem.api.repository;
+
+import com.ticketingSystem.api.models.TicketCrStatusWorkflow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TicketCrStatusWorkflowRepository extends JpaRepository<TicketCrStatusWorkflow, String> {
+    List<TicketCrStatusWorkflow> findByCurrentStatus_CrStatusIdAndActiveTrue(String currentStatusId);
+}

--- a/api/src/main/java/com/ticketingSystem/api/service/TicketCrService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/TicketCrService.java
@@ -2,6 +2,8 @@ package com.ticketingSystem.api.service;
 
 import com.ticketingSystem.api.dto.TicketCrCreateRequestDto;
 import com.ticketingSystem.api.dto.TicketCrDto;
+import com.ticketingSystem.api.dto.TicketCrStatusWorkflowDto;
+import com.ticketingSystem.api.dto.TicketCrUpdateStatusRequestDto;
 import com.ticketingSystem.api.models.CrStatusMaster;
 import com.ticketingSystem.api.models.Status;
 import com.ticketingSystem.api.models.Ticket;
@@ -10,6 +12,7 @@ import com.ticketingSystem.api.repository.CrStatusMasterRepository;
 import com.ticketingSystem.api.repository.StatusMasterRepository;
 import com.ticketingSystem.api.repository.TicketCrRepository;
 import com.ticketingSystem.api.repository.TicketRepository;
+import com.ticketingSystem.api.repository.TicketCrStatusWorkflowRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,6 +28,7 @@ public class TicketCrService {
     private final StatusMasterRepository statusMasterRepository;
     private final CrStatusMasterRepository crStatusMasterRepository;
     private final TicketCrIdGenerator ticketCrIdGenerator;
+    private final TicketCrStatusWorkflowRepository ticketCrStatusWorkflowRepository;
 
     public TicketCrDto create(TicketCrCreateRequestDto request) {
         Ticket ticket = ticketRepository.findById(request.getTicketId())
@@ -61,6 +65,39 @@ public class TicketCrService {
 
     public List<TicketCrDto> getAll() {
         return ticketCrRepository.findAll().stream().map(this::toDto).toList();
+    }
+
+
+    public List<TicketCrStatusWorkflowDto> getAvailableActions(String currentCrStatusId) {
+        return ticketCrStatusWorkflowRepository.findByCurrentStatus_CrStatusIdAndActiveTrue(currentCrStatusId)
+                .stream()
+                .map(workflow -> {
+                    TicketCrStatusWorkflowDto dto = new TicketCrStatusWorkflowDto();
+                    dto.setId(workflow.getId());
+                    dto.setAction(workflow.getAction());
+                    dto.setCurrentStatusId(workflow.getCurrentStatus().getCrStatusId());
+                    dto.setNextStatusId(workflow.getNextStatus().getCrStatusId());
+                    return dto;
+                })
+                .toList();
+    }
+
+    public TicketCrDto updateStatus(String ticketCrId, TicketCrUpdateStatusRequestDto request) {
+        TicketCr ticketCr = ticketCrRepository.findById(ticketCrId)
+                .orElseThrow(() -> new EntityNotFoundException("Ticket CR not found: " + ticketCrId));
+
+        var workflow = ticketCrStatusWorkflowRepository.findById(request.getWorkflowId())
+                .orElseThrow(() -> new EntityNotFoundException("Ticket CR workflow not found: " + request.getWorkflowId()));
+
+        if (!workflow.getCurrentStatus().getCrStatusId().equals(ticketCr.getCrStatus().getCrStatusId())) {
+            throw new IllegalArgumentException("Invalid workflow for current CR status");
+        }
+
+        ticketCr.setCrStatus(workflow.getNextStatus());
+        ticketCr.setRemarks(request.getRemarks());
+        ticketCr.setUpdatedBy(request.getUpdatedBy());
+
+        return toDto(ticketCrRepository.save(ticketCr));
     }
 
     private TicketCrDto toDto(TicketCr ticketCr) {

--- a/api/src/main/java/com/ticketingSystem/api/service/TicketCrService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/TicketCrService.java
@@ -73,7 +73,7 @@ public class TicketCrService {
                 .stream()
                 .map(workflow -> {
                     TicketCrStatusWorkflowDto dto = new TicketCrStatusWorkflowDto();
-                    dto.setId(workflow.getId());
+                    dto.setCrswId(workflow.getId());
                     dto.setAction(workflow.getAction());
                     dto.setCurrentStatusId(workflow.getCurrentStatus().getCrStatusId());
                     dto.setNextStatusId(workflow.getNextStatus().getCrStatusId());
@@ -86,8 +86,8 @@ public class TicketCrService {
         TicketCr ticketCr = ticketCrRepository.findById(ticketCrId)
                 .orElseThrow(() -> new EntityNotFoundException("Ticket CR not found: " + ticketCrId));
 
-        var workflow = ticketCrStatusWorkflowRepository.findById(request.getWorkflowId())
-                .orElseThrow(() -> new EntityNotFoundException("Ticket CR workflow not found: " + request.getWorkflowId()));
+        var workflow = ticketCrStatusWorkflowRepository.findById(request.getCrswId())
+                .orElseThrow(() -> new EntityNotFoundException("Ticket CR workflow not found: " + request.getCrswId()));
 
         if (!workflow.getCurrentStatus().getCrStatusId().equals(ticketCr.getCrStatus().getCrStatusId())) {
             throw new IllegalArgumentException("Invalid workflow for current CR status");

--- a/api/src/main/resources/db/migration/V13__create_ticket_cr_status_workflow.sql
+++ b/api/src/main/resources/db/migration/V13__create_ticket_cr_status_workflow.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS ticket_cr_status_workflow (
+    crsf_id VARCHAR(20) PRIMARY KEY,
+    action VARCHAR(100) NOT NULL,
+    current_status_id VARCHAR(20) NOT NULL,
+    next_status_id VARCHAR(20) NOT NULL,
+    created_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    created_by VARCHAR(100) NOT NULL DEFAULT 'SYSTEM',
+    updated_by VARCHAR(100) NOT NULL DEFAULT 'SYSTEM',
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    CONSTRAINT fk_ticket_cr_status_workflow_current_status FOREIGN KEY (current_status_id)
+        REFERENCES cr_status_master (cr_status_id),
+    CONSTRAINT fk_ticket_cr_status_workflow_next_status FOREIGN KEY (next_status_id)
+        REFERENCES cr_status_master (cr_status_id)
+);
+
+INSERT INTO ticket_cr_status_workflow
+    (crsf_id, action, current_status_id, next_status_id)
+VALUES
+    ('CRSF-1', 'Reject CR', 'CRS-1', 'CRS-3'),
+    ('CRSF-2', 'Approve CR', 'CRS-1', 'CRS-2');

--- a/api/src/main/resources/db/migration/V13__create_ticket_cr_status_workflow.sql
+++ b/api/src/main/resources/db/migration/V13__create_ticket_cr_status_workflow.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS ticket_cr_status_workflow (
-    crsf_id VARCHAR(20) PRIMARY KEY,
+    crsw_id VARCHAR(20) PRIMARY KEY,
     action VARCHAR(100) NOT NULL,
     current_status_id VARCHAR(20) NOT NULL,
     next_status_id VARCHAR(20) NOT NULL,
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS ticket_cr_status_workflow (
 );
 
 INSERT INTO ticket_cr_status_workflow
-    (crsf_id, action, current_status_id, next_status_id)
+    (crsw_id, action, current_status_id, next_status_id)
 VALUES
-    ('CRSF-1', 'Reject CR', 'CRS-1', 'CRS-3'),
-    ('CRSF-2', 'Approve CR', 'CRS-1', 'CRS-2');
+    ('CRSW-1', 'Reject CR', 'CRS-1', 'CRS-3'),
+    ('CRSW-2', 'Approve CR', 'CRS-1', 'CRS-2');

--- a/ui/src/pages/ViewCrTicket.tsx
+++ b/ui/src/pages/ViewCrTicket.tsx
@@ -36,10 +36,10 @@ const ViewCrTicket: React.FC = () => {
     }
   }, [changeRequest?.crStatusId]);
 
-  const handleCrActionClick = async (workflowId: string) => {
+  const handleCrActionClick = async (crswId: string) => {
     if (!ticketCrId) return;
     await apiHandler(() => updateChangeRequestStatus(ticketCrId, {
-      workflowId,
+      crswId,
       remarks: changeRequest?.remarks,
       updatedBy: 'SYSTEM',
     }));
@@ -144,11 +144,11 @@ const ViewCrTicket: React.FC = () => {
               <Stack direction="row" spacing={1} mt={2}>
                 {actions.map(action => (
                   <Button
-                    key={action.id}
+                    key={action.crswId}
                     size="small"
                     variant={action.action === 'Reject CR' ? 'outlined' : 'contained'}
                     color="success"
-                    onClick={() => handleCrActionClick(action.id)}
+                    onClick={() => handleCrActionClick(action.crswId)}
                   >
                     {action.action}
                   </Button>

--- a/ui/src/pages/ViewCrTicket.tsx
+++ b/ui/src/pages/ViewCrTicket.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Alert, Box, Chip, CircularProgress, Divider, Grid, Paper, Stack, Typography } from '@mui/material';
+import { Alert, Box, Button, Chip, CircularProgress, Divider, Grid, Paper, Stack, Typography } from '@mui/material';
 import { useApi } from '../hooks/useApi';
-import { getChangeRequestById } from '../services/TicketCrService';
+import { getChangeRequestActions, getChangeRequestById, updateChangeRequestStatus } from '../services/TicketCrService';
 
 const formatDateTime = (value?: string) => {
   if (!value) return '-';
@@ -24,6 +24,27 @@ const ViewCrTicket: React.FC = () => {
       void apiHandler(() => getChangeRequestById(ticketCrId));
     }
   }, [ticketCrId, apiHandler]);
+
+
+  const [actions, setActions] = useState<any[]>([]);
+
+  useEffect(() => {
+    if (changeRequest?.crStatusId) {
+      void getChangeRequestActions(changeRequest.crStatusId)
+        .then(res => setActions(Array.isArray(res.data) ? res.data : []))
+        .catch(() => setActions([]));
+    }
+  }, [changeRequest?.crStatusId]);
+
+  const handleCrActionClick = async (workflowId: string) => {
+    if (!ticketCrId) return;
+    await apiHandler(() => updateChangeRequestStatus(ticketCrId, {
+      workflowId,
+      remarks: changeRequest?.remarks,
+      updatedBy: 'SYSTEM',
+    }));
+    await apiHandler(() => getChangeRequestById(ticketCrId));
+  };
 
   const createdOnText = useMemo(() => formatDateTime(changeRequest?.createdDate), [changeRequest?.createdDate]);
   const updatedOnText = useMemo(() => formatDateTime(changeRequest?.updatedOn), [changeRequest?.updatedOn]);
@@ -118,6 +139,23 @@ const ViewCrTicket: React.FC = () => {
                 <Typography variant="caption" color="text.secondary">Remarks</Typography>
                 <Typography variant="body2">{changeRequest.remarks || '-'}</Typography>
               </Box>
+
+            {actions.length > 0 && (
+              <Stack direction="row" spacing={1} mt={2}>
+                {actions.map(action => (
+                  <Button
+                    key={action.id}
+                    size="small"
+                    variant={action.action === 'Reject CR' ? 'outlined' : 'contained'}
+                    color="success"
+                    onClick={() => handleCrActionClick(action.id)}
+                  >
+                    {action.action}
+                  </Button>
+                ))}
+              </Stack>
+            )}
+
             </Stack>
           </Paper>
 

--- a/ui/src/services/TicketCrService.ts
+++ b/ui/src/services/TicketCrService.ts
@@ -16,3 +16,11 @@ export function createChangeRequest(payload: any) {
 export function getChangeRequestById(ticketCrId: string) {
     return apiClient.get(`${BASE_URL}/ticket-cr/${ticketCrId}`);
 }
+
+export function getChangeRequestActions(crStatusId: string) {
+    return apiClient.get(`${BASE_URL}/ticket-cr/actions/${crStatusId}`);
+}
+
+export function updateChangeRequestStatus(ticketCrId: string, payload: any) {
+    return apiClient.patch(`${BASE_URL}/ticket-cr/${ticketCrId}/status`, payload);
+}


### PR DESCRIPTION
### Motivation
- Support approving and rejecting Change Requests (CR) from the CR details page by modeling CR status transitions in the DB and exposing actions from the backend.  
- Reuse the same workflow pattern as `ticket_status_workflow` so CR transitions are configurable and driven by data.  

### Description
- Added Flyway migration `V13__create_ticket_cr_status_workflow.sql` to create `ticket_cr_status_workflow` with columns `crsf_id`, `action`, `current_status_id`, `next_status_id`, `created_on`, `updated_on`, `created_by`, `updated_by`, and `active`, and seeded two rows: `CRSF-1` (`Reject CR`, `CRS-1`→`CRS-3`) and `CRSF-2` (`Approve CR`, `CRS-1`→`CRS-2`); defaults set to current timestamp / `SYSTEM` / `true` as requested.  
- Backend: introduced `TicketCrStatusWorkflow` entity, `TicketCrStatusWorkflowRepository`, DTOs `TicketCrStatusWorkflowDto` and `TicketCrUpdateStatusRequestDto`, and extended `TicketCrService` with `getAvailableActions` and `updateStatus` (validates workflow matches current CR status and applies the transition).  
- Controller: added endpoints `GET /ticket-cr/actions/{crStatusId}` and `PATCH /ticket-cr/{ticketCrId}/status` to retrieve actions and apply workflow transitions.  
- UI: updated `ViewCrTicket` to load available CR actions for the current CR status, render action buttons (e.g. `Approve CR`, `Reject CR`) and call the new `PATCH` API to update CR status and refresh details; added client-side helpers `getChangeRequestActions` and `updateChangeRequestStatus` in `ui/src/services/TicketCrService.ts`.  

### Testing
- Attempted to compile backend with `cd api && mvn -q -DskipTests compile`, which failed in this environment because no `pom.xml` is present at `/workspace/TicketingSystem/api`.  
- Attempted to run the CR view UI test with `cd ui && npm run -s test -- ViewCrTicket --watch=false`, which failed in this environment due to missing `react-scripts`.  
- Verified file-level changes and created migration, model, repo, DTOs, service methods, controller endpoints, and UI changes locally in the working tree; no automated tests passed in this CI-like environment due to missing build/test tool setup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7a7915a708332bc6e8ae821b0bb1d)