### PR TITLE
Add CR status workflow action mapping column to role_permission_config

### DIFF
--- a/db/queries/add_cr_status_action_ids_to_role_permission_config.sql
+++ b/db/queries/add_cr_status_action_ids_to_role_permission_config.sql
@@ -1,0 +1,11 @@
+-- Add CR status workflow action mapping column (pipe-separated IDs, Option A)
+ALTER TABLE role_permission_config
+    ADD COLUMN allowed_cr_status_action_ids VARCHAR(255) DEFAULT NULL
+    AFTER allowed_status_action_ids;
+
+-- Set CR workflow action IDs for CR Approver role
+-- Replace the sample IDs below with your final CR status workflow IDs.
+UPDATE role_permission_config
+SET allowed_cr_status_action_ids = '1|2|3'
+WHERE role = 'CR Approver'
+  AND is_deleted = 0;


### PR DESCRIPTION
### Motivation
- Introduce a column to store CR status workflow action IDs per role to support CR-specific workflow permissions.

### Description
- Add SQL migration `db/queries/add_cr_status_action_ids_to_role_permission_config.sql` which adds `allowed_cr_status_action_ids` VARCHAR(255) to `role_permission_config` and seeds a sample pipe-separated value `'1|2|3'` for the `CR Approver` role.

### Testing
- No automated tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ad03774483329479b785fd34d56b)