### PR TITLE
Filter CR action buttons by role permission action IDs

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/controller/AuthController.java
+++ b/api/src/main/java/com/ticketingSystem/api/controller/AuthController.java
@@ -81,11 +81,19 @@ public class AuthController {
                     RolePermission permissions = permissionService.mergeRolePermissions(roleIds);
 
                     Set<String> allowedStatusActionIds = new HashSet<>();
+                    Set<String> allowedCrStatusActionIds = new HashSet<>();
                     roleRepository.findAllById(roleIds).forEach(r -> {
                         if (r.getAllowedStatusActionIds() != null) {
                             for (String s : r.getAllowedStatusActionIds().split("\\|")) {
                                 if (!s.isBlank()) {
                                     allowedStatusActionIds.add(s.trim());
+                                }
+                            }
+                        }
+                        if (r.getAllowedCrStatusActionIds() != null) {
+                            for (String s : r.getAllowedCrStatusActionIds().split("\\|")) {
+                                if (!s.isBlank()) {
+                                    allowedCrStatusActionIds.add(s.trim());
                                 }
                             }
                         }
@@ -110,6 +118,7 @@ public class AuthController {
                             .levels(levels)
                             .permissions(permissions)
                             .allowedStatusActionIds(allowedStatusActionIds)
+                            .allowedCrStatusActionIds(allowedCrStatusActionIds)
                             .officeType(user.getOfficeType())
                             .officeCode(user.getOfficeCode())
                             .zoneCode(user.getZoneCode())
@@ -135,6 +144,7 @@ public class AuthController {
                     responseBody.put("permissions", permissions);
                     responseBody.put("levels", levels);
                     responseBody.put("allowedStatusActionIds", allowedStatusActionIds);
+                    responseBody.put("allowedCrStatusActionIds", allowedCrStatusActionIds);
                     responseBody.put("officeType", user.getOfficeType());
                     responseBody.put("officeCode", user.getOfficeCode());
                     responseBody.put("zoneCode", user.getZoneCode());
@@ -252,6 +262,7 @@ public class AuthController {
         responseBody.put("permissions", payload.getPermissions());
         responseBody.put("levels", payload.getLevels());
         responseBody.put("allowedStatusActionIds", payload.getAllowedStatusActionIds());
+        responseBody.put("allowedCrStatusActionIds", payload.getAllowedCrStatusActionIds());
         responseBody.put("officeType", payload.getOfficeType());
         responseBody.put("officeCode", payload.getOfficeCode());
         responseBody.put("zoneCode", payload.getZoneCode());

--- a/api/src/main/java/com/ticketingSystem/api/controller/TicketCrController.java
+++ b/api/src/main/java/com/ticketingSystem/api/controller/TicketCrController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/ticket-cr")
@@ -35,6 +36,13 @@ public class TicketCrController {
     @GetMapping("/actions/{crStatusId}")
     public ResponseEntity<List<TicketCrStatusWorkflowDto>> getAvailableActions(@PathVariable String crStatusId) {
         return ResponseEntity.ok(ticketCrService.getAvailableActions(crStatusId));
+    }
+
+
+    @PostMapping("/mappings")
+    public ResponseEntity<Map<String, List<TicketCrStatusWorkflowDto>>> getMappingsByRole(@RequestBody List<String> roles) {
+        List<Integer> ids = roles.stream().map(Integer::parseInt).toList();
+        return ResponseEntity.ok(ticketCrService.getMappingsByRoles(ids));
     }
 
     @PatchMapping("/{ticketCrId}/status")

--- a/api/src/main/java/com/ticketingSystem/api/dto/LoginPayload.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/LoginPayload.java
@@ -26,6 +26,7 @@ public class LoginPayload {
     private List<String> levels;
     private RolePermission permissions;
     private Set<String> allowedStatusActionIds;
+    private Set<String> allowedCrStatusActionIds;
     private String officeType;
     private String officeCode;
     private String zoneCode;

--- a/api/src/main/java/com/ticketingSystem/api/models/Role.java
+++ b/api/src/main/java/com/ticketingSystem/api/models/Role.java
@@ -26,6 +26,9 @@ public class Role {
     @Column(name = "allowed_status_action_ids")
     private String allowedStatusActionIds;
 
+    @Column(name = "allowed_cr_status_action_ids")
+    private String allowedCrStatusActionIds;
+
     @Column(name = "parameter_ids")
     private String parameterMaster;
 

--- a/api/src/main/java/com/ticketingSystem/api/service/JwtTokenService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/JwtTokenService.java
@@ -62,6 +62,7 @@ public class JwtTokenService {
         claims.put("roles", payload.getRoles());
         claims.put("levels", payload.getLevels());
         claims.put("allowedStatusActionIds", payload.getAllowedStatusActionIds());
+        claims.put("allowedCrStatusActionIds", payload.getAllowedCrStatusActionIds());
         claims.put("officeType", payload.getOfficeType());
         claims.put("officeCode", payload.getOfficeCode());
         claims.put("zoneCode", payload.getZoneCode());
@@ -163,6 +164,7 @@ public class JwtTokenService {
                 .roles(convertList(claims.get("roles")))
                 .levels(convertList(claims.get("levels")))
                 .allowedStatusActionIds(convertSet(claims.get("allowedStatusActionIds")))
+                .allowedCrStatusActionIds(convertSet(claims.get("allowedCrStatusActionIds")))
                 .officeType(claims.get("officeType", String.class))
                 .officeCode(claims.get("officeCode", String.class))
                 .zoneCode(claims.get("zoneCode", String.class))

--- a/api/src/main/java/com/ticketingSystem/api/service/SsoAuthService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/SsoAuthService.java
@@ -61,11 +61,19 @@ public class SsoAuthService {
         RolePermission permissions = permissionService.mergeRolePermissions(roleIds);
 
         Set<String> allowedStatusActionIds = new HashSet<>();
+        Set<String> allowedCrStatusActionIds = new HashSet<>();
         roleRepository.findAllById(roleIds).forEach(r -> {
             if (r.getAllowedStatusActionIds() != null) {
                 for (String s : r.getAllowedStatusActionIds().split("\\|")) {
                     if (!s.isBlank()) {
                         allowedStatusActionIds.add(s.trim());
+                    }
+                }
+            }
+            if (r.getAllowedCrStatusActionIds() != null) {
+                for (String s : r.getAllowedCrStatusActionIds().split("\\|")) {
+                    if (!s.isBlank()) {
+                        allowedCrStatusActionIds.add(s.trim());
                     }
                 }
             }
@@ -90,6 +98,7 @@ public class SsoAuthService {
                 .levels(levels)
                 .permissions(permissions)
                 .allowedStatusActionIds(allowedStatusActionIds)
+                .allowedCrStatusActionIds(allowedCrStatusActionIds)
                 .officeType(user.getOfficeType())
                 .officeCode(user.getOfficeCode())
                 .zoneCode(user.getZoneCode())
@@ -116,6 +125,7 @@ public class SsoAuthService {
         response.put("permissions", permissions);
         response.put("levels", levels);
         response.put("allowedStatusActionIds", allowedStatusActionIds);
+        response.put("allowedCrStatusActionIds", allowedCrStatusActionIds);
         response.put("officeType", user.getOfficeType());
         response.put("officeCode", user.getOfficeCode());
         response.put("zoneCode", user.getZoneCode());

--- a/api/src/main/java/com/ticketingSystem/api/service/TicketCrService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/TicketCrService.java
@@ -8,16 +8,22 @@ import com.ticketingSystem.api.models.CrStatusMaster;
 import com.ticketingSystem.api.models.Status;
 import com.ticketingSystem.api.models.Ticket;
 import com.ticketingSystem.api.models.TicketCr;
+import com.ticketingSystem.api.models.Role;
 import com.ticketingSystem.api.repository.CrStatusMasterRepository;
 import com.ticketingSystem.api.repository.StatusMasterRepository;
 import com.ticketingSystem.api.repository.TicketCrRepository;
 import com.ticketingSystem.api.repository.TicketRepository;
 import com.ticketingSystem.api.repository.TicketCrStatusWorkflowRepository;
+import com.ticketingSystem.api.repository.RoleRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +35,7 @@ public class TicketCrService {
     private final CrStatusMasterRepository crStatusMasterRepository;
     private final TicketCrIdGenerator ticketCrIdGenerator;
     private final TicketCrStatusWorkflowRepository ticketCrStatusWorkflowRepository;
+    private final RoleRepository roleRepository;
 
     public TicketCrDto create(TicketCrCreateRequestDto request) {
         Ticket ticket = ticketRepository.findById(request.getTicketId())
@@ -82,6 +89,36 @@ public class TicketCrService {
                 .toList();
     }
 
+
+
+    public Map<String, List<TicketCrStatusWorkflowDto>> getMappingsByRoles(List<Integer> roles) {
+        Set<String> ids = new HashSet<>();
+        if (roles == null || roles.isEmpty()) {
+            return Map.of();
+        }
+
+        for (Role role : roleRepository.findAllById(roles)) {
+            String allowed = role.getAllowedCrStatusActionIds();
+            if (allowed != null && !allowed.isBlank()) {
+                for (String s : allowed.split("\\|")) {
+                    if (!s.isBlank()) {
+                        ids.add(s.trim());
+                    }
+                }
+            }
+        }
+
+        return ticketCrStatusWorkflowRepository.findAllById(ids).stream()
+                .map(workflow -> {
+                    TicketCrStatusWorkflowDto dto = new TicketCrStatusWorkflowDto();
+                    dto.setCrswId(workflow.getId());
+                    dto.setAction(workflow.getAction());
+                    dto.setCurrentStatusId(workflow.getCurrentStatus().getCrStatusId());
+                    dto.setNextStatusId(workflow.getNextStatus().getCrStatusId());
+                    return dto;
+                })
+                .collect(Collectors.groupingBy(TicketCrStatusWorkflowDto::getCurrentStatusId));
+    }
     public TicketCrDto updateStatus(String ticketCrId, TicketCrUpdateStatusRequestDto request) {
         TicketCr ticketCr = ticketCrRepository.findById(ticketCrId)
                 .orElseThrow(() -> new EntityNotFoundException("Ticket CR not found: " + ticketCrId));

--- a/ui/src/pages/ViewCrTicket.tsx
+++ b/ui/src/pages/ViewCrTicket.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Alert, Box, Button, Chip, CircularProgress, Divider, Grid, Paper, Stack, Typography } from '@mui/material';
 import { useApi } from '../hooks/useApi';
-import { getChangeRequestActions, getChangeRequestById, updateChangeRequestStatus } from '../services/TicketCrService';
+import { getChangeRequestById, getCrStatusWorkflowMappings, updateChangeRequestStatus } from '../services/TicketCrService';
 import { getCurrentUserDetails } from '../config/config';
 
 const formatDateTime = (value?: string) => {
@@ -34,17 +34,24 @@ const ViewCrTicket: React.FC = () => {
   }, [ticketCrId, apiHandler]);
 
 
-  const [actions, setActions] = useState<any[]>([]);
+  const [statusWorkflows, setStatusWorkflows] = useState<Record<string, any[]>>({});
 
-  const allowedCrActionIds = useMemo(() => normalizeAllowedActionIds(getCurrentUserDetails()?.allowedCrStatusActionIds), []);
+  const userDetails = useMemo(() => getCurrentUserDetails(), []);
+  const allowedCrActionIds = useMemo(() => normalizeAllowedActionIds(userDetails?.allowedCrStatusActionIds), [userDetails]);
+  const roleList = userDetails?.role ?? [];
 
   useEffect(() => {
-    if (changeRequest?.crStatusId) {
-      void getChangeRequestActions(changeRequest.crStatusId)
-        .then(res => setActions(Array.isArray(res.data) ? res.data : []))
-        .catch(() => setActions([]));
-    }
-  }, [changeRequest?.crStatusId]);
+    if (!roleList.length) return;
+    void getCrStatusWorkflowMappings(roleList)
+      .then((res) => setStatusWorkflows(res.data && typeof res.data === "object" ? res.data : {}))
+      .catch(() => setStatusWorkflows({}));
+  }, [roleList]);
+
+  const actions = useMemo(() => {
+    if (!changeRequest?.crStatusId) return [];
+    const workflows = statusWorkflows[changeRequest.crStatusId] || [];
+    return workflows.filter((action) => allowedCrActionIds.has(String(action.crswId)));
+  }, [changeRequest?.crStatusId, statusWorkflows, allowedCrActionIds]);
 
   const handleCrActionClick = async (crswId: string) => {
     if (!ticketCrId) return;
@@ -152,9 +159,7 @@ const ViewCrTicket: React.FC = () => {
 
             {actions.length > 0 && (
               <Stack direction="row" spacing={1} mt={2}>
-                {actions
-                  .filter((action) => allowedCrActionIds.has(String(action.crswId)))
-                  .map(action => (
+                {actions.map(action => (
                   <Button
                     key={action.crswId}
                     size="small"

--- a/ui/src/pages/ViewCrTicket.tsx
+++ b/ui/src/pages/ViewCrTicket.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { Alert, Box, Button, Chip, CircularProgress, Divider, Grid, Paper, Stack, Typography } from '@mui/material';
 import { useApi } from '../hooks/useApi';
@@ -26,6 +26,7 @@ const normalizeAllowedActionIds = (raw: unknown): Set<string> => {
 const ViewCrTicket: React.FC = () => {
   const { ticketCrId } = useParams<{ ticketCrId: string }>();
   const { data: changeRequest, apiHandler, pending } = useApi<any>();
+  const { data: workflowMappings, apiHandler: workflowApiHandler } = useApi<Record<string, any[]>>();
 
   useEffect(() => {
     if (ticketCrId) {
@@ -33,25 +34,20 @@ const ViewCrTicket: React.FC = () => {
     }
   }, [ticketCrId, apiHandler]);
 
-
-  const [statusWorkflows, setStatusWorkflows] = useState<Record<string, any[]>>({});
-
   const userDetails = useMemo(() => getCurrentUserDetails(), []);
   const allowedCrActionIds = useMemo(() => normalizeAllowedActionIds(userDetails?.allowedCrStatusActionIds), [userDetails]);
   const roleList = userDetails?.role ?? [];
 
   useEffect(() => {
     if (!roleList.length) return;
-    void getCrStatusWorkflowMappings(roleList)
-      .then((res) => setStatusWorkflows(res.data && typeof res.data === "object" ? res.data : {}))
-      .catch(() => setStatusWorkflows({}));
-  }, [roleList]);
+    void workflowApiHandler(() => getCrStatusWorkflowMappings(roleList));
+  }, [roleList, workflowApiHandler]);
 
   const actions = useMemo(() => {
     if (!changeRequest?.crStatusId) return [];
-    const workflows = statusWorkflows[changeRequest.crStatusId] || [];
+    const workflows = workflowMappings?.[changeRequest.crStatusId] || [];
     return workflows.filter((action) => allowedCrActionIds.has(String(action.crswId)));
-  }, [changeRequest?.crStatusId, statusWorkflows, allowedCrActionIds]);
+  }, [changeRequest?.crStatusId, workflowMappings, allowedCrActionIds]);
 
   const handleCrActionClick = async (crswId: string) => {
     if (!ticketCrId) return;

--- a/ui/src/pages/ViewCrTicket.tsx
+++ b/ui/src/pages/ViewCrTicket.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { Alert, Box, Button, Chip, CircularProgress, Divider, Grid, Paper, Stack, Typography } from '@mui/material';
 import { useApi } from '../hooks/useApi';
 import { getChangeRequestActions, getChangeRequestById, updateChangeRequestStatus } from '../services/TicketCrService';
+import { getCurrentUserDetails } from '../config/config';
 
 const formatDateTime = (value?: string) => {
   if (!value) return '-';
@@ -14,6 +15,13 @@ const formatDateTime = (value?: string) => {
 };
 
 const statusColor = (crStatusColor?: string) => crStatusColor || '#94A3B8';
+
+
+const normalizeAllowedActionIds = (raw: unknown): Set<string> => {
+  if (Array.isArray(raw)) return new Set(raw.map((id) => String(id)));
+  if (typeof raw === 'string') return new Set(raw.split('|').map((id) => id.trim()).filter(Boolean));
+  return new Set<string>();
+};
 
 const ViewCrTicket: React.FC = () => {
   const { ticketCrId } = useParams<{ ticketCrId: string }>();
@@ -27,6 +35,8 @@ const ViewCrTicket: React.FC = () => {
 
 
   const [actions, setActions] = useState<any[]>([]);
+
+  const allowedCrActionIds = useMemo(() => normalizeAllowedActionIds(getCurrentUserDetails()?.allowedCrStatusActionIds), []);
 
   useEffect(() => {
     if (changeRequest?.crStatusId) {
@@ -142,7 +152,9 @@ const ViewCrTicket: React.FC = () => {
 
             {actions.length > 0 && (
               <Stack direction="row" spacing={1} mt={2}>
-                {actions.map(action => (
+                {actions
+                  .filter((action) => allowedCrActionIds.has(String(action.crswId)))
+                  .map(action => (
                   <Button
                     key={action.crswId}
                     size="small"

--- a/ui/src/services/TicketCrService.ts
+++ b/ui/src/services/TicketCrService.ts
@@ -24,3 +24,7 @@ export function getChangeRequestActions(crStatusId: string) {
 export function updateChangeRequestStatus(ticketCrId: string, payload: any) {
     return apiClient.patch(`${BASE_URL}/ticket-cr/${ticketCrId}/status`, payload);
 }
+
+export function getCrStatusWorkflowMappings(roles: string[]) {
+    return apiClient.post(`${BASE_URL}/ticket-cr/mappings`, roles);
+}

--- a/ui/src/types/auth.ts
+++ b/ui/src/types/auth.ts
@@ -18,6 +18,7 @@ export interface UserDetails {
   email?: string;
   phone?: string;
   allowedStatusActionIds?: string[];
+  allowedCrStatusActionIds?: string[];
   officeCode?: string;
   officeType?: string;
   zoneCode?: string;
@@ -54,6 +55,7 @@ export interface LoginResponse {
     levels?: string[];
     name?: string;
     allowedStatusActionIds?: string[];
+    allowedCrStatusActionIds?: string[];
     email?: string;
     emailId?: string;
     emailID?: string;

--- a/ui/src/utils/session.ts
+++ b/ui/src/utils/session.ts
@@ -87,6 +87,9 @@ export async function persistLoginData(
     email: emailFromResponse,
     phone: phoneFromResponse,
     allowedStatusActionIds: data.allowedStatusActionIds ?? [],
+    allowedCrStatusActionIds: data.allowedCrStatusActionIds
+      ?? data.allowed_cr_status_action_ids
+      ?? [],
     officeCode: pickString(locationSources, ["officeCode", "office_code", "officeCd"]),
     officeType: pickString(locationSources, ["officeType", "office_type", "officeTypeCode"]),
     zoneCode: pickString(locationSources, ["zoneCode", "zone_code", "zoCode", "zo_code"]),


### PR DESCRIPTION
### Motivation
- Ensure CR action buttons (e.g. Approve CR / Reject CR) are shown only when the current user's role permits the specific CR workflow actions as defined in `role_permission_config.allowed_cr_status_action_ids`.

### Description
- Add `allowedCrStatusActionIds` to UI auth typings so the login/session payload can carry CR action permission IDs (`ui/src/types/auth.ts`).
- Persist `allowedCrStatusActionIds` from login/session payloads with a snake_case fallback `allowed_cr_status_action_ids` into stored user details (`ui/src/utils/session.ts`).
- Filter the change request actions rendered on the CR detail page by the current user’s allowed CR action IDs, using a `normalizeAllowedActionIds` helper and `getCurrentUserDetails()` to read permissions (`ui/src/pages/ViewCrTicket.tsx`).

### Testing
- Ran targeted Jest invocation for the CR view pattern with `cd ui && npm run -s test -- ViewCrTicket --watch=false`, which completed with no tests matched (exit 0).
- Attempted production build with `cd ui && npm run -s build`, which failed in this environment due to a missing dependency (`react-i18next`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b241430c8332ac9a7913084ed8de)