### PR TITLE
Require remark on CR actions and log CR status changes to ticket_cr_history

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/models/TicketCrHistory.java
+++ b/api/src/main/java/com/ticketingSystem/api/models/TicketCrHistory.java
@@ -1,0 +1,44 @@
+package com.ticketingSystem.api.models;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "ticket_cr_history")
+@Getter
+@Setter
+public class TicketCrHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ticket_cr_id", referencedColumnName = "ticket_cr_id", nullable = false)
+    private TicketCr ticketCr;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "previous_cr_status_id", referencedColumnName = "cr_status_id")
+    private CrStatusMaster previousCrStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "current_cr_status_id", referencedColumnName = "cr_status_id", nullable = false)
+    private CrStatusMaster currentCrStatus;
+
+    @Column(name = "remarks", columnDefinition = "TEXT")
+    private String remarks;
+
+    @Column(name = "updated_by", nullable = false)
+    private String updatedBy;
+
+    @Column(name = "updated_on", nullable = false)
+    private LocalDateTime updatedOn;
+
+    @PrePersist
+    protected void onCreate() {
+        this.updatedOn = LocalDateTime.now();
+    }
+}

--- a/api/src/main/java/com/ticketingSystem/api/repository/TicketCrHistoryRepository.java
+++ b/api/src/main/java/com/ticketingSystem/api/repository/TicketCrHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.ticketingSystem.api.repository;
+
+import com.ticketingSystem.api.models.TicketCrHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TicketCrHistoryRepository extends JpaRepository<TicketCrHistory, Long> {
+}

--- a/api/src/main/java/com/ticketingSystem/api/service/TicketCrService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/TicketCrService.java
@@ -8,12 +8,14 @@ import com.ticketingSystem.api.models.CrStatusMaster;
 import com.ticketingSystem.api.models.Status;
 import com.ticketingSystem.api.models.Ticket;
 import com.ticketingSystem.api.models.TicketCr;
+import com.ticketingSystem.api.models.TicketCrHistory;
 import com.ticketingSystem.api.models.Role;
 import com.ticketingSystem.api.repository.CrStatusMasterRepository;
 import com.ticketingSystem.api.repository.StatusMasterRepository;
 import com.ticketingSystem.api.repository.TicketCrRepository;
 import com.ticketingSystem.api.repository.TicketRepository;
 import com.ticketingSystem.api.repository.TicketCrStatusWorkflowRepository;
+import com.ticketingSystem.api.repository.TicketCrHistoryRepository;
 import com.ticketingSystem.api.repository.RoleRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +37,7 @@ public class TicketCrService {
     private final CrStatusMasterRepository crStatusMasterRepository;
     private final TicketCrIdGenerator ticketCrIdGenerator;
     private final TicketCrStatusWorkflowRepository ticketCrStatusWorkflowRepository;
+    private final TicketCrHistoryRepository ticketCrHistoryRepository;
     private final RoleRepository roleRepository;
 
     public TicketCrDto create(TicketCrCreateRequestDto request) {
@@ -130,11 +133,23 @@ public class TicketCrService {
             throw new IllegalArgumentException("Invalid workflow for current CR status");
         }
 
+        CrStatusMaster previousStatus = ticketCr.getCrStatus();
+
         ticketCr.setCrStatus(workflow.getNextStatus());
         ticketCr.setRemarks(request.getRemarks());
         ticketCr.setUpdatedBy(request.getUpdatedBy());
 
-        return toDto(ticketCrRepository.save(ticketCr));
+        TicketCr saved = ticketCrRepository.save(ticketCr);
+
+        TicketCrHistory history = new TicketCrHistory();
+        history.setTicketCr(saved);
+        history.setPreviousCrStatus(previousStatus);
+        history.setCurrentCrStatus(saved.getCrStatus());
+        history.setRemarks(request.getRemarks());
+        history.setUpdatedBy(request.getUpdatedBy() != null && !request.getUpdatedBy().isBlank() ? request.getUpdatedBy() : "SYSTEM");
+        ticketCrHistoryRepository.save(history);
+
+        return toDto(saved);
     }
 
     private TicketCrDto toDto(TicketCr ticketCr) {

--- a/api/src/main/resources/db/migration/V14__create_ticket_cr_history_table.sql
+++ b/api/src/main/resources/db/migration/V14__create_ticket_cr_history_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS ticket_cr_history (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    ticket_cr_id VARCHAR(20) NOT NULL,
+    previous_cr_status_id VARCHAR(255),
+    current_cr_status_id VARCHAR(255) NOT NULL,
+    remarks TEXT,
+    updated_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_by VARCHAR(255) NOT NULL,
+    CONSTRAINT fk_ticket_cr_history_ticket_cr FOREIGN KEY (ticket_cr_id) REFERENCES ticket_cr(ticket_cr_id),
+    CONSTRAINT fk_ticket_cr_history_prev_status FOREIGN KEY (previous_cr_status_id) REFERENCES cr_status_master(cr_status_id),
+    CONSTRAINT fk_ticket_cr_history_curr_status FOREIGN KEY (current_cr_status_id) REFERENCES cr_status_master(cr_status_id)
+);
+
+CREATE INDEX idx_ticket_cr_history_ticket_cr_id ON ticket_cr_history(ticket_cr_id);
+CREATE INDEX idx_ticket_cr_history_updated_on ON ticket_cr_history(updated_on);

--- a/ui/src/pages/ViewCrTicket.tsx
+++ b/ui/src/pages/ViewCrTicket.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link as RouterLink, useParams } from 'react-router-dom';
 import { Alert, Box, CircularProgress, Divider, Link, Paper, Stack, Tooltip, Typography } from '@mui/material';
 import { useApi } from '../hooks/useApi';
 import { getChangeRequestById, getCrStatusWorkflowMappings, updateChangeRequestStatus } from '../services/TicketCrService';
 import { getCurrentUserDetails } from '../config/config';
 import GenericButton from '../components/UI/Button';
+import RemarkComponent from '../components/UI/Remark/RemarkComponent';
 
 const formatDateTime = (value?: string) => {
   if (!value) return '-';
@@ -27,6 +28,7 @@ const ViewCrTicket: React.FC = () => {
   const { ticketCrId } = useParams<{ ticketCrId: string }>();
   const { data: changeRequest, apiHandler, pending } = useApi<any>();
   const { data: workflowMappings, apiHandler: workflowApiHandler } = useApi<Record<string, any[]>>();
+  const [selectedAction, setSelectedAction] = useState<any | null>(null);
 
   useEffect(() => {
     if (ticketCrId) {
@@ -49,13 +51,14 @@ const ViewCrTicket: React.FC = () => {
     return workflows.filter((action) => allowedCrActionIds.has(String(action.crswId)));
   }, [changeRequest?.crStatusId, workflowMappings, allowedCrActionIds]);
 
-  const handleCrActionClick = async (crswId: string) => {
-    if (!ticketCrId) return;
+  const handleCrActionSubmit = async (remark: string) => {
+    if (!ticketCrId || !selectedAction?.crswId) return;
     await apiHandler(() => updateChangeRequestStatus(ticketCrId, {
-      crswId,
-      remarks: changeRequest?.remarks,
-      updatedBy: 'SYSTEM',
+      crswId: selectedAction.crswId,
+      remarks: remark,
+      updatedBy: userDetails?.userName || userDetails?.username || 'SYSTEM',
     }));
+    setSelectedAction(null);
     await apiHandler(() => getChangeRequestById(ticketCrId));
   };
 
@@ -87,7 +90,7 @@ const ViewCrTicket: React.FC = () => {
                       size="small"
                       variant={action.action === 'Reject CR' ? 'outlined' : 'contained'}
                       color="success"
-                      onClick={() => handleCrActionClick(action.crswId)}
+                      onClick={() => setSelectedAction(action)}
                     >
                       {action.action}
                     </GenericButton>
@@ -148,6 +151,17 @@ const ViewCrTicket: React.FC = () => {
               </Typography>
             </Box>
       </Paper>
+      <RemarkComponent
+        isModal
+        open={Boolean(selectedAction)}
+        title={selectedAction?.action || 'Update CR'}
+        actionName={selectedAction?.action}
+        textFieldLabel="Remark"
+        placeholder="Enter remark"
+        multiline
+        onSubmit={handleCrActionSubmit}
+        onCancel={() => setSelectedAction(null)}
+      />
     </Box>
   );
 };


### PR DESCRIPTION
### Motivation
- Make CR status transitions (approve/reject and other CR actions) consistent with ticket flow by requiring a remark before submitting the action. 
- Persist an audit trail of all CR updates so any change to a CR ticket is logged for review and reporting. 

### Description
- UI: Updated `ui/src/pages/ViewCrTicket.tsx` to open the existing `RemarkComponent` as a modal when a CR action button is clicked, and to send the user-entered `remark` and actor (`updatedBy`) in the update payload. 
- Backend: Added `TicketCrHistory` JPA entity and `TicketCrHistoryRepository`, and updated `TicketCrService.updateStatus` to capture the previous CR status, save the updated `TicketCr`, then create a `TicketCrHistory` row with previous/current status, `remarks`, `updatedBy`, and timestamp. 
- Database: Added Flyway migration `api/src/main/resources/db/migration/V14__create_ticket_cr_history_table.sql` which creates the `ticket_cr_history` table (FKs to `ticket_cr` and `cr_status_master`) and adds indexes on `ticket_cr_id` and `updated_on`.
- SQL provided to create the history table is included in the migration and is: 

```
CREATE TABLE IF NOT EXISTS ticket_cr_history (
    id BIGINT PRIMARY KEY AUTO_INCREMENT,
    ticket_cr_id VARCHAR(20) NOT NULL,
    previous_cr_status_id VARCHAR(255),
    current_cr_status_id VARCHAR(255) NOT NULL,
    remarks TEXT,
    updated_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
    updated_by VARCHAR(255) NOT NULL,
    CONSTRAINT fk_ticket_cr_history_ticket_cr FOREIGN KEY (ticket_cr_id) REFERENCES ticket_cr(ticket_cr_id),
    CONSTRAINT fk_ticket_cr_history_prev_status FOREIGN KEY (previous_cr_status_id) REFERENCES cr_status_master(cr_status_id),
    CONSTRAINT fk_ticket_cr_history_curr_status FOREIGN KEY (current_cr_status_id) REFERENCES cr_status_master(cr_status_id)
);

CREATE INDEX idx_ticket_cr_history_ticket_cr_id ON ticket_cr_history(ticket_cr_id);
CREATE INDEX idx_ticket_cr_history_updated_on ON ticket_cr_history(updated_on);
```

### Testing
- Ran backend compile with `cd api && ./gradlew compileJava -x test`, which failed due to an environment/toolchain mismatch (`Unsupported class file major version 69`), so no server-side binary verification completed. 
- No automated unit/integration tests were run as part of this change; frontend behavior relies on the existing `RemarkComponent` which is covered by existing component tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f86b28a3b88332a0d50c7e9ce26892)