### PR TITLE
Add report definition API, JPA models, repositories, provider wiring and generator stubs

### DIFF
--- a/api/src/main/java/com/ticketingSystem/reportGenerator/controller/ReportDefinitionController.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/controller/ReportDefinitionController.java
@@ -1,0 +1,30 @@
+package com.ticketingSystem.reportGenerator.controller;
+
+import com.ticketingSystem.reportGenerator.dto.ReportDefinitionResponse;
+import com.ticketingSystem.reportGenerator.service.ReportDefinitionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/report-definitions")
+@RequiredArgsConstructor
+public class ReportDefinitionController {
+
+    private final ReportDefinitionService reportDefinitionService;
+
+    @GetMapping
+    public ResponseEntity<List<ReportDefinitionResponse>> getActiveDefinitions() {
+        return ResponseEntity.ok(reportDefinitionService.getActiveDefinitions());
+    }
+
+    @GetMapping("/{reportCode}")
+    public ResponseEntity<ReportDefinitionResponse> getByCode(@PathVariable String reportCode) {
+        return ResponseEntity.ok(reportDefinitionService.getDefinitionByCode(reportCode));
+    }
+}

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/dto/ReportDefinitionResponse.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/dto/ReportDefinitionResponse.java
@@ -1,0 +1,48 @@
+package com.ticketingSystem.reportGenerator.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ReportDefinitionResponse {
+    private Long reportId;
+    private String reportCode;
+    private String name;
+    private String description;
+    private String dataKey;
+    private String sourceType;
+    private String sourceRef;
+    private String templateLocation;
+    private String templateType;
+    private String defaultOutputFormat;
+    private List<FilterDefinition> filters;
+    private List<ColumnDefinition> columns;
+
+    @Getter
+    @Builder
+    public static class FilterDefinition {
+        private Long filterId;
+        private Integer displayOrder;
+        private String filterKey;
+        private String filterType;
+        private boolean required;
+        private String defaultValue;
+        private String optionSourceType;
+        private String optionSourceRef;
+    }
+
+    @Getter
+    @Builder
+    public static class ColumnDefinition {
+        private Long columnId;
+        private String columnKey;
+        private String columnLabel;
+        private String dataType;
+        private boolean defaultColumn;
+        private boolean selectable;
+        private Integer displayOrder;
+    }
+}

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/enums/FilterType.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/enums/FilterType.java
@@ -1,0 +1,11 @@
+package com.ticketingSystem.reportGenerator.enums;
+
+public enum FilterType {
+    TEXT,
+    NUMBER,
+    DATE,
+    DATE_RANGE,
+    SELECT,
+    MULTI_SELECT,
+    BOOLEAN
+}

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/enums/OptionSourceType.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/enums/OptionSourceType.java
@@ -1,0 +1,9 @@
+package com.ticketingSystem.reportGenerator.enums;
+
+public enum OptionSourceType {
+    NONE,
+    STATIC,
+    API,
+    QUERY,
+    ENUM
+}

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/enums/ReportSourceType.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/enums/ReportSourceType.java
@@ -1,0 +1,9 @@
+package com.ticketingSystem.reportGenerator.enums;
+
+public enum ReportSourceType {
+    CLASSPATH,
+    FILE_SYSTEM,
+    URL,
+    DB,
+    BUILTIN
+}

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/enums/RequestStatus.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/enums/RequestStatus.java
@@ -1,0 +1,10 @@
+package com.ticketingSystem.reportGenerator.enums;
+
+public enum RequestStatus {
+    QUEUED,
+    IN_PROGRESS,
+    COMPLETED,
+    FAILED,
+    CANCELLED,
+    EXPIRED
+}

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/generators/excel/JasperExcelReportGenerator.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/generators/excel/JasperExcelReportGenerator.java
@@ -1,4 +1,13 @@
 package com.ticketingSystem.reportGenerator.generators.excel;
 
-public class JasperExcelReportGenerator {
+import com.ticketingSystem.reportGenerator.api.ReportContext;
+import com.ticketingSystem.reportGenerator.api.ReportGenerator;
+import org.springframework.stereotype.Component;
+
+@Component("jasperExcel")
+public class JasperExcelReportGenerator implements ReportGenerator {
+    @Override
+    public byte[] generateReport(ReportContext context) {
+        return new byte[0];
+    }
 }

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/generators/pdf/OpenPdfReportGenerator.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/generators/pdf/OpenPdfReportGenerator.java
@@ -1,4 +1,13 @@
 package com.ticketingSystem.reportGenerator.generators.pdf;
 
-public class OpenPdfReportGenerator {
+import com.ticketingSystem.reportGenerator.api.ReportContext;
+import com.ticketingSystem.reportGenerator.api.ReportGenerator;
+import org.springframework.stereotype.Component;
+
+@Component("openPdf")
+public class OpenPdfReportGenerator implements ReportGenerator {
+    @Override
+    public byte[] generateReport(ReportContext context) {
+        return new byte[0];
+    }
 }

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/models/ReportArtifact.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/models/ReportArtifact.java
@@ -1,0 +1,46 @@
+package com.ticketingSystem.reportGenerator.models;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "report_artifact")
+@Getter
+@Setter
+public class ReportArtifact {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "artifact_id")
+    private Long artifactId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "request_id", nullable = false)
+    private ReportRequestHistory request;
+
+    @Column(name = "file_name", nullable = false, length = 512)
+    private String fileName;
+
+    @Column(name = "content_type", length = 255)
+    private String contentType;
+
+    @Column(name = "file_size")
+    private Long fileSize;
+
+    @Column(name = "storage_location", nullable = false, columnDefinition = "TEXT")
+    private String storageLocation;
+
+    @Column(name = "checksum", length = 255)
+    private String checksum;
+
+    @Column(name = "created_at", nullable = false, insertable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "download_count", nullable = false)
+    private Integer downloadCount = 0;
+
+    @Column(name = "last_downloaded_at")
+    private LocalDateTime lastDownloadedAt;
+}

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/models/ReportColumnMapping.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/models/ReportColumnMapping.java
@@ -1,0 +1,42 @@
+package com.ticketingSystem.reportGenerator.models;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "report_column_mapping", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_report_column", columnNames = {"report_id", "column_key"})
+})
+@Getter
+@Setter
+public class ReportColumnMapping {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "column_id")
+    private Long columnId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "report_id", nullable = false)
+    private ReportMaster report;
+
+    @Column(name = "column_key", nullable = false, length = 255)
+    private String columnKey;
+
+    @Column(name = "column_label", nullable = false, length = 255)
+    private String columnLabel;
+
+    @Column(name = "data_type", nullable = false, length = 100)
+    private String dataType;
+
+    @Column(name = "is_default", nullable = false)
+    private boolean defaultColumn = true;
+
+    @Column(name = "is_selectable", nullable = false)
+    private boolean selectable = true;
+
+    @Column(name = "display_order", nullable = false)
+    private Integer displayOrder = 1;
+}

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/models/ReportFilterMapping.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/models/ReportFilterMapping.java
@@ -1,0 +1,57 @@
+package com.ticketingSystem.reportGenerator.models;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "report_filter_mapping", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_report_filter", columnNames = {"report_id", "filter_key"})
+})
+@Getter
+@Setter
+public class ReportFilterMapping {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "filter_id")
+    private Long filterId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "report_id", nullable = false)
+    private ReportMaster report;
+
+    @Column(name = "display_order", nullable = false)
+    private Integer displayOrder = 1;
+
+    @Column(name = "filter_key", nullable = false, length = 255)
+    private String filterKey;
+
+    @Column(name = "filter_type", nullable = false, length = 100)
+    private String filterType;
+
+    @Column(name = "is_required", nullable = false)
+    private boolean required;
+
+    @Column(name = "default_value", columnDefinition = "TEXT")
+    private String defaultValue;
+
+    @Column(name = "option_source_type", length = 100)
+    private String optionSourceType;
+
+    @Column(name = "option_source_ref", columnDefinition = "TEXT")
+    private String optionSourceRef;
+
+    @Column(name = "created_at", nullable = false, insertable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "created_by", nullable = false, length = 100)
+    private String createdBy = "SYSTEM";
+
+    @Column(name = "updated_at", nullable = false, insertable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "updated_by", nullable = false, length = 100)
+    private String updatedBy = "SYSTEM";
+}

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/models/ReportMaster.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/models/ReportMaster.java
@@ -1,0 +1,60 @@
+package com.ticketingSystem.reportGenerator.models;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "report_master")
+@Getter
+@Setter
+public class ReportMaster {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    private Long reportId;
+
+    @Column(name = "report_code", nullable = false, unique = true, length = 100)
+    private String reportCode;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "data_key", nullable = false, length = 255)
+    private String dataKey;
+
+    @Column(name = "source_type", nullable = false, length = 100)
+    private String sourceType;
+
+    @Column(name = "source_ref", nullable = false, columnDefinition = "TEXT")
+    private String sourceRef;
+
+    @Column(name = "template_location", columnDefinition = "TEXT")
+    private String templateLocation;
+
+    @Column(name = "template_type", length = 100)
+    private String templateType;
+
+    @Column(name = "default_output_format", nullable = false, length = 50)
+    private String defaultOutputFormat;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active = true;
+
+    @Column(name = "created_at", nullable = false, insertable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "created_by", nullable = false, length = 100)
+    private String createdBy = "SYSTEM";
+
+    @Column(name = "updated_at", nullable = false, insertable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "updated_by", nullable = false, length = 100)
+    private String updatedBy = "SYSTEM";
+}

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/models/ReportRequestHistory.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/models/ReportRequestHistory.java
@@ -1,0 +1,58 @@
+package com.ticketingSystem.reportGenerator.models;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "report_request_history")
+@Getter
+@Setter
+public class ReportRequestHistory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "request_id")
+    private Long requestId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "report_id", nullable = false)
+    private ReportMaster report;
+
+    @Column(name = "requested_by", nullable = false)
+    private Long requestedBy;
+
+    @Column(name = "status", nullable = false, length = 50)
+    private String status;
+
+    @Column(name = "output_format", nullable = false, length = 50)
+    private String outputFormat;
+
+    @Column(name = "selected_columns_json", columnDefinition = "json")
+    private String selectedColumnsJson;
+
+    @Column(name = "filters_json", columnDefinition = "json")
+    private String filtersJson;
+
+    @Column(name = "engine_name", length = 255)
+    private String engineName;
+
+    @Column(name = "requested_at", nullable = false, insertable = false, updatable = false)
+    private LocalDateTime requestedAt;
+
+    @Column(name = "started_at")
+    private LocalDateTime startedAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    @Column(name = "failed_at")
+    private LocalDateTime failedAt;
+
+    @Column(name = "error_message", columnDefinition = "TEXT")
+    private String errorMessage;
+
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
+}

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/provider/ReportGeneratorProvider.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/provider/ReportGeneratorProvider.java
@@ -4,13 +4,18 @@ import com.ticketingSystem.reportGenerator.api.ReportGenerator;
 import com.ticketingSystem.reportGenerator.enums.ReportFormat;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
 
+@Component
 public class ReportGeneratorProvider {
-    @Value("${report.generate.pdf}")
-    private String pdfBeanName;
+    @Value("${report.engine:jasper}")
+    private String reportEngine;
 
-    @Value("${report.generate.excel}")
-    private String excelBeanName;
+    @Value("${report.generate.jasper.pdf:jasperPdf}")
+    private String jasperPdfBeanName;
+
+    @Value("${report.generate.jasper.excel:jasperExcel}")
+    private String jasperExcelBeanName;
 
     private final ApplicationContext ctx;
 
@@ -19,9 +24,14 @@ public class ReportGeneratorProvider {
     }
 
     public ReportGenerator getGenerator(ReportFormat format) {
+        String engine = reportEngine == null ? "jasper" : reportEngine.trim().toLowerCase();
+        if (!"jasper".equals(engine)) {
+            throw new IllegalArgumentException("Unsupported report.engine: " + reportEngine);
+        }
+
         return switch (format) {
-            case PDF -> ctx.getBean(pdfBeanName, ReportGenerator.class);
-            case EXCEL -> ctx.getBean(excelBeanName, ReportGenerator.class);
+            case PDF -> ctx.getBean(jasperPdfBeanName, ReportGenerator.class);
+            case EXCEL -> ctx.getBean(jasperExcelBeanName, ReportGenerator.class);
         };
     }
 }

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/repository/ReportColumnMappingRepository.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/repository/ReportColumnMappingRepository.java
@@ -1,0 +1,10 @@
+package com.ticketingSystem.reportGenerator.repository;
+
+import com.ticketingSystem.reportGenerator.models.ReportColumnMapping;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReportColumnMappingRepository extends JpaRepository<ReportColumnMapping, Long> {
+    List<ReportColumnMapping> findByReport_ReportIdOrderByDisplayOrderAsc(Long reportId);
+}

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/repository/ReportColumnMappingRepository.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/repository/ReportColumnMappingRepository.java
@@ -2,9 +2,11 @@ package com.ticketingSystem.reportGenerator.repository;
 
 import com.ticketingSystem.reportGenerator.models.ReportColumnMapping;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface ReportColumnMappingRepository extends JpaRepository<ReportColumnMapping, Long> {
     List<ReportColumnMapping> findByReport_ReportIdOrderByDisplayOrderAsc(Long reportId);
 }

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/repository/ReportFilterMappingRepository.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/repository/ReportFilterMappingRepository.java
@@ -1,0 +1,10 @@
+package com.ticketingSystem.reportGenerator.repository;
+
+import com.ticketingSystem.reportGenerator.models.ReportFilterMapping;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReportFilterMappingRepository extends JpaRepository<ReportFilterMapping, Long> {
+    List<ReportFilterMapping> findByReport_ReportIdOrderByDisplayOrderAsc(Long reportId);
+}

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/repository/ReportFilterMappingRepository.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/repository/ReportFilterMappingRepository.java
@@ -2,9 +2,11 @@ package com.ticketingSystem.reportGenerator.repository;
 
 import com.ticketingSystem.reportGenerator.models.ReportFilterMapping;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface ReportFilterMappingRepository extends JpaRepository<ReportFilterMapping, Long> {
     List<ReportFilterMapping> findByReport_ReportIdOrderByDisplayOrderAsc(Long reportId);
 }

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/repository/ReportMasterRepository.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/repository/ReportMasterRepository.java
@@ -1,0 +1,10 @@
+package com.ticketingSystem.reportGenerator.repository;
+
+import com.ticketingSystem.reportGenerator.models.ReportMaster;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ReportMasterRepository extends JpaRepository<ReportMaster, Long> {
+    Optional<ReportMaster> findByReportCodeAndActiveTrue(String reportCode);
+}

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/repository/ReportMasterRepository.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/repository/ReportMasterRepository.java
@@ -2,9 +2,11 @@ package com.ticketingSystem.reportGenerator.repository;
 
 import com.ticketingSystem.reportGenerator.models.ReportMaster;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface ReportMasterRepository extends JpaRepository<ReportMaster, Long> {
     Optional<ReportMaster> findByReportCodeAndActiveTrue(String reportCode);
 }

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/service/ReportDefinitionService.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/service/ReportDefinitionService.java
@@ -1,0 +1,82 @@
+package com.ticketingSystem.reportGenerator.service;
+
+import com.ticketingSystem.reportGenerator.dto.ReportDefinitionResponse;
+import com.ticketingSystem.reportGenerator.models.ReportColumnMapping;
+import com.ticketingSystem.reportGenerator.models.ReportFilterMapping;
+import com.ticketingSystem.reportGenerator.models.ReportMaster;
+import com.ticketingSystem.reportGenerator.repository.ReportColumnMappingRepository;
+import com.ticketingSystem.reportGenerator.repository.ReportFilterMappingRepository;
+import com.ticketingSystem.reportGenerator.repository.ReportMasterRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReportDefinitionService {
+
+    private final ReportMasterRepository reportMasterRepository;
+    private final ReportFilterMappingRepository reportFilterMappingRepository;
+    private final ReportColumnMappingRepository reportColumnMappingRepository;
+
+    public List<ReportDefinitionResponse> getActiveDefinitions() {
+        return reportMasterRepository.findAll().stream()
+                .filter(ReportMaster::isActive)
+                .map(this::toResponse)
+                .toList();
+    }
+
+    public ReportDefinitionResponse getDefinitionByCode(String reportCode) {
+        ReportMaster reportMaster = reportMasterRepository.findByReportCodeAndActiveTrue(reportCode)
+                .orElseThrow(() -> new IllegalArgumentException("Report definition not found for code: " + reportCode));
+        return toResponse(reportMaster);
+    }
+
+    private ReportDefinitionResponse toResponse(ReportMaster reportMaster) {
+        List<ReportFilterMapping> filters = reportFilterMappingRepository
+                .findByReport_ReportIdOrderByDisplayOrderAsc(reportMaster.getReportId());
+        List<ReportColumnMapping> columns = reportColumnMappingRepository
+                .findByReport_ReportIdOrderByDisplayOrderAsc(reportMaster.getReportId());
+
+        return ReportDefinitionResponse.builder()
+                .reportId(reportMaster.getReportId())
+                .reportCode(reportMaster.getReportCode())
+                .name(reportMaster.getName())
+                .description(reportMaster.getDescription())
+                .dataKey(reportMaster.getDataKey())
+                .sourceType(reportMaster.getSourceType())
+                .sourceRef(reportMaster.getSourceRef())
+                .templateLocation(reportMaster.getTemplateLocation())
+                .templateType(reportMaster.getTemplateType())
+                .defaultOutputFormat(reportMaster.getDefaultOutputFormat())
+                .filters(filters.stream().map(this::toFilter).toList())
+                .columns(columns.stream().map(this::toColumn).toList())
+                .build();
+    }
+
+    private ReportDefinitionResponse.FilterDefinition toFilter(ReportFilterMapping filter) {
+        return ReportDefinitionResponse.FilterDefinition.builder()
+                .filterId(filter.getFilterId())
+                .displayOrder(filter.getDisplayOrder())
+                .filterKey(filter.getFilterKey())
+                .filterType(filter.getFilterType())
+                .required(filter.isRequired())
+                .defaultValue(filter.getDefaultValue())
+                .optionSourceType(filter.getOptionSourceType())
+                .optionSourceRef(filter.getOptionSourceRef())
+                .build();
+    }
+
+    private ReportDefinitionResponse.ColumnDefinition toColumn(ReportColumnMapping column) {
+        return ReportDefinitionResponse.ColumnDefinition.builder()
+                .columnId(column.getColumnId())
+                .columnKey(column.getColumnKey())
+                .columnLabel(column.getColumnLabel())
+                .dataType(column.getDataType())
+                .defaultColumn(column.isDefaultColumn())
+                .selectable(column.isSelectable())
+                .displayOrder(column.getDisplayOrder())
+                .build();
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce a report definition API and persistence model to support listing and retrieving report metadata and mappings. 
- Provide wiring for pluggable report engines and default Jasper-based generators. 
- Create DTOs and enums to shape responses and standardize filter/option/source types.

### Description
- Added REST endpoints `GET /report-definitions` and `GET /report-definitions/{reportCode}` in `ReportDefinitionController` that return `ReportDefinitionResponse` DTOs. 
- Implemented `ReportDefinitionService` to assemble DTOs from new JPA entities `ReportMaster`, `ReportFilterMapping`, `ReportColumnMapping`, `ReportRequestHistory`, and `ReportArtifact`. 
- Added Spring Data repositories `ReportMasterRepository`, `ReportFilterMappingRepository`, and `ReportColumnMappingRepository` with query helpers used by the service. 
- Introduced enums `FilterType`, `OptionSourceType`, `ReportSourceType`, and `RequestStatus`, and a response DTO `ReportDefinitionResponse` with nested `FilterDefinition` and `ColumnDefinition`. 
- Updated `ReportGeneratorProvider` to read `report.engine` configuration, validate engine name, register as a Spring `@Component`, and resolve bean names `jasperPdf`/`jasperExcel`; added stub `ReportGenerator` implementations `OpenPdfReportGenerator` and `JasperExcelReportGenerator` annotated with `@Component`. 

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a057b148bc08332b3b01f57c38661ab)