### PR TITLE
Align report engine properties and fix bean lookup in ReportGeneratorProvider

### DIFF
--- a/api/src/main/java/com/ticketingSystem/reportGenerator/provider/ReportGeneratorProvider.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/provider/ReportGeneratorProvider.java
@@ -42,7 +42,7 @@ public class ReportGeneratorProvider {
             throw new IllegalArgumentException("No report generator bean configured for an engine=" + engine + ", format=" + format);
         }
 
-        if(ctx.containsBean(beanName)) {
+        if(!ctx.containsBean(beanName)) {
             throw new IllegalArgumentException("Configured report generator bean not found: " + beanName);
         }
 

--- a/api/src/main/resources/application-dev-local.properties
+++ b/api/src/main/resources/application-dev-local.properties
@@ -85,7 +85,13 @@ app.ticket.auto-close-resolved.enabled=false
 app.ticket.auto-close-resolved.after-hours=1
 
 # Reports
-#report.generate.pdf=openPdf
-report.generate.pdf=jasper
-report.generate.excel=jasper
-#report.generate.excel=poiExcel
+# Select report engine key used by ReportGeneratorProvider
+report.engine=jasper
+
+# Engine+format to Spring bean mapping
+report.generate.jasper.pdf=jasperPdf
+report.generate.jasper.excel=jasperExcel
+
+# Optional defaults used when report.engine mapping is absent
+#report.generate.default.pdf=openPdf
+#report.generate.default.excel=jasperExcel


### PR DESCRIPTION
### Motivation
- The report generator configuration keys in `application-dev-local.properties` did not match the lookup logic in `ReportGeneratorProvider`, preventing the configured Jasper beans from being resolved. 
- A logic bug in the provider inverted the `containsBean` check, causing a "bean not found" error even when a valid bean name was configured.

### Description
- Updated `api/src/main/resources/application-dev-local.properties` to set `report.engine=jasper` and engine-specific mappings `report.generate.jasper.pdf=jasperPdf` and `report.generate.jasper.excel=jasperExcel` so the provider can resolve beans by engine+format.
- Fixed `ReportGeneratorProvider` in `api/src/main/java/com/ticketingSystem/reportGenerator/provider/ReportGeneratorProvider.java` by changing the inverted bean existence check to `if(!ctx.containsBean(beanName))` so the provider throws only when the configured bean is missing.
- Left a note that the `JasperPdfReportGenerator` still calls `JasperCompileManager.compileReport("")`, so runtime loading/compilation from `ReportMaster.templateLocation` must be wired separately to actually use `reports/tickets_rpt.jrxml`.

### Testing
- Attempted `./mvnw -pl api -DskipTests compile` failed because `./mvnw` is not present in the repo root (wrapper missing). 
- Attempted `mvn -pl api -DskipTests compile` failed because the reactor did not recognize `api` as a Maven module from the repo root. 
- Attempted `cd api && ./gradlew compileJava` failed with `Unsupported class file major version 69` indicating a JDK/Gradle environment mismatch, so no successful automated build ran after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06fafb7a948332ab9c757b8d069368)