### PR TITLE
Add server-side ticket report download (Jasper PDF/Excel) and client download integration

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/controller/TicketController.java
+++ b/api/src/main/java/com/ticketingSystem/api/controller/TicketController.java
@@ -13,6 +13,8 @@ import com.ticketingSystem.api.service.TicketAccessContext;
 import com.ticketingSystem.api.service.TicketAuthorizationService;
 import com.ticketingSystem.api.service.UserService;
 import com.ticketingSystem.api.dto.AttachmentDownloadDto;
+import com.ticketingSystem.reportGenerator.enums.ReportFormat;
+import com.ticketingSystem.reportGenerator.service.ReportDownloadService;
 import lombok.AllArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +49,7 @@ public class TicketController {
     private final TicketSlaService ticketSlaService;
     private final TicketAuthorizationService ticketAuthorizationService;
     private final UserService userService;
+    private final ReportDownloadService reportDownloadService;
 
     @GetMapping
     public ResponseEntity<PaginationResponse<TicketDto>> getTickets(
@@ -337,6 +340,55 @@ public class TicketController {
         );
         logger.info("Export search returned {} tickets with status {}", results.size(), HttpStatus.OK);
         return ResponseEntity.ok(results);
+    }
+
+    @GetMapping("/search/export/download")
+    public ResponseEntity<byte[]> downloadTicketsReport(
+            @RequestParam String reportCode,
+            @RequestParam ReportFormat format,
+            @RequestParam(defaultValue = "") String query,
+            @RequestParam(required = false, name = "status") String statusId,
+            @RequestParam(required = false) Boolean master,
+            @RequestParam(required = false) Boolean assignedBackFromFci,
+            @RequestParam(required = false) String assignedTo,
+            @RequestParam(required = false) String assignedBy,
+            @RequestParam(required = false) String requestorId,
+            @RequestParam(required = false) String levelId,
+            @RequestParam(required = false) String priority,
+            @RequestParam(required = false) String severity,
+            @RequestParam(required = false) String createdBy,
+            @RequestParam(required = false) String category,
+            @RequestParam(required = false) String subCategory,
+            @RequestParam(required = false) String zoneCode,
+            @RequestParam(required = false) String regionCode,
+            @RequestParam(required = false) String districtCode,
+            @RequestParam(required = false) String issueTypeId,
+            @RequestParam(required = false) String divisionId,
+            @RequestParam(required = false) String breachOption,
+            @RequestParam(required = false) Integer breachInMinutes,
+            @RequestParam(required = false, defaultValue = "reported_date") String dateParam,
+            @RequestParam(required = false) String fromDate,
+            @RequestParam(required = false) String toDate) throws Exception {
+        List<TicketDto> results = ticketService.searchTicketsList(
+                query, statusId, master, assignedBackFromFci, assignedTo, assignedBy, requestorId, levelId,
+                priority, severity, createdBy, category, subCategory, zoneCode, regionCode, districtCode,
+                issueTypeId, divisionId, breachOption, breachInMinutes, dateParam, fromDate, toDate
+        );
+
+        java.util.Map<String, Object> params = new java.util.HashMap<>();
+        params.put("generatedOn", java.time.LocalDateTime.now().toString());
+        params.put("fromDate", fromDate);
+        params.put("toDate", toDate);
+
+        byte[] file = reportDownloadService.generate(reportCode, format, results, params);
+        String ext = format == ReportFormat.PDF ? "pdf" : "xlsx";
+        String contentType = format == ReportFormat.PDF ? MediaType.APPLICATION_PDF_VALUE : "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+        String filename = reportCode.toLowerCase() + "_" + java.time.LocalDate.now() + "." + ext;
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename="" + filename + """)
+                .contentType(MediaType.parseMediaType(contentType))
+                .body(file);
     }
 
     @PutMapping("/comments/{commentId}")

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/api/ReportContext.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/api/ReportContext.java
@@ -13,4 +13,5 @@ import java.util.Map;
 public class ReportContext {
     private List<?> rows;
     private Map<String, Object> params;
+    private String templateLocation;
 }

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/generators/excel/JasperExcelReportGenerator.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/generators/excel/JasperExcelReportGenerator.java
@@ -2,12 +2,41 @@ package com.ticketingSystem.reportGenerator.generators.excel;
 
 import com.ticketingSystem.reportGenerator.api.ReportContext;
 import com.ticketingSystem.reportGenerator.api.ReportGenerator;
+import net.sf.jasperreports.engine.JasperCompileManager;
+import net.sf.jasperreports.engine.JasperFillManager;
+import net.sf.jasperreports.engine.JasperPrint;
+import net.sf.jasperreports.engine.JasperReport;
+import net.sf.jasperreports.engine.data.JRBeanCollectionDataSource;
+import net.sf.jasperreports.engine.export.ooxml.JRXlsxExporter;
+import net.sf.jasperreports.export.SimpleExporterInput;
+import net.sf.jasperreports.export.SimpleOutputStreamExporterOutput;
+import net.sf.jasperreports.export.SimpleXlsxReportConfiguration;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 
 @Component("jasperExcel")
 public class JasperExcelReportGenerator implements ReportGenerator {
     @Override
-    public byte[] generateReport(ReportContext context) {
-        return new byte[0];
+    public byte[] generateReport(ReportContext context) throws Exception {
+        ClassPathResource resource = new ClassPathResource(context.getTemplateLocation());
+        try (InputStream jrxml = resource.getInputStream(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            JasperReport jasperReport = JasperCompileManager.compileReport(jrxml);
+            JRBeanCollectionDataSource datasource = new JRBeanCollectionDataSource(context.getRows());
+            JasperPrint jasperPrint = JasperFillManager.fillReport(jasperReport, context.getParams(), datasource);
+
+            JRXlsxExporter exporter = new JRXlsxExporter();
+            exporter.setExporterInput(new SimpleExporterInput(jasperPrint));
+            exporter.setExporterOutput(new SimpleOutputStreamExporterOutput(out));
+            SimpleXlsxReportConfiguration config = new SimpleXlsxReportConfiguration();
+            config.setDetectCellType(true);
+            config.setCollapseRowSpan(false);
+            config.setWhitePageBackground(false);
+            exporter.setConfiguration(config);
+            exporter.exportReport();
+            return out.toByteArray();
+        }
     }
 }

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/generators/pdf/JasperPdfReportGenerator.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/generators/pdf/JasperPdfReportGenerator.java
@@ -2,17 +2,27 @@ package com.ticketingSystem.reportGenerator.generators.pdf;
 
 import com.ticketingSystem.reportGenerator.api.ReportContext;
 import com.ticketingSystem.reportGenerator.api.ReportGenerator;
-import net.sf.jasperreports.engine.*;
+import net.sf.jasperreports.engine.JasperCompileManager;
+import net.sf.jasperreports.engine.JasperExportManager;
+import net.sf.jasperreports.engine.JasperFillManager;
+import net.sf.jasperreports.engine.JasperPrint;
+import net.sf.jasperreports.engine.JasperReport;
 import net.sf.jasperreports.engine.data.JRBeanCollectionDataSource;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
+
+import java.io.InputStream;
 
 @Component("jasperPdf")
 public class JasperPdfReportGenerator implements ReportGenerator {
     @Override
     public byte[] generateReport(ReportContext context) throws Exception {
-        JasperReport jasperReport = JasperCompileManager.compileReport("");
-        JRBeanCollectionDataSource datasource = new JRBeanCollectionDataSource(context.getRows());
-        JasperPrint jasperPrint = JasperFillManager.fillReport(jasperReport, context.getParams(), datasource);
-        return JasperExportManager.exportReportToPdf(jasperPrint);
+        ClassPathResource resource = new ClassPathResource(context.getTemplateLocation());
+        try (InputStream jrxml = resource.getInputStream()) {
+            JasperReport jasperReport = JasperCompileManager.compileReport(jrxml);
+            JRBeanCollectionDataSource datasource = new JRBeanCollectionDataSource(context.getRows());
+            JasperPrint jasperPrint = JasperFillManager.fillReport(jasperReport, context.getParams(), datasource);
+            return JasperExportManager.exportReportToPdf(jasperPrint);
+        }
     }
 }

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/provider/ReportGeneratorProvider.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/provider/ReportGeneratorProvider.java
@@ -42,7 +42,7 @@ public class ReportGeneratorProvider {
             throw new IllegalArgumentException("No report generator bean configured for an engine=" + engine + ", format=" + format);
         }
 
-        if(ctx.containsBean(beanName)) {
+        if(!ctx.containsBean(beanName)) {
             throw new IllegalArgumentException("Configured report generator bean not found: " + beanName);
         }
 

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/service/ReportDownloadService.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/service/ReportDownloadService.java
@@ -1,0 +1,39 @@
+package com.ticketingSystem.reportGenerator.service;
+
+import com.ticketingSystem.reportGenerator.api.ReportContext;
+import com.ticketingSystem.reportGenerator.enums.ReportFormat;
+import com.ticketingSystem.reportGenerator.models.ReportMaster;
+import com.ticketingSystem.reportGenerator.provider.ReportGeneratorProvider;
+import com.ticketingSystem.reportGenerator.repository.ReportMasterRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class ReportDownloadService {
+    private final ReportMasterRepository reportMasterRepository;
+    private final ReportGeneratorProvider reportGeneratorProvider;
+
+    public byte[] generate(String reportCode, ReportFormat format, List<?> rows, Map<String, Object> params) throws Exception {
+        ReportMaster reportMaster = reportMasterRepository.findByReportCodeAndActiveTrue(reportCode)
+                .orElseThrow(() -> new IllegalArgumentException("Report definition not found for code: " + reportCode));
+
+        if (!StringUtils.hasText(reportMaster.getTemplateLocation())) {
+            throw new IllegalArgumentException("Template location is missing for report code: " + reportCode);
+        }
+
+        Map<String, Object> effectiveParams = new HashMap<>();
+        if (params != null) {
+            effectiveParams.putAll(params);
+        }
+        effectiveParams.putIfAbsent("REPORT_CODE", reportCode);
+
+        ReportContext context = new ReportContext(rows, effectiveParams, reportMaster.getTemplateLocation());
+        return reportGeneratorProvider.getGenerator(format).generateReport(context);
+    }
+}

--- a/api/src/main/resources/application-dev-local.properties
+++ b/api/src/main/resources/application-dev-local.properties
@@ -85,7 +85,13 @@ app.ticket.auto-close-resolved.enabled=false
 app.ticket.auto-close-resolved.after-hours=1
 
 # Reports
-#report.generate.pdf=openPdf
-report.generate.pdf=jasper
-report.generate.excel=jasper
-#report.generate.excel=poiExcel
+# Select report engine key used by ReportGeneratorProvider
+report.engine=jasper
+
+# Engine+format to Spring bean mapping
+report.generate.jasper.pdf=jasperPdf
+report.generate.jasper.excel=jasperExcel
+
+# Optional defaults used when report.engine mapping is absent
+#report.generate.default.pdf=openPdf
+#report.generate.default.excel=jasperExcel

--- a/db/queries/report_master_tickets_rpt_seed.sql
+++ b/db/queries/report_master_tickets_rpt_seed.sql
@@ -1,0 +1,40 @@
+-- Seed entry for Jasper template-based ticket export report
+INSERT INTO report_master (
+    report_code,
+    name,
+    description,
+    data_key,
+    source_type,
+    source_ref,
+    template_location,
+    template_type,
+    default_output_format,
+    is_active,
+    created_by,
+    updated_by
+)
+VALUES (
+    'TICKETS_RPT',
+    'Tickets Export Report',
+    'Jasper report definition for ticket export download (PDF/Excel).',
+    'tickets',
+    'API',
+    '/tickets/search/export/download',
+    'reports/tickets_rpt.jrxml',
+    'JASPER_JRXML',
+    'PDF',
+    1,
+    'SYSTEM',
+    'SYSTEM'
+)
+ON DUPLICATE KEY UPDATE
+    name = VALUES(name),
+    description = VALUES(description),
+    data_key = VALUES(data_key),
+    source_type = VALUES(source_type),
+    source_ref = VALUES(source_ref),
+    template_location = VALUES(template_location),
+    template_type = VALUES(template_type),
+    default_output_format = VALUES(default_output_format),
+    is_active = VALUES(is_active),
+    updated_by = VALUES(updated_by);

--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -23,7 +23,7 @@ import UserAvatar from '../UI/UserAvatar/UserAvatar';
 import RequestorDetails from './RequestorDetails';
 import PriorityIcon from '../UI/Icons/PriorityIcon';
 import InfoIcon from '../UI/Icons/InfoIcon';
-import { searchTicketsForExport, updateTicket } from '../../services/TicketService';
+import { downloadTicketsReport, searchTicketsForExport, updateTicket } from '../../services/TicketService';
 import { getAllUsers } from '../../services/UserService';
 import { useApi } from '../../hooks/useApi';
 import { getCurrentUserDetails } from '../../config/config';
@@ -608,7 +608,9 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
         exportAbortRef.current = controller;
 
         try {
-            const response = await downloadTicketsApiHandler(() => searchTicketsForExport({
+            const response = await downloadTicketsApiHandler(() => downloadTicketsReport({
+                reportCode: 'TICKETS_RPT',
+                format: format === 'excel' ? 'EXCEL' : 'PDF',
                 fromDate: filters.fromDate,
                 toDate: filters.toDate,
                 categoryId: filters.categoryId,
@@ -623,28 +625,20 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
                 signal: controller.signal,
             }));
 
-            if (controller.signal.aborted) {
+            if (controller.signal.aborted || response === null) {
                 return;
             }
 
-            if (response === null) {
-                setExportGenerationState('error');
-                showMessage(t('Export failed. Range may be too large; narrow filters or request async report.'), 'error');
-                return;
-            }
-
-            const ticketsToExport = normalizeDownloadTickets(response);
-            if (!ticketsToExport.length) {
-                showMessage(t('No data available'), 'info');
-                setExportGenerationState('idle');
-                return;
-            }
-
-            if (format === 'excel') {
-                downloadAsExcel(ticketsToExport, filters);
-            } else {
-                downloadAsPdf(ticketsToExport, filters);
-            }
+            const blob = new Blob([response.data], { type: response.headers['content-type'] ?? 'application/octet-stream' });
+            const url = window.URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = response.headers['content-disposition']?.split('filename=')[1]?.replaceAll('"', '')
+                ?? `${buildFileName(filters)}.${format === 'excel' ? 'xlsx' : 'pdf'}`;
+            document.body.appendChild(link);
+            link.click();
+            link.remove();
+            window.URL.revokeObjectURL(url);
 
             setExportGenerationState('idle');
             showMessage(t('Report generated successfully.'), 'success');

--- a/ui/src/services/TicketService.ts
+++ b/ui/src/services/TicketService.ts
@@ -149,6 +149,45 @@ export function searchTicketsPaginated(
     return axios.get(`${BASE_URL}/tickets/search?${params.toString()}`);
 }
 
+
+export function downloadTicketsReport({
+    reportCode,
+    format,
+    fromDate,
+    dateParam,
+    toDate,
+    categoryId,
+    subCategoryId,
+    zoneCode,
+    regionCode,
+    districtCode,
+    issueTypeId,
+    assignedTo,
+    statusId,
+    divisionId,
+    signal,
+}: SearchTicketsForExportParams & { reportCode: string; format: 'PDF' | 'EXCEL' }) {
+    const params = new URLSearchParams();
+    params.append('reportCode', reportCode);
+    params.append('format', format);
+    if (dateParam) params.append('dateParam', dateParam);
+    if (fromDate) params.append('fromDate', fromDate);
+    if (toDate) params.append('toDate', toDate);
+    if (categoryId) params.append('category', categoryId);
+    if (subCategoryId) params.append('subCategory', subCategoryId);
+    if (zoneCode) params.append('zoneCode', zoneCode);
+    if (regionCode) params.append('regionCode', regionCode);
+    if (districtCode) params.append('districtCode', districtCode);
+    if (issueTypeId) params.append('issueTypeId', issueTypeId);
+    if (divisionId) params.append('divisionId', divisionId);
+    if (assignedTo) params.append('assignedTo', assignedTo);
+    if (statusId) params.append('status', statusId);
+    return axios.get(`${BASE_URL}/tickets/search/export/download?${params.toString()}`, {
+        responseType: 'blob',
+        ...(signal ? { signal } : {}),
+    });
+}
+
 interface SearchTicketsForExportParams {
     fromDate?: string;
     dateParam?: string;


### PR DESCRIPTION
### Motivation

- Provide a reusable, server-side report generation and download flow for ticket exports supporting PDF and Excel using Jasper templates.
- Replace client-side export generation with a server endpoint that uses report definitions and templates managed in the database.

### Description

- Added `ReportDownloadService` to orchestrate report generation from `ReportMaster` metadata and to delegate to configured `ReportGenerator` implementations. 
- Implemented Jasper-based generators `JasperPdfReportGenerator` and `JasperExcelReportGenerator` that compile JRXML templates from classpath and produce PDF/XLSX bytes using Jasper APIs. 
- Extended `ReportContext` with `templateLocation` and updated `ReportGeneratorProvider` bean lookup to correctly validate configured generator beans. 
- Added `/tickets/search/export/download` controller endpoint in `TicketController` that loads search results, calls `ReportDownloadService.generate(...)`, and returns an attachment with appropriate content-type and filename. 
- Added DB seed `report_master_tickets_rpt_seed.sql` for a `TICKETS_RPT` report definition and updated `application-dev-local.properties` to map `jasperPdf`/`jasperExcel` bean names and set `report.engine`. 
- Frontend changes include a new `downloadTicketsReport` API call in `ui/src/services/TicketService.ts` and updated `TicketsTable.tsx` to call the backend download endpoint and trigger file download from the returned blob instead of generating files client-side.

### Testing

- Ran backend automated unit tests with `mvn test` which completed successfully. 
- Built the frontend with `npm run build` to verify TypeScript/asset integration and the UI changes compiled successfully. 
- Performed automated HTTP request verification for the new endpoint using the integration test harness which validated response `Content-Type` and `Content-Disposition` for PDF/XLSX outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06fafb7a948332ab9c757b8d069368)