### PR TITLE
ApiResponseBodyAdvice: Bypass wrapping for binary/download responses

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/config/ApiResponseBodyAdvice.java
+++ b/api/src/main/java/com/ticketingSystem/api/config/ApiResponseBodyAdvice.java
@@ -4,6 +4,7 @@ import com.ticketingSystem.api.dto.ApiResponse;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.http.server.ServletServerHttpResponse;
@@ -26,7 +27,15 @@ public class ApiResponseBodyAdvice implements ResponseBodyAdvice {
         if (body instanceof SseEmitter) {
             return body;
         }
-        if (selectedContentType != null && MediaType.TEXT_EVENT_STREAM.isCompatibleWith(selectedContentType)) {
+        if (body instanceof ResponseEntity) {
+            return body;
+        }
+        if (selectedContentType != null && (MediaType.TEXT_EVENT_STREAM.isCompatibleWith(selectedContentType)
+                || MediaType.APPLICATION_OCTET_STREAM.isCompatibleWith(selectedContentType)
+                || MediaType.APPLICATION_PDF.isCompatibleWith(selectedContentType))) {
+            return body;
+        }
+        if (body instanceof byte[]) {
             return body;
         }
         if (body == null && response instanceof ServletServerHttpResponse) {


### PR DESCRIPTION
### Motivation
- The global response wrapper was intercepting download endpoints and wrapping binary `byte[]`/`ResponseEntity` responses, causing `ClassCastException` during HTTP message conversion for file downloads.
- File download endpoints need to return raw bytes with appropriate content type so browsers can correctly download PDFs and other binary files.

### Description
- Updated `api/src/main/java/com/ticketingSystem/api/config/ApiResponseBodyAdvice.java` to bypass wrapping when the body is a `ResponseEntity`.
- Added content-type checks to skip wrapping for `MediaType.APPLICATION_OCTET_STREAM` and `MediaType.APPLICATION_PDF` and for `MediaType.TEXT_EVENT_STREAM` to preserve SSE behavior.
- Added a direct bypass when the controller returns a `byte[]` so binary payloads are returned unchanged while `String` responses remain wrapped with `ApiResponse.success(...)` and `application/json` is enforced.

### Testing
- Attempted to compile the `api` module with `cd api && ./gradlew -q compileJava` and the build failed due to an environment Java/Gradle mismatch (`Unsupported class file major version 69`).
- No further automated tests were run in this environment because compilation could not complete due to the toolchain incompatibility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0abd430d04833295fac01ead00a302)