### PR TITLE
Remove invalid `isStretchWithOverflow` attribute from phase1 table JRXMLs

### DIFF
--- a/api/src/main/resources/reports/tickets_rpt_phase1_table.jrxml
+++ b/api/src/main/resources/reports/tickets_rpt_phase1_table.jrxml
@@ -66,7 +66,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="60" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="60" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{id}]]></textFieldExpression>
@@ -85,7 +85,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="80" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="80" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{requestorName}]]></textFieldExpression>
@@ -104,7 +104,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="90" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="90" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{reportedDate}]]></textFieldExpression>
@@ -123,7 +123,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="80" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="80" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{category}]]></textFieldExpression>
@@ -142,7 +142,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="100" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="100" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{subCategory}]]></textFieldExpression>
@@ -161,7 +161,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="210" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="210" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{issueTypeLabel}]]></textFieldExpression>
@@ -180,7 +180,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="80" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="80" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{zoneCode}]]></textFieldExpression>
@@ -199,7 +199,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="80" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="80" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{districtName}]]></textFieldExpression>
@@ -218,7 +218,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="90" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="90" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{regionName}]]></textFieldExpression>
@@ -237,7 +237,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="60" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="60" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{severity}]]></textFieldExpression>
@@ -256,7 +256,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="60" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="60" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{priority}]]></textFieldExpression>
@@ -275,7 +275,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="100" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="100" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{assignedToName}]]></textFieldExpression>
@@ -294,7 +294,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="90" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="90" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{statusLabel}]]></textFieldExpression>

--- a/api/src/main/resources/reports/tickets_rpt_phase1_table_ui.jrxml
+++ b/api/src/main/resources/reports/tickets_rpt_phase1_table_ui.jrxml
@@ -66,7 +66,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="60" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="60" height="20"/>
                                 <box><pen lineWidth="0.75"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/><paragraph leftIndent="2" rightIndent="2"/></textElement>
                                 <textFieldExpression><![CDATA[$F{id}]]></textFieldExpression>
@@ -85,7 +85,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="80" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="80" height="20"/>
                                 <box><pen lineWidth="0.75"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/><paragraph leftIndent="2" rightIndent="2"/></textElement>
                                 <textFieldExpression><![CDATA[$F{requestorName}]]></textFieldExpression>
@@ -104,7 +104,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="90" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="90" height="20"/>
                                 <box><pen lineWidth="0.75"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/><paragraph leftIndent="2" rightIndent="2"/></textElement>
                                 <textFieldExpression><![CDATA[$F{reportedDate}]]></textFieldExpression>
@@ -123,7 +123,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="80" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="80" height="20"/>
                                 <box><pen lineWidth="0.75"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/><paragraph leftIndent="2" rightIndent="2"/></textElement>
                                 <textFieldExpression><![CDATA[$F{category}]]></textFieldExpression>
@@ -142,7 +142,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="100" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="100" height="20"/>
                                 <box><pen lineWidth="0.75"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/><paragraph leftIndent="2" rightIndent="2"/></textElement>
                                 <textFieldExpression><![CDATA[$F{subCategory}]]></textFieldExpression>
@@ -161,7 +161,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="210" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="210" height="20"/>
                                 <box><pen lineWidth="0.75"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/><paragraph leftIndent="2" rightIndent="2"/></textElement>
                                 <textFieldExpression><![CDATA[$F{issueTypeLabel}]]></textFieldExpression>
@@ -180,7 +180,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="80" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="80" height="20"/>
                                 <box><pen lineWidth="0.75"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/><paragraph leftIndent="2" rightIndent="2"/></textElement>
                                 <textFieldExpression><![CDATA[$F{zoneCode}]]></textFieldExpression>
@@ -199,7 +199,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="80" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="80" height="20"/>
                                 <box><pen lineWidth="0.75"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/><paragraph leftIndent="2" rightIndent="2"/></textElement>
                                 <textFieldExpression><![CDATA[$F{districtName}]]></textFieldExpression>
@@ -218,7 +218,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="90" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="90" height="20"/>
                                 <box><pen lineWidth="0.75"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/><paragraph leftIndent="2" rightIndent="2"/></textElement>
                                 <textFieldExpression><![CDATA[$F{regionName}]]></textFieldExpression>
@@ -237,7 +237,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="60" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="60" height="20"/>
                                 <box><pen lineWidth="0.75"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/><paragraph leftIndent="2" rightIndent="2"/></textElement>
                                 <textFieldExpression><![CDATA[$F{severity}]]></textFieldExpression>
@@ -256,7 +256,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="60" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="60" height="20"/>
                                 <box><pen lineWidth="0.75"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/><paragraph leftIndent="2" rightIndent="2"/></textElement>
                                 <textFieldExpression><![CDATA[$F{priority}]]></textFieldExpression>
@@ -275,7 +275,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="100" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="100" height="20"/>
                                 <box><pen lineWidth="0.75"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/><paragraph leftIndent="2" rightIndent="2"/></textElement>
                                 <textFieldExpression><![CDATA[$F{assignedToName}]]></textFieldExpression>
@@ -294,7 +294,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="90" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="90" height="20"/>
                                 <box><pen lineWidth="0.75"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/><paragraph leftIndent="2" rightIndent="2"/></textElement>
                                 <textFieldExpression><![CDATA[$F{statusLabel}]]></textFieldExpression>


### PR DESCRIPTION
### Motivation
- Editor/schema hovers reported `Element jr:table is not allowed here` and `Attribute isStretchWithOverflow is not allowed here`, caused by unsupported attributes inside table detail cells. 
- Removing the invalid attribute restores JRXML schema validity and prevents cascading validation errors while preserving layout behavior.

### Description
- Removed `isStretchWithOverflow="true"` from `<reportElement>` nodes inside detail `<textField>` elements in `api/src/main/resources/reports/tickets_rpt_phase1_table.jrxml`. 
- Applied the same removal to `api/src/main/resources/reports/tickets_rpt_phase1_table_ui.jrxml`. 
- Left `textAdjust="StretchHeight"` on the `<textField>` elements to preserve the intended text-stretching behavior.

### Testing
- Ran `rg --files | rg -i 'phase1.*\.jrxml|tickets.*\.jrxml'` and `rg -n 'isStretchWithOverflow|<jr:table'` to locate and verify occurrences, and the searches succeeded. 
- Inspected the file diffs with `git diff` to confirm only the intended attribute removals in the two JRXML files, and the diff matched expectations. 
- Verified the updated files were written and show the attribute removed, and this verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bee2ee14c8332a37a905baa92b0df)