### PR TITLE
Update AllTickets export flow messaging and thresholds

### DIFF
--- a/ui/src/components/AllTickets/DownloadFiltersScreen.tsx
+++ b/ui/src/components/AllTickets/DownloadFiltersScreen.tsx
@@ -5,6 +5,7 @@ import {
     Chip,
     FormControl,
     InputLabel,
+    Link,
     MenuItem,
     Select,
     Stack,
@@ -44,7 +45,6 @@ interface DownloadFiltersScreenProps {
     estimatedCount: number | null;
     selectedRangeDays: number | null;
     isRangeInvalid: boolean;
-    onCancelExport?: () => void;
     onRetryExport?: () => void;
     onYearChange: (year: number | '') => void;
     onMonthChange: (month: number | '') => void;
@@ -93,7 +93,6 @@ const DownloadFiltersScreen: React.FC<DownloadFiltersScreenProps> = ({
     estimatedCount,
     selectedRangeDays,
     isRangeInvalid,
-    onCancelExport,
     onRetryExport,
     onYearChange,
     onMonthChange,
@@ -227,8 +226,13 @@ const DownloadFiltersScreen: React.FC<DownloadFiltersScreenProps> = ({
 
             {generationState === 'generating' && (
                 <Alert severity="info">
-                    {t('Your report is being generated.')}
-                    {onCancelExport && <Button size="small" sx={{ ml: 1 }} onClick={onCancelExport}>{t('Cancel export')}</Button>}
+                    {t('Go to Downloads.')}
+                    {' '}
+                    {t('You will find your downloads on the Downloads page.')}
+                    {' '}
+                    <Link href="/downloads" target="_blank" rel="noopener noreferrer">
+                        {t('Open Downloads')}
+                    </Link>
                 </Alert>
             )}
 
@@ -240,7 +244,7 @@ const DownloadFiltersScreen: React.FC<DownloadFiltersScreenProps> = ({
             )}
 
             {isRangeInvalid && <Alert severity="warning">{t('Please select a valid date range.')}</Alert>}
-            {selectedRangeDays !== null && selectedRangeDays > 31 && (
+            {estimatedCount !== null && estimatedCount > 2000 && (
                 <Alert severity="info">{t('Large date range selected. It may take some time to download this data.')}</Alert>
             )}
         </Stack>

--- a/ui/src/components/AllTickets/DownloadTicketsDialog.tsx
+++ b/ui/src/components/AllTickets/DownloadTicketsDialog.tsx
@@ -71,7 +71,6 @@ interface DownloadTicketsDialogProps {
     exportableColumns: DownloadReportColumn[];
     onClose: () => void;
     onGenerate: (format: 'pdf' | 'excel', filters: DownloadFilters) => Promise<void> | void;
-    onCancelExport?: () => void;
     onRetryExport?: () => void;
 }
 
@@ -117,7 +116,6 @@ const DownloadTicketsDialog: React.FC<DownloadTicketsDialogProps> = ({
     exportableColumns,
     onClose,
     onGenerate,
-    onCancelExport,
     onRetryExport,
 }) => {
     const { t } = useTranslation();
@@ -460,7 +458,6 @@ const DownloadTicketsDialog: React.FC<DownloadTicketsDialogProps> = ({
                             estimatedCount={estimatedCount}
                             selectedRangeDays={selectedRangeDays}
                             isRangeInvalid={isRangeInvalid}
-                            onCancelExport={onCancelExport}
                             onRetryExport={onRetryExport}
                             onYearChange={setYear}
                             onMonthChange={setMonth}

--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -575,15 +575,6 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
         doc.save(`${fileName}.pdf`);
     };
 
-    const cancelExportGeneration = () => {
-        if (exportAbortRef.current) {
-            exportAbortRef.current.abort();
-            exportAbortRef.current = null;
-        }
-        setExportGenerationState('idle');
-        showMessage(t('Export cancelled.'), 'info');
-    };
-
     const handleGenerateSelection = async (format: 'pdf' | 'excel', filters: DownloadFilters) => {
         if (!filters.fromDate || !filters.toDate) {
             showMessage(t('Please select a valid date range.'), 'warning');
@@ -594,10 +585,6 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
         if (!selectedRangeDays) {
             showMessage(t('Please select a valid date range.'), 'warning');
             return;
-        }
-
-        if (selectedRangeDays > 31) {
-            showMessage(t('Large date range selected. It may take some time to download this data.'), 'info');
         }
 
         setLastExportRequest({ format, filters });
@@ -1130,7 +1117,7 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
                     startIcon={<DownloadIcon fontSize="small" />}
                     onClick={handleDownloadDialogOpen}
                 >
-                    {t('Download')}
+                    {t('Generate Report')}
                 </Button>
             </div>
             {showColumnSelector && (
@@ -1182,7 +1169,6 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
                 open={downloadDialogOpen}
                 loading={downloadingTickets || exportGenerationState === 'generating'}
                 generationState={exportGenerationState}
-                onCancelExport={cancelExportGeneration}
                 onRetryExport={retryLastExport}
                 zoneOptions={zoneOptions}
                 issueTypeOptions={issueTypeOptions}

--- a/ui/src/components/AllTickets/__tests__/DownloadFiltersScreen.test.tsx
+++ b/ui/src/components/AllTickets/__tests__/DownloadFiltersScreen.test.tsx
@@ -60,10 +60,9 @@ describe('DownloadFiltersScreen', () => {
         generationState: 'idle' as const,
         estimateLoading: false,
         estimateCountPending: false,
-        estimatedCount: 1234,
+        estimatedCount: 2345,
         selectedRangeDays: 45,
         isRangeInvalid: true,
-        onCancelExport: jest.fn(),
         onRetryExport: jest.fn(),
         onYearChange: jest.fn(),
         onMonthChange: jest.fn(),
@@ -130,7 +129,7 @@ describe('DownloadFiltersScreen', () => {
         expect(screen.getByTestId('alert-info')).toHaveTextContent('Large date range selected. It may take some time to download this data.');
     });
 
-    it('shows generating state with cancel and estimating label when loading', async () => {
+    it('shows generating state with downloads guidance and link when loading', async () => {
         render(
             <DownloadFiltersScreen
                 {...props}
@@ -143,10 +142,8 @@ describe('DownloadFiltersScreen', () => {
         );
 
         expect(screen.getByText('Estimating records...')).toBeInTheDocument();
-        expect(screen.getByTestId('alert-info')).toHaveTextContent('Your report is being generated.');
-
-        await userEvent.click(screen.getByRole('button', { name: 'Cancel export' }));
-        expect(props.onCancelExport).toHaveBeenCalledTimes(1);
+        expect(screen.getByTestId('alert-info')).toHaveTextContent('Go to Downloads.');
+        expect(screen.getByRole('link', { name: 'Open Downloads' })).toHaveAttribute('href', '/downloads');
     });
 
     it('shows error state with retry and unavailable estimate fallback', async () => {

--- a/ui/src/components/AllTickets/__tests__/TicketsTable.test.tsx
+++ b/ui/src/components/AllTickets/__tests__/TicketsTable.test.tsx
@@ -353,7 +353,7 @@ describe('TicketsTable', () => {
         const initialProps = mockDownloadTicketsDialog.mock.calls[0][0];
         expect(initialProps.open).toBe(false);
 
-        await userEvent.click(screen.getByRole('button', { name: /Download/i }));
+        await userEvent.click(screen.getByRole('button', { name: /Generate Report/i }));
 
         const latestProps = mockDownloadTicketsDialog.mock.calls.at(-1)?.[0];
         expect(latestProps.open).toBe(true);


### PR DESCRIPTION
### Motivation
- Exports that take long should be queued and the user guided to the Downloads page instead of offering an in-dialog cancel action. 
- The “large date range” advisory should be driven by estimated record count instead of days to better reflect backend load. 
- Replace the ambiguous “Download” action with a clearer `Generate Report` label for async report generation.

### Description
- Renamed the top-row action button from `Download` to `Generate Report` in `TicketsTable.tsx` and updated related UI wiring. 
- Reworked the download dialog UI in `DownloadFiltersScreen.tsx` to replace the in-progress alert with: `Go to Downloads.` guidance, a link `Open Downloads` that opens `/downloads` in a new tab, and removed the cancel-export control. 
- Changed the large-range advisory to show only when `estimatedCount` is greater than `2000` (instead of using date-range days). 
- Removed the `onCancelExport` prop from `DownloadTicketsDialog.tsx` and removed the local cancel/export-abort UI path while retaining existing async API call flow to `tickets/search/export/download?` and error handling.
- Updated unit tests to reflect the new button label and generating-state messaging/link (`__tests__/TicketsTable.test.tsx` and `__tests__/DownloadFiltersScreen.test.tsx`).

### Testing
- Ran focused tests with `cd ui && npm test -- --runInBand src/components/AllTickets/__tests__/DownloadFiltersScreen.test.tsx src/components/AllTickets/__tests__/TicketsTable.test.tsx`.
- `DownloadFiltersScreen` tests were updated and pass with the new generation-state guidance and `/downloads` link.
- `TicketsTable` tests currently fail in this environment; failures include React `act(...)` warnings, a missing unique `key` console warning during render, and some assertion mismatches in the test suite (so the overall focused test run is failing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c23fbce6c8332ba8a95445c296744)