### PR TITLE
Downloads UI & API: use UUID request IDs, add Requested By details, and UI tweaks

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/controller/TicketController.java
+++ b/api/src/main/java/com/ticketingSystem/api/controller/TicketController.java
@@ -3,6 +3,7 @@ package com.ticketingSystem.api.controller;
 import com.ticketingSystem.api.dto.*;
 import com.ticketingSystem.api.exception.CustomGenericException;
 import com.ticketingSystem.api.models.Ticket;
+import com.ticketingSystem.api.dto.UserDto;
 import com.ticketingSystem.api.models.TicketComment;
 import com.ticketingSystem.api.models.TicketSla;
 import com.ticketingSystem.api.service.TicketService;
@@ -381,7 +382,7 @@ public class TicketController {
             @RequestParam(required = false, defaultValue = "reported_date") String dateParam,
             @RequestParam(required = false) String fromDate,
             @RequestParam(required = false) String toDate,
-            @RequestParam(required = false) Long requestedBy) {
+            @RequestParam(required = false) String requestedBy) {
         Map<String, Object> filters = new HashMap<>();
         filters.put("query", query);
         filters.put("statusId", statusId);
@@ -438,7 +439,7 @@ public class TicketController {
             @RequestParam(required = false, defaultValue = "reported_date") String dateParam,
             @RequestParam(required = false) String fromDate,
             @RequestParam(required = false) String toDate,
-            @RequestParam(required = false) Long requestedBy) {
+            @RequestParam(required = false) String requestedBy) {
         Map<String, Object> filters = new HashMap<>();
         filters.put("query", query);
         filters.put("statusId", statusId);
@@ -482,6 +483,15 @@ public class TicketController {
                     row.put("failedAt", req.getFailedAt());
                     row.put("errorMessage", req.getErrorMessage());
                     row.put("expiresAt", req.getExpiresAt());
+                    if (req.getRequestedBy() != null && !req.getRequestedBy().isBlank()) {
+                        userService.getUserDetails(req.getRequestedBy()).ifPresent(user -> {
+                            Map<String, Object> requestedByDetails = new HashMap<>();
+                            requestedByDetails.put("userId", user.getUserId());
+                            requestedByDetails.put("username", user.getUsername());
+                            requestedByDetails.put("name", user.getName());
+                            row.put("requestedByDetails", requestedByDetails);
+                        });
+                    }
                     reportArtifactRepository.findByRequestRequestId(req.getRequestId()).ifPresent(a -> {
                         row.put("fileName", a.getFileName());
                         row.put("downloadPath", "/tickets/search/export/requests/" + req.getRequestId() + "/download");
@@ -492,7 +502,7 @@ public class TicketController {
     }
 
     @GetMapping("/search/export/requests/{requestId}/artifact")
-    public ResponseEntity<Map<String, Object>> getReportArtifact(@PathVariable Long requestId) {
+    public ResponseEntity<Map<String, Object>> getReportArtifact(@PathVariable String requestId) {
         Optional<ReportArtifact> artifact = reportArtifactRepository.findByRequestRequestId(requestId);
         if (artifact.isEmpty()) {
             return ResponseEntity.notFound().build();
@@ -510,7 +520,7 @@ public class TicketController {
     }
 
     @GetMapping("/search/export/requests/{requestId}/download")
-    public ResponseEntity<Void> downloadReportArtifact(@PathVariable Long requestId) throws Exception {
+    public ResponseEntity<Void> downloadReportArtifact(@PathVariable String requestId) throws Exception {
         Optional<ReportArtifact> artifact = reportArtifactRepository.findByRequestRequestId(requestId);
         if (artifact.isEmpty()) {
             return ResponseEntity.notFound().build();

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/models/ReportRequestHistory.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/models/ReportRequestHistory.java
@@ -12,16 +12,16 @@ import java.time.LocalDateTime;
 @Setter
 public class ReportRequestHistory {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "request_id")
-    private Long requestId;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "request_id", length = 36)
+    private String requestId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "report_id", nullable = false)
     private ReportMaster report;
 
-    @Column(name = "requested_by", nullable = false)
-    private Long requestedBy;
+    @Column(name = "requested_by", nullable = false, length = 36)
+    private String requestedBy;
 
     @Column(name = "status", nullable = false, length = 50)
     private String status;

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/repository/ReportArtifactRepository.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/repository/ReportArtifactRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface ReportArtifactRepository extends JpaRepository<ReportArtifact, Long> {
-    Optional<ReportArtifact> findByRequestRequestId(Long requestId);
+    Optional<ReportArtifact> findByRequestRequestId(String requestId);
 }

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/repository/ReportRequestHistoryRepository.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/repository/ReportRequestHistoryRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface ReportRequestHistoryRepository extends JpaRepository<ReportRequestHistory, Long> {
+public interface ReportRequestHistoryRepository extends JpaRepository<ReportRequestHistory, String> {
     List<ReportRequestHistory> findTop50ByOrderByRequestedAtDesc();
 }

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/service/AsyncReportService.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/service/AsyncReportService.java
@@ -55,23 +55,23 @@ public class AsyncReportService {
     }
 
 
-    public ReportRequestHistory queueTicketExport(String reportCode, ReportFormat format, Map<String, Object> filters, Long requestedBy) {
+    public ReportRequestHistory queueTicketExport(String reportCode, ReportFormat format, Map<String, Object> filters, String requestedBy) {
         ReportMaster reportMaster = reportMasterRepository.findByReportCodeAndActiveTrue(reportCode)
                 .orElseThrow(() -> new IllegalArgumentException("Report definition not found for code: " + reportCode));
 
         ReportRequestHistory request = new ReportRequestHistory();
         request.setReport(reportMaster);
-        request.setRequestedBy(requestedBy != null ? requestedBy : 0L);
+        request.setRequestedBy(requestedBy != null ? requestedBy : "SYSTEM");
         request.setStatus(RequestStatus.QUEUED.name());
         request.setOutputFormat(format.name());
         request = reportRequestHistoryRepository.save(request);
 
-        final Long requestId = request.getRequestId();
+        final String requestId = request.getRequestId();
         taskExecutor.execute(() -> processRequest(requestId, reportCode, format, filters));
         return request;
     }
 
-    private void processRequest(Long requestId, String reportCode, ReportFormat format, Map<String, Object> filters) {
+    private void processRequest(String requestId, String reportCode, ReportFormat format, Map<String, Object> filters) {
         ReportRequestHistory request = reportRequestHistoryRepository.findById(requestId).orElse(null);
         if (request == null) return;
         try {

--- a/api/src/main/resources/db/migration/V16__create_report_definition_tables.sql
+++ b/api/src/main/resources/db/migration/V16__create_report_definition_tables.sql
@@ -58,9 +58,9 @@ CREATE TABLE IF NOT EXISTS report_column_mapping (
 ------------------------------------------------------
 
 CREATE TABLE IF NOT EXISTS report_request_history (
-    request_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    request_id VARCHAR(36) PRIMARY KEY,
     report_id BIGINT NOT NULL,
-    requested_by BIGINT NOT NULL,
+    requested_by VARCHAR(36) NOT NULL,
     status VARCHAR(50) NOT NULL,
     output_format VARCHAR(50) NOT NULL,
     selected_columns_json JSON,
@@ -79,7 +79,7 @@ CREATE TABLE IF NOT EXISTS report_request_history (
 
 CREATE TABLE IF NOT EXISTS report_artifact (
     artifact_id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    request_id BIGINT NOT NULL,
+    request_id VARCHAR(36) NOT NULL,
     file_name VARCHAR(512) NOT NULL,
     content_type VARCHAR(255),
     file_size BIGINT,

--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -609,6 +609,7 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
                 divisionId: filters.divisionId,
                 assignedTo: filters.assignedTo,
                 statusId: filters.statusId,
+                requestedBy: getCurrentUserDetails()?.userId,
                 signal: controller.signal,
             }));
 

--- a/ui/src/pages/Downloads.tsx
+++ b/ui/src/pages/Downloads.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, CircularProgress, Typography } from '@mui/material';
+import { Box, CircularProgress, Tooltip, Typography } from '@mui/material';
 import type { ColumnsType } from 'antd/es/table';
 import GenericTable from '../components/UI/GenericTable';
 import { useApi } from '../hooks/useApi';
@@ -8,7 +8,7 @@ import CustomIconButton from '../components/UI/IconButton/CustomIconButton';
 import { formatDateTimeWithRelative } from '../utils/Utils';
 
 type ReportRequestRow = {
-  requestId: number;
+  requestId: string;
   reportCode?: string;
   status?: string;
   outputFormat?: string;
@@ -18,6 +18,11 @@ type ReportRequestRow = {
   errorMessage?: string;
   fileName?: string;
   downloadPath?: string;
+  requestedByDetails?: {
+    userId?: string;
+    username?: string;
+    name?: string;
+  };
 };
 
 const Downloads: React.FC = () => {
@@ -47,16 +52,24 @@ const Downloads: React.FC = () => {
 
   const columns = React.useMemo<ColumnsType<ReportRequestRow>>(
     () => [
-      { title: 'Request ID', dataIndex: 'requestId', key: 'requestId', width: 120 },
       { title: 'Report', dataIndex: 'reportCode', key: 'reportCode', render: (value) => value || '-' },
       { title: 'Format', dataIndex: 'outputFormat', key: 'outputFormat', render: (value) => value || '-' },
+      {
+        title: 'Requested By',
+        key: 'requestedBy',
+        render: (_, row) => {
+          const name = row.requestedByDetails?.name || '-';
+          const username = row.requestedByDetails?.username;
+          if (!username || name === '-') return name;
+          return <Tooltip title={username}><span>{name}</span></Tooltip>;
+        },
+      },
       { title: 'Requested At', dataIndex: 'requestedAt', key: 'requestedAt', render: (value) => renderDateCell(value) },
       {
         title: 'Completed At',
         key: 'doneAt',
         render: (_, row) => renderDateCell(row.completedAt || row.failedAt),
       },
-      { title: 'File', dataIndex: 'fileName', key: 'fileName', render: (value) => value || '-' },
       {
         title: 'Action',
         key: 'action',
@@ -66,7 +79,7 @@ const Downloads: React.FC = () => {
           }
 
           if (row.status === 'FAILED') {
-            return <CustomIconButton icon="error" size="small" disabled aria-label="Failed" />;
+            return <CustomIconButton icon="error" size="small" disabled aria-label="Failed" sx={{ color: "error.main" }} />;
           }
 
           if (row.downloadPath && row.status === 'COMPLETED') {

--- a/ui/src/services/TicketService.ts
+++ b/ui/src/services/TicketService.ts
@@ -165,6 +165,7 @@ export function downloadTicketsReport({
     assignedTo,
     statusId,
     divisionId,
+    requestedBy,
     signal,
 }: SearchTicketsForExportParams & { reportCode: string; format: 'PDF' | 'EXCEL' }) {
     const params = new URLSearchParams();
@@ -182,6 +183,7 @@ export function downloadTicketsReport({
     if (divisionId) params.append('divisionId', divisionId);
     if (assignedTo) params.append('assignedTo', assignedTo);
     if (statusId) params.append('status', statusId);
+    if (requestedBy) params.append('requestedBy', requestedBy);
     return axios.get(`${BASE_URL}/tickets/search/export/download?${params.toString()}`, signal ? { signal } : undefined);
 }
 
@@ -208,6 +210,7 @@ interface SearchTicketsForExportParams {
     assignedTo?: string;
     statusId?: string;
     divisionId?: string;
+    requestedBy?: string;
     signal?: AbortSignal;
 }
 
@@ -239,6 +242,7 @@ export function searchTicketsForExport({
     if (divisionId) params.append('divisionId', divisionId);
     if (assignedTo) params.append('assignedTo', assignedTo);
     if (statusId) params.append('status', statusId);
+    if (requestedBy) params.append('requestedBy', requestedBy);
     if (divisionId) params.append('divisionId', divisionId);
     return axios.get(`${BASE_URL}/tickets/search/export?${params.toString()}`, signal ? { signal } : undefined);
 }


### PR DESCRIPTION
### Motivation
- Improve the Downloads page UX by showing who requested a report (name + username on hover), removing redundant columns, and making the failed icon clearly visible in red. 
- Ensure report requests are tracked with stable UUID identifiers instead of numeric IDs. 
- Record and return requester identity details from the report-generation API so the UI can display requester name and username.

### Description
- UI: `ui/src/pages/Downloads.tsx` was updated to remove the `Request ID` and `File` columns, add a `Requested By` column that shows requester `name` and displays `username` in a tooltip on hover, and style the failed action icon to use the theme error color. 
- Frontend API client: `ui/src/services/TicketService.ts` now accepts and sends a `requestedBy` parameter for report export requests, and `ui/src/components/AllTickets/TicketsTable.tsx` forwards `getCurrentUserDetails()?.userId` as `requestedBy` when queuing exports. 
- Backend model and repos: `api/src/main/java/com/ticketingSystem/reportGenerator/models/ReportRequestHistory.java` was changed to use `String requestId` with `GenerationType.UUID` and `String requestedBy`; `ReportRequestHistoryRepository` now uses `String` as the ID type; `ReportArtifactRepository.findByRequestRequestId(...)` signature was adjusted to accept `String`. 
- Backend service/controller: `AsyncReportService` signatures and the internal `processRequest` now use `String` request IDs and `String requestedBy`; `TicketController` endpoints that accept/return request IDs or `requestedBy` were updated to `String`, the `GET /tickets/search/export/requests` response was enhanced to include `requestedByDetails` (`userId`, `username`, `name`) when available, and artifact/download lookups were adapted for string request IDs. 
- DB migration: `api/src/main/resources/db/migration/V16__create_report_definition_tables.sql` updated `report_request_history.request_id`/`requested_by` and `report_artifact.request_id` to `VARCHAR(36)` to support UUIDs.

### Testing
- Attempted to compile the API with `./gradlew -q compileJava` which failed due to an environment/tooling mismatch (`Unsupported class file major version 69`), so backend compile verification could not complete. 
- Ran the UI test command `npm run test -- --watch=false --runInBand src/pages/Downloads.tsx --passWithNoTests` which exited successfully with no matching tests (no tests for the Downloads page) and returned exit code 0.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c2f6883d88332a32cc370110e47d7)