### PR TITLE
Remove invalid isStretchWithOverflow attributes from phase1 table JRXML

### DIFF
--- a/api/src/main/resources/reports/tickets_rpt_phase1_table.jrxml
+++ b/api/src/main/resources/reports/tickets_rpt_phase1_table.jrxml
@@ -66,7 +66,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="60" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="60" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{id}]]></textFieldExpression>
@@ -85,7 +85,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="80" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="80" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{requestorName}]]></textFieldExpression>
@@ -104,7 +104,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="90" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="90" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{reportedDate}]]></textFieldExpression>
@@ -123,7 +123,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="80" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="80" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{category}]]></textFieldExpression>
@@ -142,7 +142,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="100" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="100" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{subCategory}]]></textFieldExpression>
@@ -161,7 +161,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="210" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="210" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{issueTypeLabel}]]></textFieldExpression>
@@ -180,7 +180,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="80" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="80" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{zoneCode}]]></textFieldExpression>
@@ -199,7 +199,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="80" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="80" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{districtName}]]></textFieldExpression>
@@ -218,7 +218,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="90" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="90" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{regionName}]]></textFieldExpression>
@@ -237,7 +237,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="60" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="60" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{severity}]]></textFieldExpression>
@@ -256,7 +256,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="60" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="60" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{priority}]]></textFieldExpression>
@@ -275,7 +275,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="100" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="100" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{assignedToName}]]></textFieldExpression>
@@ -294,7 +294,7 @@
                         </jr:columnHeader>
                         <jr:detailCell height="20">
                             <textField textAdjust="StretchHeight">
-                                <reportElement x="0" y="0" width="90" height="20" isStretchWithOverflow="true"/>
+                                <reportElement x="0" y="0" width="90" height="20"/>
                                 <box><pen lineWidth="1.0"/></box>
                                 <textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
                                 <textFieldExpression><![CDATA[$F{statusLabel}]]></textFieldExpression>


### PR DESCRIPTION
### Motivation
- Fix JRXML schema validation failures during report compilation caused by the illegal `isStretchWithOverflow` attribute on `<reportElement>` elements in the phase1 table report.

### Description
- Removed `isStretchWithOverflow="true"` from all `<reportElement>` nodes inside detail `<textField>` entries in `api/src/main/resources/reports/tickets_rpt_phase1_table.jrxml`.
- Kept the `<textField textAdjust="StretchHeight">` configuration intact so text growth behavior remains governed by the `textField` settings.
- Updated the JRXML to be schema-compliant for the JRXML version used by the project.

### Testing
- Ran `rg -n 'isStretchWithOverflow' api/src/main/resources/reports/tickets_rpt_phase1_table.jrxml || true` and confirmed there were no matches, indicating the attribute was removed successfully.
- Inspected the modified file with `nl -ba api/src/main/resources/reports/tickets_rpt_phase1_table.jrxml | sed -n '64,305p'` to verify the `<reportElement>` tags no longer contain the invalid attribute.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c48dfab3083329829d516ca039255)