### PR TITLE
Fix JRXML schema order for tickets phase1 table report

### DIFF
--- a/api/src/main/resources/reports/tickets_rpt_phase1_table.jrxml
+++ b/api/src/main/resources/reports/tickets_rpt_phase1_table.jrxml
@@ -37,6 +37,22 @@
     <field name="assignedToName" class="java.lang.String"/>
     <field name="statusLabel" class="java.lang.String"/>
 
+    <subDataset name="TicketTableDataset">
+        <field name="id" class="java.lang.String"/>
+        <field name="requestorName" class="java.lang.String"/>
+        <field name="reportedDate" class="java.time.LocalDateTime"/>
+        <field name="category" class="java.lang.String"/>
+        <field name="subCategory" class="java.lang.String"/>
+        <field name="issueTypeLabel" class="java.lang.String"/>
+        <field name="zoneCode" class="java.lang.String"/>
+        <field name="districtName" class="java.lang.String"/>
+        <field name="regionName" class="java.lang.String"/>
+        <field name="severity" class="java.lang.String"/>
+        <field name="priority" class="java.lang.String"/>
+        <field name="assignedToName" class="java.lang.String"/>
+        <field name="statusLabel" class="java.lang.String"/>
+    </subDataset>
+
     <title>
         <band height="40">
             <staticText>
@@ -305,19 +321,4 @@
             </componentElement>
         </band>
     </detail>
-    <subDataset name="TicketTableDataset">
-        <field name="id" class="java.lang.String"/>
-        <field name="requestorName" class="java.lang.String"/>
-        <field name="reportedDate" class="java.time.LocalDateTime"/>
-        <field name="category" class="java.lang.String"/>
-        <field name="subCategory" class="java.lang.String"/>
-        <field name="issueTypeLabel" class="java.lang.String"/>
-        <field name="zoneCode" class="java.lang.String"/>
-        <field name="districtName" class="java.lang.String"/>
-        <field name="regionName" class="java.lang.String"/>
-        <field name="severity" class="java.lang.String"/>
-        <field name="priority" class="java.lang.String"/>
-        <field name="assignedToName" class="java.lang.String"/>
-        <field name="statusLabel" class="java.lang.String"/>
-    </subDataset>
 </jasperReport>


### PR DESCRIPTION
### Motivation
- The JRXML failed to parse with a SAX validation error because a root-level `<subDataset>` was placed after `</detail>`, which violates the JasperReports schema that expects elements like `columnFooter`, `pageFooter`, `lastPageFooter`, `summary`, or `noData` in that position. 
- The `<jr:table>` in the detail band needs a subDataset definition present in a valid root-level location so the `datasetRun` can reference it and the XML validates.

### Description
- Moved the `<subDataset name="TicketTableDataset">` block from the end of the file to immediately after the root-level `<field>` declarations and before the `<title>` element. 
- Removed the duplicate/trailing `<subDataset>` block that remained after `</detail>` to restore valid element ordering. 
- Modified `api/src/main/resources/reports/tickets_rpt_phase1_table.jrxml` to apply the fix.

### Testing
- Searched for `<subDataset>` occurrences with `rg -n` and confirmed the subDataset now appears only in the intended location; the search succeeded. 
- Inspected the updated file with `nl`/`sed` to verify the moved block and absence of the trailing duplicate; the inspection succeeded. 
- Verified repository state and committed the change with `git status` and `git commit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4d28e59883328127d41d449a2b09)