### PR TITLE
Fix JRXML schema validation error in phase1 table report

### DIFF
--- a/api/src/main/resources/reports/tickets_rpt_phase1_table.jrxml
+++ b/api/src/main/resources/reports/tickets_rpt_phase1_table.jrxml
@@ -23,20 +23,6 @@
     <parameter name="showAssigneeName" class="java.lang.Boolean"/>
     <parameter name="showStatus" class="java.lang.Boolean"/>
 
-    <field name="id" class="java.lang.String"/>
-    <field name="requestorName" class="java.lang.String"/>
-    <field name="reportedDate" class="java.time.LocalDateTime"/>
-    <field name="category" class="java.lang.String"/>
-    <field name="subCategory" class="java.lang.String"/>
-    <field name="issueTypeLabel" class="java.lang.String"/>
-    <field name="zoneCode" class="java.lang.String"/>
-    <field name="districtName" class="java.lang.String"/>
-    <field name="regionName" class="java.lang.String"/>
-    <field name="severity" class="java.lang.String"/>
-    <field name="priority" class="java.lang.String"/>
-    <field name="assignedToName" class="java.lang.String"/>
-    <field name="statusLabel" class="java.lang.String"/>
-
     <subDataset name="TicketTableDataset">
         <field name="id" class="java.lang.String"/>
         <field name="requestorName" class="java.lang.String"/>
@@ -52,6 +38,21 @@
         <field name="assignedToName" class="java.lang.String"/>
         <field name="statusLabel" class="java.lang.String"/>
     </subDataset>
+
+    <field name="id" class="java.lang.String"/>
+    <field name="requestorName" class="java.lang.String"/>
+    <field name="reportedDate" class="java.time.LocalDateTime"/>
+    <field name="category" class="java.lang.String"/>
+    <field name="subCategory" class="java.lang.String"/>
+    <field name="issueTypeLabel" class="java.lang.String"/>
+    <field name="zoneCode" class="java.lang.String"/>
+    <field name="districtName" class="java.lang.String"/>
+    <field name="regionName" class="java.lang.String"/>
+    <field name="severity" class="java.lang.String"/>
+    <field name="priority" class="java.lang.String"/>
+    <field name="assignedToName" class="java.lang.String"/>
+    <field name="statusLabel" class="java.lang.String"/>
+
 
     <title>
         <band height="40">


### PR DESCRIPTION
### Motivation
- The JRXML file failed JasperReports XML schema validation with a SAXParseException because a `<subDataset>` element appeared after top-level `<field>` declarations, which violates the expected element ordering.

### Description
- Moved the `<subDataset name="TicketTableDataset">` block so it appears before the top-level `<field>` declarations in `api/src/main/resources/reports/tickets_rpt_phase1_table.jrxml`.
- Kept the existing `<datasetRun subDataset="TicketTableDataset">` binding intact so runtime behavior is unchanged.
- Updated the file in the repository and committed the change.

### Testing
- Inspected the file with `nl`/`sed` to confirm the new element order and ran a scripted edit via a small Python replacement, both of which completed successfully. 
- Verified repository status with `git status --short` and committed the change with `git commit`, and both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c82e14ec0833294c70eed3f5dccab)