### PR TITLE
Re-enable Download Tickets Generate button after request completion

### DIFF
--- a/ui/src/components/AllTickets/TicketsTable.tsx
+++ b/ui/src/components/AllTickets/TicketsTable.tsx
@@ -617,7 +617,6 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
                 return;
             }
 
-            setExportGenerationState('idle');
             showMessage(t('Report request queued. Please check Downloads page.'), 'success');
             handleDownloadDialogClose();
         } catch (error: any) {
@@ -631,6 +630,7 @@ const TicketsTable: React.FC<TicketsTableProps> = ({ tickets, onIdClick, onRowCl
                 : t('Export failed. Range may be too large; narrow filters or request async report.');
             showMessage(message, 'error');
         } finally {
+            setExportGenerationState('idle');
             exportAbortRef.current = null;
         }
     };


### PR DESCRIPTION
### Motivation
- Ensure the Download Tickets modal `Generate` button is re-enabled whenever the report API call completes regardless of success, failure, or cancellation.

### Description
- Reset `exportGenerationState` to `'idle'` in the `finally` block of `handleGenerateSelection` in `ui/src/components/AllTickets/TicketsTable.tsx`, removing the previous success-path `setExportGenerationState('idle')` so the button state is always cleared after the request.

### Testing
- Ran `cd ui && npm test -- --runTestsByPath src/components/AllTickets/__tests__/TicketsTable.test.tsx --watch=false`, and the suite finished with two pre-existing export-related test failures while this change introduced no new TypeScript or runtime errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d71e3a63c833296866aeab8832856)