### PR TITLE
Include structured filters and summary in async report generation; add ticket JRXML template

### DIFF
--- a/api/src/main/java/com/ticketingSystem/reportGenerator/service/AsyncReportService.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/service/AsyncReportService.java
@@ -11,6 +11,8 @@ import com.ticketingSystem.reportGenerator.models.ReportRequestHistory;
 import com.ticketingSystem.reportGenerator.repository.ReportArtifactRepository;
 import com.ticketingSystem.reportGenerator.repository.ReportMasterRepository;
 import com.ticketingSystem.reportGenerator.repository.ReportRequestHistoryRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -22,6 +24,9 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.stream.Collectors;
 
 @Service
 //@RequiredArgsConstructor
@@ -35,6 +40,7 @@ public class AsyncReportService {
     private final OciUploadService ociUploadService;
 //    @Qualifier("notificationTaskExecutor")
     private final TaskExecutor taskExecutor;
+    private final ObjectMapper objectMapper;
 
     public AsyncReportService(
     ReportRequestHistoryRepository reportRequestHistoryRepository,
@@ -43,7 +49,8 @@ public class AsyncReportService {
     TicketService ticketService,
     ReportDownloadService reportDownloadService,
     OciUploadService ociUploadService,
-    @Qualifier("notificationTaskExecutor") TaskExecutor taskExecutor
+    @Qualifier("notificationTaskExecutor") TaskExecutor taskExecutor,
+    ObjectMapper objectMapper
     ) {
         this.reportRequestHistoryRepository = reportRequestHistoryRepository;
         this.reportArtifactRepository = reportArtifactRepository;
@@ -52,6 +59,7 @@ public class AsyncReportService {
         this.reportDownloadService = reportDownloadService;
         this.ociUploadService = ociUploadService;
         this.taskExecutor = taskExecutor;
+        this.objectMapper = objectMapper;
     }
 
 
@@ -64,6 +72,7 @@ public class AsyncReportService {
         request.setRequestedBy(requestedBy != null ? requestedBy : "SYSTEM");
         request.setStatus(RequestStatus.QUEUED.name());
         request.setOutputFormat(format.name());
+        request.setFiltersJson(toFiltersJson(filters));
         request = reportRequestHistoryRepository.save(request);
 
         final String requestId = request.getRequestId();
@@ -109,6 +118,7 @@ public class AsyncReportService {
             params.put("generatedOn", LocalDateTime.now().toString());
             params.put("fromDate", filters.get("fromDate"));
             params.put("toDate", filters.get("toDate"));
+            params.put("filterSummary", buildFilterSummary(filters));
 
             byte[] file = reportDownloadService.generate(reportCode, format, results, params);
             String ext = format == ReportFormat.PDF ? "pdf" : "xlsx";
@@ -136,4 +146,62 @@ public class AsyncReportService {
             reportRequestHistoryRepository.save(request);
         }
     }
+
+    private String toFiltersJson(Map<String, Object> filters) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("filters", new ArrayList<>(filters.entrySet().stream()
+                .filter(entry -> entry.getKey() != null && !entry.getKey().equals("query") && !entry.getKey().equals("dateParam"))
+                .map(entry -> {
+                    Map<String, Object> row = new LinkedHashMap<>();
+                    row.put("key", entry.getKey());
+                    row.put("label", toLabel(entry.getKey()));
+                    row.put("type", inferType(entry.getValue()));
+                    row.put("value", entry.getValue());
+                    boolean isAll = isAllValue(entry.getValue());
+                    row.put("display_value", isAll ? "All" : formatValue(entry.getValue()));
+                    row.put("is_all", isAll);
+                    return row;
+                })
+                .collect(Collectors.toList())));
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to serialize filters_json", e);
+            return "{\"filters\":[]}";
+        }
+    }
+
+    private String buildFilterSummary(Map<String, Object> filters) {
+        return filters.entrySet().stream()
+                .filter(entry -> entry.getKey() != null && !entry.getKey().equals("query") && !entry.getKey().equals("dateParam"))
+                .map(entry -> toLabel(entry.getKey()) + ": " + (isAllValue(entry.getValue()) ? "All" : formatValue(entry.getValue())))
+                .collect(Collectors.joining(" | "));
+    }
+
+    private boolean isAllValue(Object value) {
+        if (value == null) return true;
+        if (value instanceof String str) return str.trim().isEmpty();
+        if (value instanceof List<?> list) return list.isEmpty();
+        return false;
+    }
+
+    private String formatValue(Object value) {
+        if (value instanceof List<?> list) {
+            return list.stream().map(String::valueOf).collect(Collectors.joining(", "));
+        }
+        return String.valueOf(value);
+    }
+
+    private String inferType(Object value) {
+        if (value instanceof List<?>) return "multi_select";
+        if (value instanceof Boolean) return "boolean";
+        return "single_select";
+    }
+
+    private String toLabel(String key) {
+        String spaced = key.replaceAll("([a-z])([A-Z])", "$1 $2").replace('_', ' ').trim();
+        if (spaced.isEmpty()) return key;
+        return Character.toUpperCase(spaced.charAt(0)) + spaced.substring(1);
+    }
+
 }

--- a/api/src/main/resources/reports/ticket_rpt_phase1-1.jrxml
+++ b/api/src/main/resources/reports/ticket_rpt_phase1-1.jrxml
@@ -1,0 +1,642 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 6.21.5.final using JasperReports Library version 6.21.5-74d586df47b25dbd05bd0957999819196e59934a  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Ticket_Report" pageWidth="1605" pageHeight="595" orientation="Landscape" columnWidth="1565" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="49eb571f-0fd6-446d-ba14-d8096438ffca">
+	<property name="com.jaspersoft.studio.unit." value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.pageHeight" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.pageWidth" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.topMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.bottomMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.leftMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.rightMargin" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.columnWidth" value="pixel"/>
+	<property name="com.jaspersoft.studio.unit.columnSpacing" value="pixel"/>
+	<property name="com.jaspersoft.studio.data.defaultdataadapter" value="annadarpan_ticket_db"/>
+	<property name="com.jaspersoft.studio.data.sql.tables" value=""/>
+	<parameter name="fromDate" class="java.util.Date"/>
+	<parameter name="toDate" class="java.util.Date"/>
+	<parameter name="zoneCode" class="java.lang.String"/>
+	<parameter name="regionCode" class="java.lang.String"/>
+	<parameter name="districtCode" class="java.lang.String"/>
+	<parameter name="issueTypeId" class="java.lang.String"/>
+	<parameter name="statusId" class="java.lang.String"/>
+	<parameter name="priorityId" class="java.lang.String"/>
+	<parameter name="assignedToName" class="java.lang.String"/>
+	<parameter name="showTicketId" class="java.lang.Boolean"/>
+	<parameter name="showRequestor" class="java.lang.Boolean"/>
+	<parameter name="showCreatedDate" class="java.lang.Boolean"/>
+	<parameter name="showModule" class="java.lang.Boolean"/>
+	<parameter name="showSubModule" class="java.lang.Boolean"/>
+	<parameter name="showIssueType" class="java.lang.Boolean"/>
+	<parameter name="showZone" class="java.lang.Boolean"/>
+	<parameter name="showDistrict" class="java.lang.Boolean"/>
+	<parameter name="showRegion" class="java.lang.Boolean"/>
+	<parameter name="showSeverity" class="java.lang.Boolean"/>
+	<parameter name="showPriority" class="java.lang.Boolean"/>
+	<parameter name="showAssigneeName" class="java.lang.Boolean"/>
+	<parameter name="showStatus" class="java.lang.Boolean"/>
+	<parameter name="filterSummary" class="java.lang.String"/>
+	<queryString>
+		<![CDATA[SELECT
+    t.ticket_id AS id,
+    COALESCE(NULLIF(t.requestor_name, ''), '-') AS requestorName,
+    t.reported_date AS reportedDate,
+
+    COALESCE(NULLIF(t.subject, ''), '-') AS subject,
+    COALESCE(NULLIF(t.description, ''), '-') AS description,
+
+    COALESCE(NULLIF(c.category, ''), NULLIF(t.category, ''), '-') AS category,
+    COALESCE(NULLIF(sc.sub_category, ''), NULLIF(t.sub_category, ''), '-') AS subCategory,
+    COALESCE(NULLIF(it.name, ''), NULLIF(t.issue_type_id, ''), '-') AS issueTypeLabel,
+
+    COALESCE(NULLIF(zm.zone_name, ''), NULLIF(t.zone_code, ''), '-') AS zoneCode,
+    COALESCE(NULLIF(t.district_name, ''), NULLIF(dm.district_name, ''), '-') AS districtName,
+    COALESCE(NULLIF(t.region_name, ''), NULLIF(rm.region_name, ''), '-') AS regionName,
+
+    COALESCE(NULLIF(t.severity, ''), '-') AS severity,
+    COALESCE(CAST(pm.tp_id AS CHAR), NULLIF(t.priority, ''), '-') AS priority,
+
+    COALESCE(NULLIF(au.name, ''), NULLIF(t.assigned_to, ''), '-') AS assignedToName,
+    COALESCE(NULLIF(sm.label, ''), NULLIF(sm.status_name, ''), NULLIF(t.status, ''), '-') AS statusLabel
+        FROM tickets t
+        LEFT JOIN categories c ON c.category_id = t.category
+        LEFT JOIN sub_categories sc ON sc.sub_category_id = t.sub_category
+        LEFT JOIN issue_type_master it ON it.issue_type_id = t.issue_type_id
+        LEFT JOIN zone_master zm ON zm.zone_code = t.zone_code
+        LEFT JOIN region_master rm ON rm.region_code = t.region_code
+        LEFT JOIN district_master dm ON dm.district_code = t.district_code
+        LEFT JOIN priority_master pm ON pm.tp_id = t.priority
+        LEFT JOIN users au ON au.username = t.assigned_to
+        LEFT JOIN status_master sm ON sm.status_id = t.status_id
+        WHERE 1 = 1
+        AND ( $P{fromDate} IS NULL OR t.reported_date >= $P{fromDate} )
+  AND ( $P{toDate}   IS NULL OR t.reported_date <  DATE_ADD($P{toDate}, INTERVAL 1 DAY) )
+  AND ( $P{zoneCode} IS NULL OR t.zone_code = $P{zoneCode} )
+  AND ( $P{regionCode} IS NULL OR t.region_code = $P{regionCode} )
+  AND ( $P{districtCode} IS NULL OR t.district_code = $P{districtCode} )
+  AND ( $P{issueTypeId} IS NULL OR t.issue_type_id = $P{issueTypeId} )
+  AND ( $P{statusId} IS NULL OR t.status_id = $P{statusId} )
+  AND ( $P{priorityId} IS NULL OR t.priority = $P{priorityId} )
+  AND ( $P{assignedToName} IS NULL OR LOWER(t.assigned_to) = LOWER($P{assignedToName}) )
+ORDER BY t.ticket_id]]>
+	</queryString>
+	<field name="id" class="java.lang.String"/>
+	<field name="requestorName" class="java.lang.String"/>
+	<field name="reportedDate" class="java.time.LocalDateTime"/>
+	<field name="subject" class="java.lang.String"/>
+	<field name="description" class="java.lang.String"/>
+	<field name="category" class="java.lang.String"/>
+	<field name="subCategory" class="java.lang.String"/>
+	<field name="issueTypeLabel" class="java.lang.String"/>
+	<field name="zoneCode" class="java.lang.String"/>
+	<field name="districtName" class="java.lang.String"/>
+	<field name="regionName" class="java.lang.String"/>
+	<field name="severity" class="java.lang.String"/>
+	<field name="priority" class="java.lang.String"/>
+	<field name="assignedToName" class="java.lang.String"/>
+	<field name="statusLabel" class="java.lang.String"/>
+	<title>
+		<band height="40">
+			<staticText>
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" x="0" y="0" width="1565" height="40" uuid="a7f0d976-ce8a-4587-b241-3dda2d8d5b39"/>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="19" isBold="true" isItalic="false"/>
+				</textElement>
+				<text><![CDATA[Ticket Report]]></text>
+			</staticText>
+		</band>
+	</title>
+	<pageHeader>
+		<band height="70">
+			<staticText>
+				<reportElement x="0" y="0" width="240" height="20" mode="Opaque" backcolor="#D9D9D9" uuid="11111111-2222-3333-4444-555555555551"/>
+				<box><topPen lineWidth="0.75"/><leftPen lineWidth="0.75"/><bottomPen lineWidth="0.75"/><rightPen lineWidth="0.75"/></box>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="11" isBold="true"/></textElement>
+				<text><![CDATA[Filters Used]]></text>
+			</staticText>
+			<textField isStretchWithOverflow="true">
+				<reportElement x="240" y="0" width="1325" height="20" stretchType="RelativeToBandHeight" uuid="11111111-2222-3333-4444-555555555552"/>
+				<box><topPen lineWidth="0.75"/><leftPen lineWidth="0.75"/><bottomPen lineWidth="0.75"/><rightPen lineWidth="0.75"/></box>
+				<textElement verticalAlignment="Middle"><font size="10"/></textElement>
+				<textFieldExpression><![CDATA[$P{filterSummary} == null || $P{filterSummary}.trim().isEmpty() ? "All" : $P{filterSummary}]]></textFieldExpression>
+			</textField>
+		</band>
+	</pageHeader>
+
+	<columnHeader>
+		<band height="20">
+			<staticText>
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" mode="Opaque" x="0" y="0" width="60" height="20" backcolor="#ADACAC" uuid="dbc8da2f-edcf-4920-a64a-ce46bf7a4ead">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showTicketId})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<topPen lineWidth="0.75"/>
+					<leftPen lineWidth="0.75"/>
+					<bottomPen lineWidth="0.75"/>
+					<rightPen lineWidth="0.75"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Ticket ID]]></text>
+			</staticText>
+			<staticText>
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" mode="Opaque" x="60" y="0" width="80" height="20" backcolor="#ADACAC" uuid="f6b8f967-4c20-4440-b91d-6cff2ad78e5f">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showRequestor})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<topPen lineWidth="0.75"/>
+					<leftPen lineWidth="0.75"/>
+					<bottomPen lineWidth="0.75"/>
+					<rightPen lineWidth="0.75"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Requestor]]></text>
+			</staticText>
+			<staticText>
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" mode="Opaque" x="140" y="0" width="90" height="20" backcolor="#ADACAC" uuid="fe6758ca-a6f8-41d4-9ba2-d4b38325d552">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showCreatedDate})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<topPen lineWidth="0.75"/>
+					<leftPen lineWidth="0.75"/>
+					<bottomPen lineWidth="0.75"/>
+					<rightPen lineWidth="0.75"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Created Date]]></text>
+			</staticText>
+			<staticText>
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" mode="Opaque" x="230" y="0" width="80" height="20" backcolor="#ADACAC" uuid="68279be0-cc95-42ba-92dc-1322a1086382">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showModule})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<topPen lineWidth="0.75"/>
+					<leftPen lineWidth="0.75"/>
+					<bottomPen lineWidth="0.75"/>
+					<rightPen lineWidth="0.75"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Module]]></text>
+			</staticText>
+			<staticText>
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" mode="Opaque" x="310" y="0" width="100" height="20" backcolor="#ADACAC" uuid="9f96db6b-13f0-4383-b476-ebc9262deb52">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showSubModule})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<topPen lineWidth="0.75"/>
+					<leftPen lineWidth="0.75"/>
+					<bottomPen lineWidth="0.75"/>
+					<rightPen lineWidth="0.75"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Sub Module]]></text>
+			</staticText>
+
+			<staticText>
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" mode="Opaque" x="410" y="0" width="250" height="20" backcolor="#ADACAC" uuid="d3fcbede-7ff0-4290-8f7c-3e9a8e6e7d1a">
+				</reportElement>
+				<box>
+					<topPen lineWidth="0.75"/>
+					<leftPen lineWidth="0.75"/>
+					<bottomPen lineWidth="0.75"/>
+					<rightPen lineWidth="0.75"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Subject]]></text>
+			</staticText>
+			<staticText>
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" mode="Opaque" x="660" y="0" width="350" height="20" backcolor="#ADACAC" uuid="be34dc13-d1e4-4923-ae57-2f0f6d688b3f">
+				</reportElement>
+				<box>
+					<topPen lineWidth="0.75"/>
+					<leftPen lineWidth="0.75"/>
+					<bottomPen lineWidth="0.75"/>
+					<rightPen lineWidth="0.75"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Description]]></text>
+			</staticText>
+			<staticText>
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" mode="Opaque" x="1010" y="0" width="100" height="20" backcolor="#ADACAC" uuid="dafa238f-05ee-44d0-82be-504d2c323475">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showIssueType})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<topPen lineWidth="0.75"/>
+					<leftPen lineWidth="0.75"/>
+					<bottomPen lineWidth="0.75"/>
+					<rightPen lineWidth="0.75"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Issue Type]]></text>
+			</staticText>
+			<staticText>
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" mode="Opaque" x="1110" y="0" width="45" height="20" backcolor="#ADACAC" uuid="e21a4872-6783-4ce3-8505-1c82d57e8ccc">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showZone})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<topPen lineWidth="0.75"/>
+					<leftPen lineWidth="0.75"/>
+					<bottomPen lineWidth="0.75"/>
+					<rightPen lineWidth="0.75"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Zone]]></text>
+			</staticText>
+			<staticText>
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" mode="Opaque" x="1155" y="0" width="80" height="20" backcolor="#ADACAC" uuid="58af303d-d3e7-4a38-9f57-235a847aec1d">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showDistrict})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<topPen lineWidth="0.75"/>
+					<leftPen lineWidth="0.75"/>
+					<bottomPen lineWidth="0.75"/>
+					<rightPen lineWidth="0.75"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12" isBold="true"/>
+				</textElement>
+				<text><![CDATA[District]]></text>
+			</staticText>
+			<staticText>
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" mode="Opaque" x="1235" y="0" width="70" height="20" backcolor="#ADACAC" uuid="a59fa280-2683-43ef-8832-b60f2bea4e47">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showRegion})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<topPen lineWidth="0.75"/>
+					<leftPen lineWidth="0.75"/>
+					<bottomPen lineWidth="0.75"/>
+					<rightPen lineWidth="0.75"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Region]]></text>
+			</staticText>
+			<staticText>
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" mode="Opaque" x="1305" y="0" width="60" height="20" backcolor="#ADACAC" uuid="f58f6ee9-a144-4362-b012-639570bc6db8">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showSeverity})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<topPen lineWidth="0.75"/>
+					<leftPen lineWidth="0.75"/>
+					<bottomPen lineWidth="0.75"/>
+					<rightPen lineWidth="0.75"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Severity]]></text>
+			</staticText>
+			<staticText>
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" mode="Opaque" x="1365" y="0" width="60" height="20" backcolor="#ADACAC" uuid="b8f9dfb4-2dd4-451c-ae21-8689bc48a155">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showPriority})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<topPen lineWidth="0.75"/>
+					<leftPen lineWidth="0.75"/>
+					<bottomPen lineWidth="0.75"/>
+					<rightPen lineWidth="0.75"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Priority]]></text>
+			</staticText>
+			<staticText>
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" mode="Opaque" x="1425" y="0" width="80" height="20" backcolor="#ADACAC" uuid="1c1d0fd7-2b2d-43fb-9f1b-967dbfef7e07">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showAssigneeName})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<topPen lineWidth="0.75"/>
+					<leftPen lineWidth="0.75"/>
+					<bottomPen lineWidth="0.75"/>
+					<rightPen lineWidth="0.75"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Assignee]]></text>
+			</staticText>
+			<staticText>
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" mode="Opaque" x="1505" y="0" width="60" height="20" backcolor="#ADACAC" uuid="9d48cb1c-4209-4b1a-ba15-dac8745ba9d8">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showStatus})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<topPen lineWidth="0.75"/>
+					<leftPen lineWidth="0.75"/>
+					<bottomPen lineWidth="0.75"/>
+					<rightPen lineWidth="0.75"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12" isBold="true"/>
+				</textElement>
+				<text><![CDATA[Status]]></text>
+			</staticText>
+		</band>
+	</columnHeader>
+	<detail>
+		<band height="20" splitType="Stretch">
+			<textField isStretchWithOverflow="true">
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" x="0" y="0" width="60" height="20" uuid="9ce0cd5a-62fd-40fe-9b40-1f0c05fb7417">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showTicketId})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{id}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true">
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" x="60" y="0" width="80" height="20" uuid="c2e8c58b-f40b-4581-b5f9-fcae3526f267">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showRequestor})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{requestorName}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true">
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" x="140" y="0" width="90" height="20" uuid="10e754e7-ff36-4786-b5ff-d376d5463a93">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showCreatedDate})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{reportedDate}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true">
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" x="230" y="0" width="80" height="20" uuid="95d5a1b4-6cd4-4a5b-a400-f54264f3becd">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showModule})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{category}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true">
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" x="310" y="0" width="100" height="20" uuid="6d957fe1-b96c-469d-9c51-c5b9ff3b3750">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showSubModule})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{subCategory}]]></textFieldExpression>
+			</textField>
+
+			<textField isStretchWithOverflow="true">
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" x="410" y="0" width="250" height="20" uuid="b4c2d9b1-8fbe-4f55-9b3f-34e3c79a4ebd">
+				</reportElement>
+				<box><pen lineWidth="0.25"/><topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/><leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/><bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/><rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/></box>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
+				<textFieldExpression><![CDATA[$F{subject}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true">
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" x="660" y="0" width="350" height="20" uuid="d6f2f4da-6360-4f4b-9834-4adcc1a44519">
+				</reportElement>
+				<box><pen lineWidth="0.25"/><topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/><leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/><bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/><rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/></box>
+				<textElement textAlignment="Center" verticalAlignment="Middle"><font size="12"/></textElement>
+				<textFieldExpression><![CDATA[$F{description}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true">
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" x="1010" y="0" width="100" height="20" isPrintWhenDetailOverflows="true" uuid="3f97e524-57b0-4953-aa54-203ddc55ffd5">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showIssueType})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{issueTypeLabel}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true">
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" x="1110" y="0" width="45" height="20" uuid="60ade26f-36bd-4e3c-9571-82ccab1882b3">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showZone})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{zoneCode}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true">
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" x="1155" y="0" width="80" height="20" uuid="da2a8f0e-5158-4da1-9f16-fc29c24e131b">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showDistrict})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{districtName}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true">
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" x="1235" y="0" width="70" height="20" uuid="335a8af3-7ce7-4943-ac96-8f2aa81e3bbf">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showRegion})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{regionName}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true">
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" x="1305" y="0" width="60" height="20" uuid="c2a5678d-52cf-4500-a5c7-5e5ef428b00d">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showSeverity})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{severity}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true">
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" x="1365" y="0" width="60" height="20" uuid="4dc906c6-5eb7-410c-812e-6fae98f536ed">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showPriority})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{priority}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true">
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" x="1425" y="0" width="80" height="20" uuid="bf46047b-98ce-45a3-9560-4e35d2710240">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showAssigneeName})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{assignedToName}]]></textFieldExpression>
+			</textField>
+			<textField isStretchWithOverflow="true">
+				
+<reportElement  positionType="Float"
+    stretchType="RelativeToTallestObject" x="1505" y="0" width="60" height="20" uuid="642dd5d1-4f29-4f83-b7f6-6e9d555ae2e0">
+					<printWhenExpression><![CDATA[Boolean.TRUE.equals($P{showStatus})]]></printWhenExpression>
+				</reportElement>
+				<box>
+					<pen lineWidth="0.25"/>
+					<topPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<leftPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<bottomPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+					<rightPen lineWidth="1.0" lineStyle="Solid" lineColor="#000000"/>
+				</box>
+				<textElement textAlignment="Center" verticalAlignment="Middle">
+					<font size="12"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{statusLabel}]]></textFieldExpression>
+			</textField>
+		</band>
+	</detail>
+</jasperReport>


### PR DESCRIPTION
### Motivation
- Persist a structured JSON representation of report filters and surface a human-readable filter summary for generated reports.
- Improve report output by embedding filter context into the ticket report template so consumers can see which filters were applied.

### Description
- Injects an `ObjectMapper` into `AsyncReportService` and sets `filtersJson` on `ReportRequestHistory` via a new `toFiltersJson` helper. 
- Adds `buildFilterSummary`, `isAllValue`, `formatValue`, `inferType`, and `toLabel` helpers to construct a readable summary and typed filter payload, and passes `filterSummary` into report generation params. 
- Updates imports and constructor to accept the new dependency and wires the serialization during `queueTicketExport` and `processRequest` flows. 
- Adds a new JasperReports template `ticket_rpt_phase1-1.jrxml` under `api/src/main/resources/reports` which accepts `filterSummary` and multiple display toggles and uses the summary in the report header.

### Testing
- Ran the project's automated test suite with `mvn test` and validated the build with `mvn package`, both completed successfully. 
- Exercised async report generation in CI-like build to ensure serialization does not break existing flows and reports compile using the new JRXML template.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0de5882f008332b5631706aefc9f7e)