### PR TITLE
Fix Excel export hiding optional columns by defaulting visibility flags

### DIFF
--- a/api/src/main/java/com/ticketingSystem/reportGenerator/generators/excel/JasperExcelReportGenerator.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/generators/excel/JasperExcelReportGenerator.java
@@ -16,6 +16,8 @@ import org.springframework.stereotype.Component;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
 
 @Component("jasperExcel")
 public class JasperExcelReportGenerator implements ReportGenerator {
@@ -23,9 +25,10 @@ public class JasperExcelReportGenerator implements ReportGenerator {
     public byte[] generateReport(ReportContext context) throws Exception {
         ClassPathResource resource = new ClassPathResource(context.getTemplateLocation());
         try (InputStream jrxml = resource.getInputStream(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            Map<String, Object> params = withDefaultColumnVisibility(context.getParams());
             JasperReport jasperReport = JasperCompileManager.compileReport(jrxml);
             JRBeanCollectionDataSource datasource = new JRBeanCollectionDataSource(context.getRows());
-            JasperPrint jasperPrint = JasperFillManager.fillReport(jasperReport, context.getParams(), datasource);
+            JasperPrint jasperPrint = JasperFillManager.fillReport(jasperReport, params, datasource);
 
             JRXlsxExporter exporter = new JRXlsxExporter();
             exporter.setExporterInput(new SimpleExporterInput(jasperPrint));
@@ -38,5 +41,24 @@ public class JasperExcelReportGenerator implements ReportGenerator {
             exporter.exportReport();
             return out.toByteArray();
         }
+    }
+
+    private Map<String, Object> withDefaultColumnVisibility(Map<String, Object> incomingParams) {
+        Map<String, Object> params = new HashMap<>();
+        if (incomingParams != null) {
+            params.putAll(incomingParams);
+        }
+
+        String[] visibilityParams = {
+                "showTicketId", "showRequestor", "showCreatedDate", "showModule", "showSubModule",
+                "showIssueType", "showZone", "showDistrict", "showRegion", "showSeverity",
+                "showPriority", "showAssigneeName", "showStatus"
+        };
+
+        for (String key : visibilityParams) {
+            params.putIfAbsent(key, Boolean.TRUE);
+        }
+
+        return params;
     }
 }


### PR DESCRIPTION
### Motivation
- Excel exports were hiding columns controlled by `<printWhenExpression>` because `context.getParams()` could be null/omit `show*` flags, making expressions like `Boolean.TRUE.equals($P{showIssueType})` evaluate to false.
- The PDF generator already defaults these visibility flags; Excel should mirror that behavior so optional columns are visible by default when the client does not provide those parameters.

### Description
- Added a `withDefaultColumnVisibility(Map<String,Object>)` helper to `api/src/main/java/com/ticketingSystem/reportGenerator/generators/excel/JasperExcelReportGenerator.java` that injects default `Boolean.TRUE` values for the visibility params `showTicketId`, `showRequestor`, `showCreatedDate`, `showModule`, `showSubModule`, `showIssueType`, `showZone`, `showDistrict`, `showRegion`, `showSeverity`, `showPriority`, `showAssigneeName`, and `showStatus` when absent.
- The generator now calls `withDefaultColumnVisibility(context.getParams())` and passes the resulting `params` to `JasperFillManager.fillReport(...)` instead of passing `context.getParams()` directly.
- Added `HashMap`/`Map` imports required for the new helper method.

### Testing
- Ran `cd api && mvn -q -DskipTests compile`, which failed because there is no `pom.xml` in the `api` directory (module is Gradle-based), so the Maven check could not run.
- Ran `cd api && ./gradlew -q compileJava`, which failed due to environment/JDK incompatibility (`Unsupported class file major version 69`), so Java compilation could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ff9f2ad948332b65366c22d285180)