### PR TITLE
Support SQL-driven JRXML report generation in async exports

### DIFF
--- a/api/src/main/java/com/ticketingSystem/reportGenerator/generators/excel/JasperExcelReportGenerator.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/generators/excel/JasperExcelReportGenerator.java
@@ -11,21 +11,36 @@ import net.sf.jasperreports.export.SimpleXlsxReportConfiguration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 
+import javax.sql.DataSource;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.sql.Connection;
 import java.util.HashMap;
 import java.util.Map;
 
 @Component("jasperExcel")
 public class JasperExcelReportGenerator implements ReportGenerator {
+
+    private final DataSource dataSource;
+
+    public JasperExcelReportGenerator(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
     @Override
     public byte[] generateReport(ReportContext context) throws Exception {
         ClassPathResource resource = new ClassPathResource(context.getTemplateLocation());
         try (InputStream jrxml = resource.getInputStream(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             Map<String, Object> params = withDefaultColumnVisibility(context.getParams());
             JasperReport jasperReport = JasperCompileManager.compileReport(jrxml);
-            JRBeanCollectionDataSource datasource = new JRBeanCollectionDataSource(context.getRows());
-            JasperPrint jasperPrint = JasperFillManager.fillReport(jasperReport, params, datasource);
+            JasperPrint jasperPrint;
+            if (Boolean.TRUE.equals(params.get("USE_TEMPLATE_SQL"))) {
+                try (Connection connection = dataSource.getConnection()) {
+                    jasperPrint = JasperFillManager.fillReport(jasperReport, params, connection);
+                }
+            } else {
+                JRBeanCollectionDataSource datasource = new JRBeanCollectionDataSource(context.getRows());
+                jasperPrint = JasperFillManager.fillReport(jasperReport, params, datasource);
+            }
 
             JRXlsxExporter exporter = new JRXlsxExporter();
             exporter.setExporterInput(new SimpleExporterInput(jasperPrint));

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/generators/pdf/JasperPdfReportGenerator.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/generators/pdf/JasperPdfReportGenerator.java
@@ -19,14 +19,22 @@ import net.sf.jasperreports.engine.data.JRBeanCollectionDataSource;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 
+import javax.sql.DataSource;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
+import java.sql.Connection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 @Component("jasperPdf")
 public class JasperPdfReportGenerator implements ReportGenerator {
+
+    private final DataSource dataSource;
+
+    public JasperPdfReportGenerator(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
 
     /**
      * Phase-2 placeholder for fully dynamic report construction.
@@ -91,8 +99,15 @@ public class JasperPdfReportGenerator implements ReportGenerator {
         try (InputStream jrxml = resource.getInputStream()) {
             Map<String, Object> params = withDefaultColumnVisibility(context.getParams());
             JasperReport jasperReport = JasperCompileManager.compileReport(jrxml);
-            JRBeanCollectionDataSource datasource = new JRBeanCollectionDataSource(context.getRows());
-            JasperPrint jasperPrint = JasperFillManager.fillReport(jasperReport, params, datasource);
+            JasperPrint jasperPrint;
+            if (Boolean.TRUE.equals(params.get("USE_TEMPLATE_SQL"))) {
+                try (Connection connection = dataSource.getConnection()) {
+                    jasperPrint = JasperFillManager.fillReport(jasperReport, params, connection);
+                }
+            } else {
+                JRBeanCollectionDataSource datasource = new JRBeanCollectionDataSource(context.getRows());
+                jasperPrint = JasperFillManager.fillReport(jasperReport, params, datasource);
+            }
             return JasperExportManager.exportReportToPdf(jasperPrint);
         } catch (FileNotFoundException ex) {
             throw new FileNotFoundException("File not found or is not accessible. Root cause: " + ex.getMessage());

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/service/AsyncReportService.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/service/AsyncReportService.java
@@ -19,12 +19,15 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Service;
 
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.stream.Collectors;
 
@@ -120,8 +123,8 @@ public class AsyncReportService {
             Map<String, Object> params = new HashMap<>();
             params.put("USE_TEMPLATE_SQL", "template_sql".equalsIgnoreCase(reportMaster.getSourceType()));
             params.put("generatedOn", LocalDateTime.now().toString());
-            params.put("fromDate", filters.get("fromDate"));
-            params.put("toDate", filters.get("toDate"));
+            params.put("fromDate", toJasperDate(filters.get("fromDate")));
+            params.put("toDate", toJasperDate(filters.get("toDate")));
             params.put("fromDateLabel", formatValue(filters.get("fromDate")));
             params.put("toDateLabel", formatValue(filters.get("toDate")));
             params.put("zoneCodeLabel", formatValue(filters.get("zoneCode")));
@@ -166,6 +169,34 @@ public class AsyncReportService {
             request.setFailedAt(LocalDateTime.now());
             request.setErrorMessage(e.getMessage());
             reportRequestHistoryRepository.save(request);
+        }
+    }
+
+
+    private Date toJasperDate(Object rawValue) {
+        if (rawValue == null) return null;
+        if (rawValue instanceof Date dateValue) return dateValue;
+
+        String text = String.valueOf(rawValue).trim();
+        if (text.isEmpty()) return null;
+
+        try {
+            return java.sql.Date.valueOf(LocalDate.parse(text));
+        } catch (DateTimeParseException ignored) {
+            // Try datetime parse fallback below.
+        }
+
+        try {
+            return Timestamp.valueOf(LocalDateTime.parse(text));
+        } catch (DateTimeParseException ignored) {
+            // Try ISO instant parse fallback below.
+        }
+
+        try {
+            return Date.from(java.time.Instant.parse(text));
+        } catch (DateTimeParseException ignored) {
+            log.warn("Unable to parse date filter '{}' into java.util.Date; passing null to Jasper parameter.", text);
+            return null;
         }
     }
 

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/service/AsyncReportService.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/service/AsyncReportService.java
@@ -19,15 +19,12 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Service;
 
-import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.stream.Collectors;
 
@@ -123,8 +120,8 @@ public class AsyncReportService {
             Map<String, Object> params = new HashMap<>();
             params.put("USE_TEMPLATE_SQL", "template_sql".equalsIgnoreCase(reportMaster.getSourceType()));
             params.put("generatedOn", LocalDateTime.now().toString());
-            params.put("fromDate", toJasperDate(filters.get("fromDate")));
-            params.put("toDate", toJasperDate(filters.get("toDate")));
+            params.put("fromDate", filters.get("fromDate"));
+            params.put("toDate", filters.get("toDate"));
             params.put("fromDateLabel", formatValue(filters.get("fromDate")));
             params.put("toDateLabel", formatValue(filters.get("toDate")));
             params.put("zoneCodeLabel", formatValue(filters.get("zoneCode")));
@@ -173,32 +170,6 @@ public class AsyncReportService {
     }
 
 
-    private Date toJasperDate(Object rawValue) {
-        if (rawValue == null) return null;
-        if (rawValue instanceof Date dateValue) return dateValue;
-
-        String text = String.valueOf(rawValue).trim();
-        if (text.isEmpty()) return null;
-
-        try {
-            return java.sql.Date.valueOf(LocalDate.parse(text));
-        } catch (DateTimeParseException ignored) {
-            // Try datetime parse fallback below.
-        }
-
-        try {
-            return Timestamp.valueOf(LocalDateTime.parse(text));
-        } catch (DateTimeParseException ignored) {
-            // Try ISO instant parse fallback below.
-        }
-
-        try {
-            return Date.from(java.time.Instant.parse(text));
-        } catch (DateTimeParseException ignored) {
-            log.warn("Unable to parse date filter '{}' into java.util.Date; passing null to Jasper parameter.", text);
-            return null;
-        }
-    }
 
     private String toFiltersJson(Map<String, Object> filters) {
         Map<String, Object> payload = new LinkedHashMap<>();

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/service/AsyncReportService.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/service/AsyncReportService.java
@@ -114,7 +114,11 @@ public class AsyncReportService {
                     (String) filters.get("toDate")
             );
 
+            ReportMaster reportMaster = reportMasterRepository.findByReportCodeAndActiveTrue(reportCode)
+                    .orElseThrow(() -> new IllegalArgumentException("Report definition not found for code: " + reportCode));
+
             Map<String, Object> params = new HashMap<>();
+            params.put("USE_TEMPLATE_SQL", "template_sql".equalsIgnoreCase(reportMaster.getSourceType()));
             params.put("generatedOn", LocalDateTime.now().toString());
             params.put("fromDate", filters.get("fromDate"));
             params.put("toDate", filters.get("toDate"));

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/service/AsyncReportService.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/service/AsyncReportService.java
@@ -120,17 +120,17 @@ public class AsyncReportService {
             Map<String, Object> params = new HashMap<>();
             params.put("USE_TEMPLATE_SQL", "template_sql".equalsIgnoreCase(reportMaster.getSourceType()));
             params.put("generatedOn", LocalDateTime.now().toString());
-            params.put("fromDate", filters.get("fromDate"));
-            params.put("toDate", filters.get("toDate"));
+            params.put("fromDate", toNullableParam(filters.get("fromDate")));
+            params.put("toDate", toNullableParam(filters.get("toDate")));
             params.put("fromDateLabel", formatValue(filters.get("fromDate")));
             params.put("toDateLabel", formatValue(filters.get("toDate")));
             params.put("zoneCodeLabel", formatValue(filters.get("zoneCode")));
             params.put("regionCodeLabel", formatValue(filters.get("regionCode")));
             params.put("districtCodeLabel", formatValue(filters.get("districtCode")));
             params.put("issueTypeLabelFilter", formatValue(filters.get("issueTypeId")));
-            params.put("statusId", formatValue(filters.get("statusId")));
-            params.put("priorityId", formatValue(filters.get("priority")));
-            params.put("severityId", formatValue(filters.get("severity")));
+            params.put("statusId", toNullableParam(filters.get("statusId")));
+            params.put("priorityId", toNullableParam(firstNonEmpty(filters.get("priorityId"), filters.get("priority"))));
+            params.put("severityId", toNullableParam(firstNonEmpty(filters.get("severityId"), filters.get("severity"))));
             params.put("assignedToName", formatValue(filters.get("assignedTo")));
             params.put("assignedBackFromFci", formatValue(filters.get("assignedBackFromFci")));
             params.put("assignedBy", formatValue(filters.get("assignedBy")));
@@ -141,6 +141,10 @@ public class AsyncReportService {
             params.put("division", formatValue(filters.get("divisionId")));
             params.put("categoryLabel", formatValue(filters.get("category")));
             params.put("filterSummary", buildFilterSummary(filters));
+            params.put("zoneCode", toNullableParam(filters.get("zoneCode")));
+            params.put("regionCode", toNullableParam(filters.get("regionCode")));
+            params.put("districtCode", toNullableParam(filters.get("districtCode")));
+            params.put("issueTypeId", toNullableParam(filters.get("issueTypeId")));
 
             byte[] file = reportDownloadService.generate(reportCode, format, results, params);
             String ext = format == ReportFormat.PDF ? "pdf" : "xlsx";
@@ -170,6 +174,23 @@ public class AsyncReportService {
     }
 
 
+
+    private Object toNullableParam(Object value) {
+        if (value == null) return null;
+        if (value instanceof String str) {
+            String trimmed = str.trim();
+            return trimmed.isEmpty() ? null : trimmed;
+        }
+        if (value instanceof List<?> list) {
+            return list.isEmpty() ? null : value;
+        }
+        return value;
+    }
+
+    private Object firstNonEmpty(Object preferred, Object fallback) {
+        Object first = toNullableParam(preferred);
+        return first != null ? first : toNullableParam(fallback);
+    }
 
     private String toFiltersJson(Map<String, Object> filters) {
         Map<String, Object> payload = new LinkedHashMap<>();

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/service/ReportDownloadService.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/service/ReportDownloadService.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +35,17 @@ public class ReportDownloadService {
         effectiveParams.putIfAbsent("REPORT_CODE", reportCode);
 
         ReportContext context = new ReportContext(rows, effectiveParams, reportMaster.getTemplateLocation());
-        return reportGeneratorProvider.getGenerator(format).generateReport(context);
+        try {
+            return reportGeneratorProvider.getGenerator(format).generateReport(context);
+        } catch (InvocationTargetException ex) {
+            Throwable rootCause = ex.getTargetException() != null ? ex.getTargetException() : ex;
+            throw new IllegalStateException("Report generation failed for code '" + reportCode
+                    + "' using template '" + reportMaster.getTemplateLocation() + "'. Root cause: "
+                    + rootCause.getClass().getSimpleName() + ": " + rootCause.getMessage(), rootCause);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Report generation failed for code '" + reportCode
+                    + "' using template '" + reportMaster.getTemplateLocation() + "'. Root cause: "
+                    + ex.getClass().getSimpleName() + ": " + ex.getMessage(), ex);
+        }
     }
 }

--- a/api/src/main/resources/reports/tickets_rpt_simple.jrxml
+++ b/api/src/main/resources/reports/tickets_rpt_simple.jrxml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="Ticket_Report_Simple" pageWidth="1200" pageHeight="595" orientation="Landscape" columnWidth="1160" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="c8f97d26-4a51-44ff-8ddd-2e31fd4f9847">
+    <property name="com.jaspersoft.studio.data.defaultdataadapter" value="annadarpan_ticket_db"/>
+
+    <parameter name="fromDate" class="java.util.Date"/>
+    <parameter name="toDate" class="java.util.Date"/>
+    <parameter name="zoneCode" class="java.lang.String"/>
+    <parameter name="regionCode" class="java.lang.String"/>
+    <parameter name="districtCode" class="java.lang.String"/>
+    <parameter name="issueTypeId" class="java.lang.String"/>
+    <parameter name="statusId" class="java.lang.String"/>
+    <parameter name="priorityId" class="java.lang.String"/>
+    <parameter name="severityId" class="java.lang.String"/>
+    <parameter name="assignedToName" class="java.lang.String"/>
+    <parameter name="generatedOn" class="java.lang.String"/>
+
+    <queryString>
+        <![CDATA[
+SELECT
+    t.ticket_id AS id,
+    COALESCE(NULLIF(t.requestor_name, ''), '-') AS requestorName,
+    t.reported_date AS reportedDate,
+    COALESCE(NULLIF(c.category, ''), NULLIF(t.category, ''), '-') AS category,
+    COALESCE(NULLIF(sc.sub_category, ''), NULLIF(t.sub_category, ''), '-') AS subCategory,
+    COALESCE(NULLIF(it.name, ''), NULLIF(t.issue_type_id, ''), '-') AS issueTypeLabel,
+    COALESCE(NULLIF(zm.zone_name, ''), NULLIF(t.zone_code, ''), '-') AS zoneCode,
+    COALESCE(NULLIF(t.district_name, ''), NULLIF(dm.district_name, ''), '-') AS districtName,
+    COALESCE(NULLIF(t.region_name, ''), NULLIF(rm.region_name, ''), '-') AS regionName,
+    COALESCE(NULLIF(t.severity, ''), '-') AS severity,
+    COALESCE(CAST(pm.tp_id AS CHAR), NULLIF(t.priority, ''), '-') AS priority,
+    COALESCE(NULLIF(au.name, ''), NULLIF(t.assigned_to, ''), '-') AS assignedToName,
+    COALESCE(NULLIF(sm.label, ''), NULLIF(sm.status_name, ''), NULLIF(t.status, ''), '-') AS statusLabel
+FROM tickets t
+LEFT JOIN categories c ON c.category_id = t.category
+LEFT JOIN sub_categories sc ON sc.sub_category_id = t.sub_category
+LEFT JOIN issue_type_master it ON it.issue_type_id = t.issue_type_id
+LEFT JOIN zone_master zm ON zm.zone_code = t.zone_code
+LEFT JOIN region_master rm ON rm.region_code = t.region_code
+LEFT JOIN district_master dm ON dm.district_code = t.district_code
+LEFT JOIN priority_master pm ON pm.tp_id = t.priority
+LEFT JOIN users au ON au.username = t.assigned_to
+LEFT JOIN status_master sm ON sm.status_id = t.status_id
+ORDER BY t.ticket_id
+        ]]>
+    </queryString>
+
+    <field name="id" class="java.lang.String"/>
+    <field name="requestorName" class="java.lang.String"/>
+    <field name="reportedDate" class="java.sql.Timestamp"/>
+    <field name="category" class="java.lang.String"/>
+    <field name="subCategory" class="java.lang.String"/>
+    <field name="issueTypeLabel" class="java.lang.String"/>
+    <field name="zoneCode" class="java.lang.String"/>
+    <field name="districtName" class="java.lang.String"/>
+    <field name="regionName" class="java.lang.String"/>
+    <field name="severity" class="java.lang.String"/>
+    <field name="priority" class="java.lang.String"/>
+    <field name="assignedToName" class="java.lang.String"/>
+    <field name="statusLabel" class="java.lang.String"/>
+
+    <title>
+        <band height="30">
+            <staticText>
+                <reportElement x="0" y="0" width="1160" height="30" uuid="6fb9296f-7dac-4460-8931-653c5d136369"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle">
+                    <font size="16" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Ticket Report (Simple - No Filters)]]></text>
+            </staticText>
+        </band>
+    </title>
+
+    <columnHeader>
+        <band height="20">
+            <staticText><reportElement x="0" y="0" width="80" height="20" uuid="7ee464d1-a0d2-4867-819a-3fca4bdb91a0"/><text><![CDATA[Ticket ID]]></text></staticText>
+            <staticText><reportElement x="80" y="0" width="120" height="20" uuid="7f1c5d6d-eb27-4d71-8bf6-538f9780f95a"/><text><![CDATA[Requestor]]></text></staticText>
+            <staticText><reportElement x="200" y="0" width="140" height="20" uuid="3a64100b-ab00-4962-ad0f-f2735ff8a2a0"/><text><![CDATA[Reported Date]]></text></staticText>
+            <staticText><reportElement x="340" y="0" width="100" height="20" uuid="f551264f-0ac2-4f73-ad03-2b1ea3247a1e"/><text><![CDATA[Category]]></text></staticText>
+            <staticText><reportElement x="440" y="0" width="100" height="20" uuid="2e88cc91-6f74-46a4-ac58-931748f4746f"/><text><![CDATA[SubCategory]]></text></staticText>
+            <staticText><reportElement x="540" y="0" width="100" height="20" uuid="3ccca767-df77-4a43-a291-26502291d96a"/><text><![CDATA[Issue Type]]></text></staticText>
+            <staticText><reportElement x="640" y="0" width="90" height="20" uuid="b31198f1-a7de-437e-9378-2e4b87fe7e90"/><text><![CDATA[Zone]]></text></staticText>
+            <staticText><reportElement x="730" y="0" width="90" height="20" uuid="8b20a734-1eef-4d35-9f81-9b0d5d701a99"/><text><![CDATA[District]]></text></staticText>
+            <staticText><reportElement x="820" y="0" width="90" height="20" uuid="2f3826ca-a5f6-4788-8fef-64f1b13b45da"/><text><![CDATA[Region]]></text></staticText>
+            <staticText><reportElement x="910" y="0" width="60" height="20" uuid="7cfe7e6c-954c-4f80-962f-8d1f80cb31bf"/><text><![CDATA[Severity]]></text></staticText>
+            <staticText><reportElement x="970" y="0" width="60" height="20" uuid="4bf9ad1c-b74f-47b8-8403-b39984a7ef4d"/><text><![CDATA[Priority]]></text></staticText>
+            <staticText><reportElement x="1030" y="0" width="70" height="20" uuid="ea3a9738-d59d-4d75-89de-9d84df1787eb"/><text><![CDATA[Assignee]]></text></staticText>
+            <staticText><reportElement x="1100" y="0" width="60" height="20" uuid="062cb96b-5937-4950-a10c-00bc988de82f"/><text><![CDATA[Status]]></text></staticText>
+        </band>
+    </columnHeader>
+
+    <detail>
+        <band height="20">
+            <textField><reportElement x="0" y="0" width="80" height="20" uuid="fb2feddb-a5b2-4729-93e4-5b0a927d9f3b"/><textFieldExpression><![CDATA[$F{id}]]></textFieldExpression></textField>
+            <textField><reportElement x="80" y="0" width="120" height="20" uuid="7785b2d4-06ab-4a20-a4ef-c9f80cb220a9"/><textFieldExpression><![CDATA[$F{requestorName}]]></textFieldExpression></textField>
+            <textField><reportElement x="200" y="0" width="140" height="20" uuid="adf2f781-67ee-4718-b345-57f39826655b"/><textFieldExpression><![CDATA[$F{reportedDate}]]></textFieldExpression></textField>
+            <textField><reportElement x="340" y="0" width="100" height="20" uuid="24c30d80-c90a-4b34-a75f-6a4a1bb88ba8"/><textFieldExpression><![CDATA[$F{category}]]></textFieldExpression></textField>
+            <textField><reportElement x="440" y="0" width="100" height="20" uuid="c4c30dab-31f6-4c3b-bfc7-43143f9d7ea9"/><textFieldExpression><![CDATA[$F{subCategory}]]></textFieldExpression></textField>
+            <textField><reportElement x="540" y="0" width="100" height="20" uuid="fbadf2f7-e07c-4e9c-b439-98153471c50e"/><textFieldExpression><![CDATA[$F{issueTypeLabel}]]></textFieldExpression></textField>
+            <textField><reportElement x="640" y="0" width="90" height="20" uuid="bf64e2b2-c518-4064-9f87-1110dd176663"/><textFieldExpression><![CDATA[$F{zoneCode}]]></textFieldExpression></textField>
+            <textField><reportElement x="730" y="0" width="90" height="20" uuid="43d2119c-610d-450b-8309-ba4ad418b4e8"/><textFieldExpression><![CDATA[$F{districtName}]]></textFieldExpression></textField>
+            <textField><reportElement x="820" y="0" width="90" height="20" uuid="5f46ecc8-c91c-4bdd-af8a-04ce6de8fcab"/><textFieldExpression><![CDATA[$F{regionName}]]></textFieldExpression></textField>
+            <textField><reportElement x="910" y="0" width="60" height="20" uuid="68053016-0749-4964-b4fc-9f2f6f4da434"/><textFieldExpression><![CDATA[$F{severity}]]></textFieldExpression></textField>
+            <textField><reportElement x="970" y="0" width="60" height="20" uuid="1c0807cc-4dc8-4339-a4ef-5af7ff8f05ec"/><textFieldExpression><![CDATA[$F{priority}]]></textFieldExpression></textField>
+            <textField><reportElement x="1030" y="0" width="70" height="20" uuid="a130e784-e166-46e5-a59c-c9fbe5c5a604"/><textFieldExpression><![CDATA[$F{assignedToName}]]></textFieldExpression></textField>
+            <textField><reportElement x="1100" y="0" width="60" height="20" uuid="1fd4f461-faed-4ba3-a727-aad59dffef42"/><textFieldExpression><![CDATA[$F{statusLabel}]]></textFieldExpression></textField>
+        </band>
+    </detail>
+</jasperReport>


### PR DESCRIPTION
### Motivation
- Some JRXML templates include embedded SQL and need the Jasper engine to obtain rows itself instead of receiving an explicit bean collection, which the async exporter previously always passed.
- Allow selected reports to use the JRXML SQL while preserving existing bean-datasource behaviour for current reports.

### Description
- Added `DataSource` injection to `JasperPdfReportGenerator` and `JasperExcelReportGenerator` and introduced conditional filling that uses a JDBC `Connection` when `USE_TEMPLATE_SQL=true` and falls back to `JRBeanCollectionDataSource` otherwise.
- Updated `AsyncReportService` to load the `ReportMaster` and set `params.put("USE_TEMPLATE_SQL", true)` when `report_master.source_type` equals `template_sql` so template-driven SQL is enabled automatically for those reports.
- Kept backward compatibility and no schema changes were required.

### Testing
- Attempted to run the report tests with `./gradlew -p api test --tests "*Report*"` but the wrapper at the repo root was not present so the command failed.
- Attempted `./api/gradlew -p api test --tests "*Report*"` which failed in this environment with `Unsupported class file major version 69` indicating a toolchain mismatch, so no automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10ec268eb8833284b431698ed6b403)