### PR TITLE
Use filter key label for json_filter display_value

### DIFF
--- a/api/src/main/java/com/ticketingSystem/reportGenerator/service/AsyncReportService.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/service/AsyncReportService.java
@@ -137,7 +137,7 @@ public class AsyncReportService {
                     row.put("type", inferType(entry.getValue()));
                     row.put("value", entry.getValue());
                     boolean isAll = isAllValue(entry.getValue());
-                    row.put("display_value", isAll ? "All" : formatValue(entry.getValue()));
+                    row.put("display_value", isAll ? "All" : toLabel(entry.getKey()));
                     row.put("is_all", isAll);
                     return row;
                 })


### PR DESCRIPTION
### Motivation
- Ensure the `display_value` in the report `json_filter` contains the human-readable text for the filter key rather than the raw filter value so reports show the expected label text.

### Description
- In `AsyncReportService.toFiltersJson` set `display_value` to `toLabel(entry.getKey())` when not an "All" value, replacing the previous `formatValue(entry.getValue())` behavior (file: `api/src/main/java/com/ticketingSystem/reportGenerator/service/AsyncReportService.java`).

### Testing
- Ran a compile attempt with `./gradlew compileJava` in `api/` which could not complete in this environment due to Java/Gradle compatibility (`Unsupported class file major version 69`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a136c22ebcc8332a4263e332811d940)