### PR TITLE
Add From/To/Other Filters to Downloads history and expose `filters_json`

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/controller/TicketController.java
+++ b/api/src/main/java/com/ticketingSystem/api/controller/TicketController.java
@@ -515,6 +515,7 @@ public class TicketController {
                     row.put("failedAt", req.getFailedAt());
                     row.put("errorMessage", req.getErrorMessage());
                     row.put("expiresAt", req.getExpiresAt());
+                    row.put("filters_json", req.getFiltersJson());
                     if (req.getRequestedBy() != null && !req.getRequestedBy().isBlank()) {
                         userService.getUserDetails(req.getRequestedBy()).ifPresent(user -> {
                             Map<String, Object> requestedByDetails = new HashMap<>();

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/service/AsyncReportService.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/service/AsyncReportService.java
@@ -140,6 +140,7 @@ public class AsyncReportService {
                     row.put("value", entry.getValue());
                     boolean isAll = isAllValue(entry.getValue());
                     row.put("is_all", isAll);
+                    row.put("show", shouldShow(entry.getKey()));
                     return row;
                 })
                 .collect(Collectors.toList())));
@@ -151,6 +152,10 @@ public class AsyncReportService {
         }
     }
 
+
+    private boolean shouldShow(String key) {
+        return key != null && key.endsWith("Label");
+    }
 
     private boolean isAllValue(Object value) {
         if (value == null) return true;

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/service/AsyncReportService.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/service/AsyncReportService.java
@@ -128,6 +128,8 @@ public class AsyncReportService {
 
     private String toFiltersJson(Map<String, Object> filters) {
         Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("fromDate", filters.get("fromDate"));
+        payload.put("toDate", filters.get("toDate"));
         payload.put("filters", new ArrayList<>(filters.entrySet().stream()
                 .filter(entry -> entry.getKey() != null && !entry.getKey().equals("query") && !entry.getKey().equals("dateParam"))
                 .map(entry -> {

--- a/ui/src/pages/Downloads.tsx
+++ b/ui/src/pages/Downloads.tsx
@@ -13,6 +13,7 @@ type ReportFilter = {
   label?: string;
   value?: unknown;
   is_all?: boolean;
+  show?: boolean;
 };
 
 type FiltersPayload = {
@@ -76,6 +77,14 @@ const Downloads: React.FC = () => {
       }
     }
     return payload;
+  }, []);
+
+
+  const getFilterValueByKey = React.useCallback((filters: FiltersPayload, key: string): string | undefined => {
+    const match = (filters.filters ?? []).find((filter) => filter.key === key);
+    const value = match?.value;
+    if (typeof value === 'string') return value;
+    return undefined;
   }, []);
 
   const renderFilterValue = React.useCallback((value: unknown) => {
@@ -148,13 +157,19 @@ const Downloads: React.FC = () => {
           return <Tooltip title={username}><span>{name}</span></Tooltip>;
         },
       },
-      { title: 'Requested At', dataIndex: 'requestedAt', key: 'requestedAt', render: (value) => renderDateCell(value) },
+            { title: 'Requested At', dataIndex: 'requestedAt', key: 'requestedAt', render: (value) => renderDateCell(value) },
+      {
+        title: 'Completed At',
+        key: 'doneAt',
+        render: (_, row) => renderDateCell(row.completedAt || row.failedAt),
+      },
       {
         title: 'From Date',
         key: 'fromDate',
         render: (_, row) => {
           const filters = parseFilters(row.filters_json);
-          return renderDateCell(filters.fromDate);
+          const fromDate = filters.fromDate || getFilterValueByKey(filters, 'fromDate');
+          return renderDateCell(fromDate);
         },
       },
       {
@@ -162,7 +177,8 @@ const Downloads: React.FC = () => {
         key: 'toDate',
         render: (_, row) => {
           const filters = parseFilters(row.filters_json);
-          return renderDateCell(filters.toDate);
+          const toDate = filters.toDate || getFilterValueByKey(filters, 'toDate');
+          return renderDateCell(toDate);
         },
       },
       {
@@ -170,7 +186,7 @@ const Downloads: React.FC = () => {
         key: 'otherFilters',
         render: (_, row) => {
           const filters = parseFilters(row.filters_json);
-          const chips = (filters.filters ?? []).filter((f) => f.is_all === false && f.key !== 'fromDate' && f.key !== 'toDate');
+          const chips = (filters.filters ?? []).filter((f) => f.is_all === false && f.show === true && f.key !== 'fromDate' && f.key !== 'toDate');
           if (!chips.length) return '-';
 
           const expanded = !!expandedRows[row.requestId];
@@ -192,11 +208,6 @@ const Downloads: React.FC = () => {
             </Box>
           );
         },
-      },
-      {
-        title: 'Completed At',
-        key: 'doneAt',
-        render: (_, row) => renderDateCell(row.completedAt || row.failedAt),
       },
       {
         title: 'Action',
@@ -226,7 +237,7 @@ const Downloads: React.FC = () => {
         },
       },
     ],
-    [expandedRows, parseFilters, renderDateCell, renderFilterChip],
+    [expandedRows, getFilterValueByKey, parseFilters, renderDateCell, renderFilterChip],
   );
 
   return (

--- a/ui/src/pages/Downloads.tsx
+++ b/ui/src/pages/Downloads.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, CircularProgress, Tooltip, Typography } from '@mui/material';
+import { Box, Button, Chip, CircularProgress, Stack, Tooltip, Typography } from '@mui/material';
 import type { ColumnsType } from 'antd/es/table';
 import GenericTable from '../components/UI/GenericTable';
 import { useApi } from '../hooks/useApi';
@@ -7,6 +7,19 @@ import { getReportDownloadUrl, getReportRequests } from '../services/TicketServi
 import CustomIconButton from '../components/UI/IconButton/CustomIconButton';
 import { formatDateTimeWithRelative } from '../utils/Utils';
 import Title from '../components/Title';
+
+type ReportFilter = {
+  key?: string;
+  label?: string;
+  value?: unknown;
+  is_all?: boolean;
+};
+
+type FiltersPayload = {
+  filters?: ReportFilter[];
+  fromDate?: string;
+  toDate?: string;
+};
 
 type ReportRequestRow = {
   requestId: string;
@@ -19,6 +32,7 @@ type ReportRequestRow = {
   errorMessage?: string;
   fileName?: string;
   downloadPath?: string;
+  filters_json?: string | FiltersPayload;
   requestedByDetails?: {
     userId?: string;
     username?: string;
@@ -29,6 +43,7 @@ type ReportRequestRow = {
 const Downloads: React.FC = () => {
   const { data, pending, apiHandler } = useApi<ReportRequestRow[]>();
   const rows = React.useMemo(() => data ?? [], [data]);
+  const [expandedRows, setExpandedRows] = React.useState<Record<string, boolean>>({});
 
   const load = React.useCallback(async () => {
     await apiHandler(() => getReportRequests());
@@ -51,6 +66,74 @@ const Downloads: React.FC = () => {
     );
   }, []);
 
+  const parseFilters = React.useCallback((payload?: string | FiltersPayload): FiltersPayload => {
+    if (!payload) return {};
+    if (typeof payload === 'string') {
+      try {
+        return JSON.parse(payload) as FiltersPayload;
+      } catch (_) {
+        return {};
+      }
+    }
+    return payload;
+  }, []);
+
+  const renderFilterValue = React.useCallback((value: unknown) => {
+    if (Array.isArray(value)) {
+      const values = value.map(String).filter(Boolean);
+      if (!values.length) return '-';
+      return (
+        <Stack direction="row" spacing={0} sx={{ alignItems: 'center', flexWrap: 'wrap' }}>
+          {values.map((item, idx) => (
+            <Typography
+              key={`${item}-${idx}`}
+              variant="body2"
+              sx={{
+                fontWeight: 600,
+                px: 0.75,
+                borderLeft: idx === 0 ? 'none' : '1px solid',
+                borderColor: 'success.light',
+              }}
+            >
+              {item}
+            </Typography>
+          ))}
+        </Stack>
+      );
+    }
+    if (value === null || value === undefined || value === '') return '-';
+    return <Typography variant="body2" sx={{ fontWeight: 600 }}>{String(value)}</Typography>;
+  }, []);
+
+  const renderFilterChip = React.useCallback((label: string, value: unknown, key: string) => (
+    <Chip
+      key={key}
+      variant="filled"
+      sx={{
+        backgroundColor: '#e8f5e9',
+        color: 'success.dark',
+        border: '1px solid',
+        borderColor: 'success.light',
+        borderRadius: 2,
+        height: 'auto',
+        maxWidth: 250,
+        '& .MuiChip-label': {
+          display: 'block',
+          whiteSpace: 'normal',
+          py: 0.75,
+        },
+      }}
+      label={
+        <Box>
+          <Typography variant="caption" sx={{ display: 'block', color: 'success.dark', opacity: 0.9 }}>
+            {label}
+          </Typography>
+          {renderFilterValue(value)}
+        </Box>
+      }
+    />
+  ), [renderFilterValue]);
+
   const columns = React.useMemo<ColumnsType<ReportRequestRow>>(
     () => [
       { title: 'Report', dataIndex: 'reportCode', key: 'reportCode', render: (value) => value || '-' },
@@ -67,6 +150,50 @@ const Downloads: React.FC = () => {
       },
       { title: 'Requested At', dataIndex: 'requestedAt', key: 'requestedAt', render: (value) => renderDateCell(value) },
       {
+        title: 'From Date',
+        key: 'fromDate',
+        render: (_, row) => {
+          const filters = parseFilters(row.filters_json);
+          return renderDateCell(filters.fromDate);
+        },
+      },
+      {
+        title: 'To Date',
+        key: 'toDate',
+        render: (_, row) => {
+          const filters = parseFilters(row.filters_json);
+          return renderDateCell(filters.toDate);
+        },
+      },
+      {
+        title: 'Other Filters',
+        key: 'otherFilters',
+        render: (_, row) => {
+          const filters = parseFilters(row.filters_json);
+          const chips = (filters.filters ?? []).filter((f) => f.is_all === false && f.key !== 'fromDate' && f.key !== 'toDate');
+          if (!chips.length) return '-';
+
+          const expanded = !!expandedRows[row.requestId];
+          const visible = expanded ? chips : chips.slice(0, 3);
+          return (
+            <Box sx={{ maxWidth: 360 }}>
+              <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
+                {visible.map((filter, index) => renderFilterChip(filter.label || filter.key || 'Filter', filter.value, `${row.requestId}-${filter.key || index}`))}
+              </Stack>
+              {chips.length > 3 ? (
+                <Button
+                  size="small"
+                  sx={{ mt: 0.5, px: 0, minWidth: 'auto' }}
+                  onClick={() => setExpandedRows((prev) => ({ ...prev, [row.requestId]: !expanded }))}
+                >
+                  {expanded ? 'less...' : 'more...'}
+                </Button>
+              ) : null}
+            </Box>
+          );
+        },
+      },
+      {
         title: 'Completed At',
         key: 'doneAt',
         render: (_, row) => renderDateCell(row.completedAt || row.failedAt),
@@ -80,7 +207,7 @@ const Downloads: React.FC = () => {
           }
 
           if (row.status === 'FAILED') {
-            return <CustomIconButton icon="error" size="small" disabled aria-label="Failed" sx={{ color: "error.main" }} />;
+            return <CustomIconButton icon="error" size="small" disabled aria-label="Failed" sx={{ color: 'error.main' }} />;
           }
 
           if (row.downloadPath && row.status === 'COMPLETED') {
@@ -99,7 +226,7 @@ const Downloads: React.FC = () => {
         },
       },
     ],
-    [renderDateCell],
+    [expandedRows, parseFilters, renderDateCell, renderFilterChip],
   );
 
   return (


### PR DESCRIPTION
### Motivation
- Surface the report request filters on the Downloads history so users can see request `fromDate`/`toDate` and other selected filters inline. 
- Keep date display consistent by reusing the existing `Requested At` formatter for the new date columns. 
- Provide the frontend with the raw filter payload so it can render filter chips and hide filters marked as `is_all === true`.

### Description
- API: include `filters_json` in the `/tickets/search/export/requests` response rows so the frontend can access the serialized filters (file: `api/src/main/java/com/ticketingSystem/api/controller/TicketController.java`).
- Service: serialize `fromDate` and `toDate` as top-level properties inside the stored `filters_json` payload (file: `api/src/main/java/com/ticketingSystem/reportGenerator/service/AsyncReportService.java`).
- UI: enhance `Downloads` table (`ui/src/pages/Downloads.tsx`) with three new columns: `From Date`, `To Date`, and `Other Filters`, where `From Date`/`To Date` are rendered using the same `formatDateTimeWithRelative` helper as `Requested At`.
- UI: render `Other Filters` as light-green MUI chips with two-line content (top: small filter label, bottom: human-readable value), collapse long lists behind a `more...`/`less...` toggle, show multi-value filters in a single chip with vertical dividers, and only display filters where `is_all === false`.

### Testing
- Attempted frontend production build with `npm run -s build` which failed due to a pre-existing missing dependency (`i18next`) unrelated to these changes, so UI build status is failing.
- No additional automated backend or unit test runs were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a137f58fb608332b2faf2af6557a149)