### PR TITLE
Add provider and JRXML for master ticket report query

### DIFF
--- a/api/src/main/java/com/ticketingSystem/reportGenerator/service/MasterTicketReportRequestDataProvider.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/service/MasterTicketReportRequestDataProvider.java
@@ -1,0 +1,39 @@
+package com.ticketingSystem.reportGenerator.service;
+
+import com.ticketingSystem.reportGenerator.enums.ReportFormat;
+import com.ticketingSystem.reportGenerator.models.ReportMaster;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@Order(0)
+public class MasterTicketReportRequestDataProvider implements ReportRequestDataProvider {
+
+    private static final String TEMPLATE_LOCATION = "reports/master_ticket_report.jrxml";
+
+    @Override
+    public boolean supports(String reportCode, ReportMaster reportMaster, Map<String, Object> filters) {
+        return reportMaster != null
+                && reportMaster.getTemplateLocation() != null
+                && TEMPLATE_LOCATION.equalsIgnoreCase(reportMaster.getTemplateLocation());
+    }
+
+    @Override
+    public List<?> fetchRows(Map<String, Object> filters) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Map<String, Object> buildParams(Map<String, Object> filters, ReportMaster reportMaster, ReportFormat format) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("USE_TEMPLATE_SQL", Boolean.TRUE);
+        params.put("generatedOn", LocalDateTime.now().toString());
+        return params;
+    }
+}

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/service/MasterTicketReportRequestDataProvider.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/service/MasterTicketReportRequestDataProvider.java
@@ -34,6 +34,29 @@ public class MasterTicketReportRequestDataProvider implements ReportRequestDataP
         Map<String, Object> params = new HashMap<>();
         params.put("USE_TEMPLATE_SQL", Boolean.TRUE);
         params.put("generatedOn", LocalDateTime.now().toString());
+        params.put("fromDate", toNullableString(filters.get("fromDate")));
+        params.put("toDate", toNullableString(filters.get("toDate")));
+        params.put("categoryId", toNullableString(filters.get("categoryId")));
+        params.put("subCategoryId", toNullableString(filters.get("subCategoryId")));
+        params.put("zoneCode", toNullableString(filters.get("zoneCode")));
+        params.put("regionCode", toNullableString(filters.get("regionCode")));
+        params.put("districtCode", toNullableString(filters.get("districtCode")));
+        params.put("issueTypeId", toNullableString(filters.get("issueTypeId")));
+        params.put("statusId", toNullableString(filters.get("statusId")));
+        params.put("priorityId", toNullableString(firstNonEmpty(filters.get("priorityId"), filters.get("priority"))));
+        params.put("severityId", toNullableString(firstNonEmpty(filters.get("severityId"), filters.get("severity"))));
         return params;
+    }
+
+    private Object firstNonEmpty(Object preferred, Object fallback) {
+        return toNullableString(preferred) != null ? preferred : fallback;
+    }
+
+    private String toNullableString(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String text = String.valueOf(value).trim();
+        return text.isEmpty() ? null : text;
     }
 }

--- a/api/src/main/resources/reports/master_ticket_report.jrxml
+++ b/api/src/main/resources/reports/master_ticket_report.jrxml
@@ -5,6 +5,19 @@
               name="Master_Ticket_Report" pageWidth="2200" pageHeight="1000" orientation="Landscape" columnWidth="2160"
               leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20">
 
+
+    <parameter name="fromDate" class="java.lang.String"/>
+    <parameter name="toDate" class="java.lang.String"/>
+    <parameter name="categoryId" class="java.lang.String"/>
+    <parameter name="subCategoryId" class="java.lang.String"/>
+    <parameter name="zoneCode" class="java.lang.String"/>
+    <parameter name="regionCode" class="java.lang.String"/>
+    <parameter name="districtCode" class="java.lang.String"/>
+    <parameter name="issueTypeId" class="java.lang.String"/>
+    <parameter name="statusId" class="java.lang.String"/>
+    <parameter name="priorityId" class="java.lang.String"/>
+    <parameter name="severityId" class="java.lang.String"/>
+
     <queryString>
         <![CDATA[
 SELECT
@@ -61,6 +74,18 @@ LEFT JOIN status_history sh
     ON sh.ticket_id = t.ticket_id
    AND sh.`timestamp` = sh_max.max_ts
 LEFT JOIN status_master sm ON sm.status_id = sh.current_status
+WHERE 1 = 1
+  AND ($P{fromDate} IS NULL OR t.reported_date >= STR_TO_DATE($P{fromDate}, '%Y-%m-%d %H:%i:%s'))
+  AND ($P{toDate} IS NULL OR t.reported_date < DATE_ADD(STR_TO_DATE($P{toDate}, '%Y-%m-%d %H:%i:%s'), INTERVAL 1 DAY))
+  AND ($P{categoryId} IS NULL OR t.category = $P{categoryId})
+  AND ($P{subCategoryId} IS NULL OR t.sub_category = $P{subCategoryId})
+  AND ($P{zoneCode} IS NULL OR t.zone_code = $P{zoneCode})
+  AND ($P{regionCode} IS NULL OR t.region_code = $P{regionCode})
+  AND ($P{districtCode} IS NULL OR t.district_code = $P{districtCode})
+  AND ($P{issueTypeId} IS NULL OR t.issue_type_id = $P{issueTypeId})
+  AND ($P{statusId} IS NULL OR t.status_id = $P{statusId})
+  AND ($P{priorityId} IS NULL OR t.priority = $P{priorityId})
+  AND ($P{severityId} IS NULL OR t.severity = $P{severityId})
 ORDER BY t.ticket_id DESC
         ]]>
     </queryString>

--- a/api/src/main/resources/reports/master_ticket_report.jrxml
+++ b/api/src/main/resources/reports/master_ticket_report.jrxml
@@ -49,7 +49,7 @@ SELECT
     t.requestor_email_id                         AS requestor_email_id,
     t.requestor_mobile_no                        AS requestor_mobile_no,
     dm.division_name                             AS division
-FROM ad_prd_ticket_system.tickets t
+FROM tickets t
 LEFT JOIN categories        c   ON c.category_id      = t.category
 LEFT JOIN sub_categories    s   ON s.sub_category_id  = t.sub_category
 LEFT JOIN issue_type_master i   ON i.issue_type_id    = t.issue_type_id
@@ -61,7 +61,7 @@ LEFT JOIN district_master   d   ON d.district_code    = t.district_code
 LEFT JOIN division_master   dm  ON dm.division_id     = t.division
 LEFT JOIN (
     SELECT master_id, COUNT(*) AS child_ticket_count
-    FROM ad_prd_ticket_system.tickets
+    FROM tickets
     WHERE master_id IS NOT NULL
     GROUP BY master_id
 ) ct ON ct.master_id = t.ticket_id
@@ -83,7 +83,7 @@ WHERE 1 = 1
   AND ($P{regionCode} IS NULL OR t.region_code = $P{regionCode})
   AND ($P{districtCode} IS NULL OR t.district_code = $P{districtCode})
   AND ($P{issueTypeId} IS NULL OR t.issue_type_id = $P{issueTypeId})
-  AND ($P{statusId} IS NULL OR t.status_id = $P{statusId})
+  AND ($P{statusId} IS NULL OR t.status_id = $P{statusId} OR t.status = $P{statusId} OR sm.status_name = $P{statusId})
   AND ($P{priorityId} IS NULL OR t.priority = $P{priorityId})
   AND ($P{severityId} IS NULL OR t.severity = $P{severityId})
 ORDER BY t.ticket_id DESC

--- a/api/src/main/resources/reports/master_ticket_report.jrxml
+++ b/api/src/main/resources/reports/master_ticket_report.jrxml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd"
+              name="Master_Ticket_Report" pageWidth="2200" pageHeight="1000" orientation="Landscape" columnWidth="2160"
+              leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20">
+
+    <queryString>
+        <![CDATA[
+SELECT
+    t.ticket_id                                  AS ticket_id,
+    t.master_id                                  AS master_id,
+    t.is_master                                  AS is_master,
+    COALESCE(ct.child_ticket_count, 0)          AS child_ticket_count,
+    t.reported_date                              AS reported_date,
+    t.requestor_name                             AS requestor_name,
+    sh.remark                                    AS remark,
+    sh.updated_by                                AS updated_by,
+    t.status                                     AS status,
+    t.subject                                    AS subject,
+    t.description                                AS description,
+    c.category                                   AS module,
+    s.sub_category                               AS sub_module,
+    i.name                                       AS issue_type,
+    t.assigned_to                                AS assigned_to,
+    p.tp_level                                   AS priority,
+    sev.ts_level                                 AS severity,
+    t.office_code                                AS office_code,
+    d.district_name                              AS district_name,
+    d.district_code                              AS district_code,
+    z.zone_code                                  AS zone_code,
+    z.zone_name                                  AS zone,
+    r.region_name                                AS region_name,
+    r.region_code                                AS region_code,
+    t.user_id                                    AS requestor_user_id,
+    t.requestor_email_id                         AS requestor_email_id,
+    t.requestor_mobile_no                        AS requestor_mobile_no,
+    dm.division_name                             AS division
+FROM ad_prd_ticket_system.tickets t
+LEFT JOIN categories        c   ON c.category_id      = t.category
+LEFT JOIN sub_categories    s   ON s.sub_category_id  = t.sub_category
+LEFT JOIN issue_type_master i   ON i.issue_type_id    = t.issue_type_id
+LEFT JOIN priority_master   p   ON p.tp_id            = t.priority
+LEFT JOIN severity_master   sev ON sev.ts_id          = t.severity
+LEFT JOIN zone_master       z   ON z.zone_code        = t.zone_code
+LEFT JOIN region_master     r   ON r.region_code      = t.region_code
+LEFT JOIN district_master   d   ON d.district_code    = t.district_code
+LEFT JOIN division_master   dm  ON dm.division_id     = t.division
+LEFT JOIN (
+    SELECT master_id, COUNT(*) AS child_ticket_count
+    FROM ad_prd_ticket_system.tickets
+    WHERE master_id IS NOT NULL
+    GROUP BY master_id
+) ct ON ct.master_id = t.ticket_id
+LEFT JOIN (
+    SELECT ticket_id, MAX(`timestamp`) AS max_ts
+    FROM status_history
+    GROUP BY ticket_id
+) sh_max ON sh_max.ticket_id = t.ticket_id
+LEFT JOIN status_history sh
+    ON sh.ticket_id = t.ticket_id
+   AND sh.`timestamp` = sh_max.max_ts
+LEFT JOIN status_master sm ON sm.status_id = sh.current_status
+ORDER BY t.ticket_id DESC
+        ]]>
+    </queryString>
+
+    <field name="ticket_id" class="java.lang.String"/>
+    <field name="master_id" class="java.lang.String"/>
+    <field name="is_master" class="java.lang.Boolean"/>
+    <field name="child_ticket_count" class="java.lang.Integer"/>
+    <field name="reported_date" class="java.sql.Timestamp"/>
+    <field name="requestor_name" class="java.lang.String"/>
+    <field name="remark" class="java.lang.String"/>
+    <field name="updated_by" class="java.lang.String"/>
+    <field name="status" class="java.lang.String"/>
+    <field name="subject" class="java.lang.String"/>
+    <field name="description" class="java.lang.String"/>
+
+    <title>
+        <band height="24">
+            <staticText>
+                <reportElement x="0" y="0" width="2160" height="24"/>
+                <textElement textAlignment="Center" verticalAlignment="Middle"><font size="14" isBold="true"/></textElement>
+                <text><![CDATA[Master Ticket Report]]></text>
+            </staticText>
+        </band>
+    </title>
+
+    <columnHeader>
+        <band height="20">
+            <staticText><reportElement x="0" y="0" width="100" height="20"/><text><![CDATA[Ticket Id]]></text></staticText>
+            <staticText><reportElement x="100" y="0" width="100" height="20"/><text><![CDATA[Master Id]]></text></staticText>
+            <staticText><reportElement x="200" y="0" width="80" height="20"/><text><![CDATA[Is Master]]></text></staticText>
+            <staticText><reportElement x="280" y="0" width="100" height="20"/><text><![CDATA[Child Count]]></text></staticText>
+            <staticText><reportElement x="380" y="0" width="150" height="20"/><text><![CDATA[Reported Date]]></text></staticText>
+            <staticText><reportElement x="530" y="0" width="150" height="20"/><text><![CDATA[Requestor]]></text></staticText>
+            <staticText><reportElement x="680" y="0" width="150" height="20"/><text><![CDATA[Remark]]></text></staticText>
+            <staticText><reportElement x="830" y="0" width="130" height="20"/><text><![CDATA[Updated By]]></text></staticText>
+            <staticText><reportElement x="960" y="0" width="100" height="20"/><text><![CDATA[Status]]></text></staticText>
+            <staticText><reportElement x="1060" y="0" width="200" height="20"/><text><![CDATA[Subject]]></text></staticText>
+            <staticText><reportElement x="1260" y="0" width="300" height="20"/><text><![CDATA[Description]]></text></staticText>
+        </band>
+    </columnHeader>
+
+    <detail>
+        <band height="20">
+            <textField><reportElement x="0" y="0" width="100" height="20"/><textFieldExpression><![CDATA[$F{ticket_id}]]></textFieldExpression></textField>
+            <textField><reportElement x="100" y="0" width="100" height="20"/><textFieldExpression><![CDATA[$F{master_id}]]></textFieldExpression></textField>
+            <textField><reportElement x="200" y="0" width="80" height="20"/><textFieldExpression><![CDATA[$F{is_master}]]></textFieldExpression></textField>
+            <textField><reportElement x="280" y="0" width="100" height="20"/><textFieldExpression><![CDATA[$F{child_ticket_count}]]></textFieldExpression></textField>
+            <textField pattern="yyyy-MM-dd HH:mm:ss"><reportElement x="380" y="0" width="150" height="20"/><textFieldExpression><![CDATA[$F{reported_date}]]></textFieldExpression></textField>
+            <textField><reportElement x="530" y="0" width="150" height="20"/><textFieldExpression><![CDATA[$F{requestor_name}]]></textFieldExpression></textField>
+            <textField><reportElement x="680" y="0" width="150" height="20"/><textFieldExpression><![CDATA[$F{remark}]]></textFieldExpression></textField>
+            <textField><reportElement x="830" y="0" width="130" height="20"/><textFieldExpression><![CDATA[$F{updated_by}]]></textFieldExpression></textField>
+            <textField><reportElement x="960" y="0" width="100" height="20"/><textFieldExpression><![CDATA[$F{status}]]></textFieldExpression></textField>
+            <textField><reportElement x="1060" y="0" width="200" height="20"/><textFieldExpression><![CDATA[$F{subject}]]></textFieldExpression></textField>
+            <textField><reportElement x="1260" y="0" width="300" height="20"/><textFieldExpression><![CDATA[$F{description}]]></textFieldExpression></textField>
+        </band>
+    </detail>
+</jasperReport>


### PR DESCRIPTION
### Motivation
- Provide a server-side Jasper SQL-backed report for the master/child ticket query so the report can be generated from the DB using an existing report generation pipeline.
- Allow the report framework to select a provider that forces JRXML template SQL execution (so large/heavy queries run in the DB instead of in-memory row lists).

### Description
- Added `MasterTicketReportRequestDataProvider` which selects templates whose `templateLocation` equals `reports/master_ticket_report.jrxml` and sets `USE_TEMPLATE_SQL=true` in the parameters. 
- The provider returns an empty row list because the JRXML executes the SQL via DB connection and provides generation metadata such as `generatedOn`. 
- Added `api/src/main/resources/reports/master_ticket_report.jrxml` that embeds the supplied SQL (field-safe aliases, child-ticket aggregation, latest status_history join) inside a `<queryString>` and declares corresponding `<field>` entries. 
- The JRXML includes a basic title, column headers and detail band layout suitable for PDF/Excel exports used by the existing Jasper generators (`jasperPdf` / `jasperExcel`).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13dcb13bd083329b2507ca8c8e541f)