### PR TITLE
Fix master ticket report status filtering and field mappings

### DIFF
--- a/api/src/main/resources/reports/master_ticket_report.jrxml
+++ b/api/src/main/resources/reports/master_ticket_report.jrxml
@@ -23,7 +23,7 @@
                 SELECT
                     COALESCE(NULLIF(t.ticket_id, ''), '-')                AS id,
                     COALESCE(NULLIF(t.master_id, ''), '-')                AS masterId,
-                    COALESCE(NULLIF(t.is_master, 0), 0)                  AS isMaster,
+                    COALESCE(t.is_master, 0)                             AS isMaster,
                     COALESCE(ct.child_ticket_count, 0)                   AS childTicketCount,
 
                     t.reported_date                                       AS reportedDate,
@@ -31,7 +31,7 @@
                     COALESCE(NULLIF(t.requestor_name, ''), '-')          AS requestorName,
                     COALESCE(NULLIF(sh.remark, ''), '-')                 AS remark,
                     COALESCE(NULLIF(sh.updated_by, ''), '-')             AS updatedBy,
-                    COALESCE(NULLIF(t.status, ''), '-')                  AS statusLabel,
+                    COALESCE(NULLIF(sm.status_name, ''), NULLIF(t.status, ''), '-') AS statusLabel,
                     COALESCE(NULLIF(t.subject, ''), '-')                 AS subject,
                     COALESCE(NULLIF(t.description, ''), '-')             AS description,
 
@@ -93,7 +93,7 @@
               AND ($P{regionCode} IS NULL OR t.region_code = $P{regionCode})
               AND ($P{districtCode} IS NULL OR t.district_code = $P{districtCode})
               AND ($P{issueTypeId} IS NULL OR t.issue_type_id = $P{issueTypeId})
-              AND ($P{statusId} IS NULL OR t.status_id = $P{statusId})
+              AND ($P{statusId} IS NULL OR sh.current_status = $P{statusId})
               AND ($P{priorityId} IS NULL OR t.priority = $P{priorityId})
               AND ($P{severityId} IS NULL OR t.severity = $P{severityId})
             ORDER BY t.ticket_id DESC
@@ -102,7 +102,7 @@
 
     <field name="id" class="java.lang.String"/>
     <field name="masterId" class="java.lang.String"/>
-    <field name="isMaster" class="java.lang.Boolean"/>
+    <field name="isMaster" class="java.lang.Integer"/>
     <field name="childTicketCount" class="java.lang.Integer"/>
     <field name="reportedDate" class="java.sql.Timestamp"/>
     <field name="requestorName" class="java.lang.String"/>


### PR DESCRIPTION
### Motivation
- The master ticket report was returning empty results when filtering by status because the report derived status from the latest status history join but the filter used the ticket table's status column. 
- There was a type/format mismatch for the `isMaster` field which could cause export/parsing issues in Jasper/Excel.

### Description
- Updated `master_ticket_report.jrxml` to apply the status filter against the latest status history value by changing the WHERE clause to use `sh.current_status` instead of `t.status_id`. 
- Changed the `statusLabel` expression to coalesce `sm.status_name` with `t.status` as fallback so status text comes from the joined `status_master`. 
- Simplified the SQL expression for `isMaster` to `COALESCE(t.is_master, 0)` and changed the Jasper field declaration for `isMaster` from `java.lang.Boolean` to `java.lang.Integer` to align types. 
- No changes were made to `tickets_rpt_filtered.jrxml`; the fix is limited to the master report template file at `api/src/main/resources/reports/master_ticket_report.jrxml`.

### Testing
- Parsed both JRXML files with `python` using `xml.etree.ElementTree` and parsing succeeded for both files. 
- Compared the original and updated report file contents and confirmed the WHERE clause, `statusLabel` expression, and `isMaster` field/type changes are present. 
- No automated unit test failures were observed during these checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1410bbe0b08332ba9682d66e1520ee)