### PR TITLE
Gate Downloads sidebar item by role permissions

### DIFF
--- a/ui/src/components/Layout/Sidebar.tsx
+++ b/ui/src/components/Layout/Sidebar.tsx
@@ -149,8 +149,6 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
     text: textColor
   } = useMemo(() => theme.palette.sidebar, [theme.palette.mode]);
 
-  console.log(selectedKey)
-
   return (
     <div
       className="p-0 position-relative"
@@ -169,7 +167,7 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
         <img src="./menu-leaf.png" className="position-absolute" style={{ left: "0", bottom: "0", width: collapsed ? "80px" : "auto" }} />
         <List component="nav">
           {menuItems.map(({ key, label, to, icon }) => {
-            const alwaysVisible = key === 'myProfile' || key === 'downloads';
+            const alwaysVisible = key === 'myProfile';
             if (!alwaysVisible && !checkSidebarAccess(key)) {
               return null;
             }

--- a/ui/src/components/Layout/__tests__/Sidebar.test.tsx
+++ b/ui/src/components/Layout/__tests__/Sidebar.test.tsx
@@ -44,5 +44,6 @@ describe('Sidebar', () => {
 
     expect(screen.getByText('t:My Tickets')).toBeInTheDocument();
     expect(screen.queryByText('t:All Tickets')).not.toBeInTheDocument();
+    expect(screen.queryByText('t:Downloads')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### Motivation
- Ensure the `Downloads` sidebar item follows role-based visibility like other menu items instead of being always visible.

### Description
- Updated `ui/src/components/Layout/Sidebar.tsx` to remove the hardcoded always-visible check for `downloads`, leaving only `myProfile` as always visible and using `checkSidebarAccess(key)` for `Downloads` and other items, and removed a stray `console.log`.

### Testing
- Ran the Sidebar unit test: `npm test -- --runTestsByPath src/components/Layout/__tests__/Sidebar.test.tsx --watch=false`, which passed (1 suite, 3 tests all green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a143fcbacf883329e3d08c088d70774)