### PR TITLE
Add disabled-state logging to NotificationService

### DIFF
--- a/api/src/main/java/com/ticketingSystem/notification/service/NotificationService.java
+++ b/api/src/main/java/com/ticketingSystem/notification/service/NotificationService.java
@@ -5,6 +5,8 @@ import com.ticketingSystem.notification.enums.ChannelType;
 import com.ticketingSystem.notification.models.NotificationMaster;
 import com.ticketingSystem.notification.repository.NotificationMasterRepository;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
@@ -14,13 +16,17 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
+    private static final Logger log = LoggerFactory.getLogger(NotificationService.class);
     private final List<Notifier> notifiers;
     private final NotificationProperties properties;
     private final NotificationRuntimeToggleService notificationRuntimeToggleService;
     private final NotificationMasterRepository notificationMasterRepository;
 
     public void sendNotification(ChannelType channel, String notificationCode, Map<String, Object> dataModel, String recipient) throws Exception {
-        if (!notificationRuntimeToggleService.isNotificationEnabled()) return; // Notification Globally disabled
+        if (!notificationRuntimeToggleService.isNotificationEnabled()) {
+            log.info("Notification dispatch skipped because notifications are globally disabled. channel={}, notificationCode={}, recipient={}", channel, notificationCode, recipient);
+            return;
+        }
 
         Notifier notifier = notifiers.stream()
                 .filter(n -> n.getChannel() == channel)


### PR DESCRIPTION
### Motivation
- Make skipped notification dispatches observable when the runtime toggle disables notifications so operators can troubleshoot why messages are not being sent.

### Description
- Add an SLF4J logger to `NotificationService` and log an informational message with `channel`, `notificationCode` and `recipient` when `notificationRuntimeToggleService.isNotificationEnabled()` returns `false` before returning early (file `api/src/main/java/com/ticketingSystem/notification/service/NotificationService.java`).

### Testing
- Attempted to run the targeted unit test with `cd api && ./gradlew test --tests com.ticketingSystem.notification.service.NotificationServiceTest`, but the local Gradle invocation failed in this environment with `Unsupported class file major version 69`, so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a145c48ee3883328f6c7226bb7d4363)