### PR TITLE
Enhance download request listing with requester details, artifacts and date filter

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/dto/DownloadRequestDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/DownloadRequestDto.java
@@ -1,10 +1,17 @@
 package com.ticketingSystem.api.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class DownloadRequestDto {
     private String requestId;
     private String reportCode;
     private String format;
-    private String requestedByDetails;
+    private RequestedByDetails requestedByDetails;
     private String requestedAt;
     private String completedAt;
     private String filtersJson;
@@ -13,4 +20,13 @@ public class DownloadRequestDto {
     private String expiresAt;
     private String filename;
     private String downloadPath;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RequestedByDetails {
+        private String userId;
+        private String username;
+        private String name;
+    }
 }

--- a/api/src/main/java/com/ticketingSystem/api/service/ReportService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/ReportService.java
@@ -31,6 +31,7 @@ import com.ticketingSystem.api.repository.TicketSlaRepository;
 import com.ticketingSystem.api.repository.UserRepository;
 import com.ticketingSystem.api.util.DateTimeUtils;
 import com.ticketingSystem.reportGenerator.repository.ReportRequestHistoryRepository;
+import com.ticketingSystem.reportGenerator.repository.ReportArtifactRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -76,6 +77,7 @@ public class ReportService {
     private final RoleService roleService;
     private final ParameterMasterService parameterMasterService;
     private final ReportRequestHistoryRepository reportRequestHistoryRepository;
+    private final ReportArtifactRepository reportArtifactRepository;
 
     private static final EnumSet<TicketStatus> RESOLVED_STATUSES = EnumSet.of(
             TicketStatus.RESOLVED,
@@ -105,11 +107,43 @@ public class ReportService {
     }
 
     public PaginationResponse<DownloadRequestDto> getDownloadRequests(String requestedBy, String reportCode, String format, String requestedAt, Pageable pageable) {
-        Page<DownloadRequestDto> p = reportRequestHistoryRepository.findDownloadRequests(requestedBy, reportCode, format, requestedAt, pageable);
-        PaginationResponse<DownloadRequestDto> response = new PaginationResponse<>(
-           p.getContent(), p.getNumber(), p.getSize(), p.getTotalElements(), p.getTotalPages()
-        );
-        return response;
+        LocalDateTime requestedFrom = null;
+        LocalDateTime requestedTo = null;
+        if (StringUtils.hasText(requestedAt)) {
+            LocalDate requestedDate = LocalDate.parse(requestedAt.trim());
+            requestedFrom = requestedDate.atStartOfDay();
+            requestedTo = requestedFrom.plusDays(1);
+        }
+
+        Page<DownloadRequestDto> p = reportRequestHistoryRepository
+                .findDownloadRequests(requestedBy, reportCode, format, requestedFrom, requestedTo, pageable)
+                .map(req -> {
+                    DownloadRequestDto dto = new DownloadRequestDto();
+                    dto.setRequestId(req.getRequestId());
+                    dto.setReportCode(req.getReport() != null ? req.getReport().getReportCode() : null);
+                    dto.setFormat(req.getOutputFormat());
+                    dto.setRequestedAt(req.getRequestedAt() != null ? req.getRequestedAt().toString() : null);
+                    dto.setCompletedAt(req.getCompletedAt() != null ? req.getCompletedAt().toString() : null);
+                    dto.setFiltersJson(req.getFiltersJson());
+                    dto.setFailedAt(req.getFailedAt() != null ? req.getFailedAt().toString() : null);
+                    dto.setErrorMessage(req.getErrorMessage());
+                    dto.setExpiresAt(req.getExpiresAt() != null ? req.getExpiresAt().toString() : null);
+
+                    if (StringUtils.hasText(req.getRequestedBy())) {
+                        userService.getUserDetails(req.getRequestedBy()).ifPresent(user -> dto.setRequestedByDetails(
+                                new DownloadRequestDto.RequestedByDetails(user.getUserId(), user.getUsername(), user.getName())
+                        ));
+                    }
+
+                    reportArtifactRepository.findByRequestRequestId(req.getRequestId()).ifPresent(a -> {
+                        dto.setFilename(a.getFileName());
+                        dto.setDownloadPath("/tickets/search/export/requests/" + req.getRequestId() + "/download");
+                    });
+
+                    return dto;
+                });
+
+        return new PaginationResponse<>(p.getContent(), p.getNumber(), p.getSize(), p.getTotalElements(), p.getTotalPages());
     }
 
     private record ParameterCriteria(String assignedTo, String assignedBy, String updatedBy, String createdBy, String userId, String zoneCode, String regionCode, String districtCode, String issueTypeId) {
@@ -1919,10 +1953,6 @@ public class ReportService {
     public void notifyBreachedSlaAssignees() {
         List<TicketSla> breachedTickets = ticketSlaRepository.findBreachedWithTicket();
         ticketSlaService.notifyAssigneesOfBreachedTickets(breachedTickets);
-    }
-
-    public PaginationResponse<DownloadRequestDto> getDownloadRequests(String re) {
-
     }
 
     private List<SlaPerformanceReportDto.SlaStatusBreakdownDto> buildStatusBreakdown(

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/repository/ReportRequestHistoryRepository.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/repository/ReportRequestHistoryRepository.java
@@ -1,6 +1,5 @@
 package com.ticketingSystem.reportGenerator.repository;
 
-import com.ticketingSystem.api.dto.DownloadRequestDto;
 import com.ticketingSystem.reportGenerator.models.ReportRequestHistory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -8,38 +7,31 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ReportRequestHistoryRepository extends JpaRepository<ReportRequestHistory, String> {
     List<ReportRequestHistory> findTop50ByOrderByRequestedAtDesc();
 
-    @Query("Select " +
-            "r.request_id, r. " +
-            "rm.report_code" +
-            "r.output_format" +
-            "r.requested_by" +
-            "r.requested_at" +
-            "r.requested_at" +
-            "r.completed_at" +
-            "ra.filters_json" +
-            "r.failed_at" +
-            "r.error_message" +
-            "r.expires_at" +
-            "ra.filename" +
-            "ra.storage_location" +
-            "FROM report_request_history rrh " +
-            "LEFT JOIN report_artifact ra " +
-            "ON rrh.request_id = ra.request_id " +
-            "LEFT JOIN report_master rm " +
-            "ON rm.report_id = rrh.report_id" +
-            "WHERE (:requestedById IS NULL OR r.requested_by = :requestedById) " +
+    @Query(value = "SELECT rrh.* FROM report_request_history rrh " +
+            "LEFT JOIN report_master rm ON rm.report_id = rrh.report_id " +
+            "WHERE (:requestedById IS NULL OR rrh.requested_by = :requestedById) " +
             "AND (:reportCode IS NULL OR rm.report_code = :reportCode) " +
-            "AND (:format IS NULL OR r.output_format = :format) " +
-            "AND (:requestedAt IS NULL OR r.requested_at = :requestedAt) "
-    )
-    Page<DownloadRequestDto> findDownloadRequests(@Param("requestedById") String requestedBy,
-                                                  @Param("reportCode") String reportCode,
-                                                  @Param("format") String format,
-                                                  @Param("requestedAt") String requestedAt,
+            "AND (:format IS NULL OR rrh.output_format = :format) " +
+            "AND (:requestedFrom IS NULL OR rrh.requested_at >= :requestedFrom) " +
+            "AND (:requestedTo IS NULL OR rrh.requested_at < :requestedTo)",
+            countQuery = "SELECT COUNT(*) FROM report_request_history rrh " +
+                    "LEFT JOIN report_master rm ON rm.report_id = rrh.report_id " +
+                    "WHERE (:requestedById IS NULL OR rrh.requested_by = :requestedById) " +
+                    "AND (:reportCode IS NULL OR rm.report_code = :reportCode) " +
+                    "AND (:format IS NULL OR rrh.output_format = :format) " +
+                    "AND (:requestedFrom IS NULL OR rrh.requested_at >= :requestedFrom) " +
+                    "AND (:requestedTo IS NULL OR rrh.requested_at < :requestedTo)",
+            nativeQuery = true)
+    Page<ReportRequestHistory> findDownloadRequests(@Param("requestedById") String requestedBy,
+                                                    @Param("reportCode") String reportCode,
+                                                    @Param("format") String format,
+                                                    @Param("requestedFrom") LocalDateTime requestedFrom,
+                                                    @Param("requestedTo") LocalDateTime requestedTo,
                                                   Pageable pageable);
 }


### PR DESCRIPTION
### Motivation

- Provide richer download request payloads by including structured requester information and artifact metadata.
- Allow filtering download requests by requested date (as a date range) to support UI date-picker searches.
- Use existing report artifact records to expose filename and a consistent download path for requests.

### Description

- Changed `DownloadRequestDto` to use Lombok (`@Data`, `@NoArgsConstructor`, `@AllArgsConstructor`) and replaced `requestedByDetails` `String` with a nested `RequestedByDetails` class containing `userId`, `username`, and `name`.
- Updated `ReportService#getDownloadRequests` to parse an incoming `requestedAt` date into a `requestedFrom`/`requestedTo` `LocalDateTime` range, call the repository with the new parameters, map `ReportRequestHistory` entities to `DownloadRequestDto`, resolve requester info via `userService.getUserDetails`, and populate artifact filename and download path using `ReportArtifactRepository`.
- Injected `ReportArtifactRepository` into `ReportService` to look up artifacts by request id.
- Reworked `ReportRequestHistoryRepository.findDownloadRequests` into a native query that joins `report_master` and supports `requestedFrom`/`requestedTo` `LocalDateTime` parameters, added a `countQuery`, and changed the return type to `Page<ReportRequestHistory>` to let the service do DTO mapping.
- Removed an unused stub overload of `getDownloadRequests`.

### Testing

- Built the project and ran the test suite with `mvn -DskipTests=false test`, and the build and tests completed successfully.
- Verified the modified repository query compiles and the `ReportService` mapping compiles during the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15770f65508332bff968eeba7ba5c6)