### PR TITLE
Add paginated report downloads API support and UI pagination to Downloads page

### DIFF
--- a/ui/src/pages/Downloads.tsx
+++ b/ui/src/pages/Downloads.tsx
@@ -3,10 +3,11 @@ import { Box, Button, Chip, CircularProgress, Stack, Tooltip, Typography } from 
 import type { ColumnsType } from 'antd/es/table';
 import GenericTable from '../components/UI/GenericTable';
 import { useApi } from '../hooks/useApi';
-import { getReportDownloadUrl, getReportRequests } from '../services/TicketService';
+import { getReportDownloadUrl, getReportDownloads } from '../services/TicketService';
 import CustomIconButton from '../components/UI/IconButton/CustomIconButton';
 import { formatDateTimeWithRelative } from '../utils/Utils';
 import Title from '../components/Title';
+import PaginationControls from '../components/PaginationControls';
 
 type ReportFilter = {
   key?: string;
@@ -42,19 +43,50 @@ type ReportRequestRow = {
 };
 
 const Downloads: React.FC = () => {
-  const { data, pending, apiHandler } = useApi<ReportRequestRow[]>();
-  const rows = React.useMemo(() => data ?? [], [data]);
+  const { data, pending, apiHandler } = useApi<any>();
+  const [rows, setRows] = React.useState<ReportRequestRow[]>([]);
+  const [page, setPage] = React.useState(1);
+  const [pageSize, setPageSize] = React.useState(10);
+  const [totalPages, setTotalPages] = React.useState(1);
   const [expandedRows, setExpandedRows] = React.useState<Record<string, boolean>>({});
 
   const load = React.useCallback(async () => {
-    await apiHandler(() => getReportRequests());
-  }, [apiHandler]);
+    await apiHandler(() => getReportDownloads({ page: page - 1, size: pageSize }));
+  }, [apiHandler, page, pageSize]);
 
   React.useEffect(() => {
     load();
     const id = setInterval(load, 10000);
     return () => clearInterval(id);
   }, [load]);
+
+  React.useEffect(() => {
+    const payload = data?.data;
+    const content = Array.isArray(payload?.content)
+      ? payload.content
+      : Array.isArray(payload?.items)
+        ? payload.items
+        : Array.isArray(payload?.data)
+          ? payload.data
+          : Array.isArray(payload)
+            ? payload
+            : [];
+
+    setRows(content);
+
+    const resolvedTotalPages =
+      typeof payload?.totalPages === 'number'
+        ? payload.totalPages
+        : typeof payload?.pages === 'number'
+          ? payload.pages
+          : Math.max(1, Math.ceil((payload?.totalElements || content.length || 0) / pageSize));
+
+    setTotalPages(Math.max(1, resolvedTotalPages));
+  }, [data, pageSize]);
+
+  React.useEffect(() => {
+    setExpandedRows({});
+  }, [rows]);
 
   const renderDateCell = React.useCallback((value?: string) => {
     if (!value) return '-';
@@ -252,8 +284,22 @@ const Downloads: React.FC = () => {
           dataSource={rows}
           columns={columns}
           loading={pending}
-          pagination={{ pageSize: 10, showSizeChanger: true }}
+          pagination={false}
         />
+        <div className="d-flex justify-content-end mt-3">
+          <PaginationControls
+            className="justify-content-between align-items-center mt-3 w-100"
+            page={page}
+            totalPages={totalPages}
+            onChange={(_, val) => setPage(val)}
+            pageSize={pageSize}
+            onPageSizeChange={(value) => {
+              setPage(1);
+              setPageSize(value);
+            }}
+            displayPagePosition
+          />
+        </div>
       </div>
     </div>
   );

--- a/ui/src/services/TicketService.ts
+++ b/ui/src/services/TicketService.ts
@@ -203,8 +203,19 @@ export function downloadTicketsReport({
     return axios.get(`${BASE_URL}/tickets/search/export/download?${params.toString()}`, signal ? { signal } : undefined);
 }
 
-export function getReportRequests() {
-    return axios.get(`${BASE_URL}/tickets/search/export/requests`);
+
+
+export interface ReportDownloadsParams {
+    page?: number;
+    size?: number;
+}
+
+export function getReportDownloads(params: ReportDownloadsParams = {}) {
+    const searchParams = new URLSearchParams();
+    if (typeof params.page === 'number') searchParams.append('page', String(params.page));
+    if (typeof params.size === 'number') searchParams.append('size', String(params.size));
+    const query = searchParams.toString();
+    return axios.get(`${BASE_URL}/reports/downloads${query ? `?${query}` : ''}`);
 }
 
 export function getReportDownloadUrl(downloadPath: string) {


### PR DESCRIPTION
### Motivation
- Replace the old unpaginated report requests list with a paginated downloads endpoint to support large result sets and server-side paging.
- Expose page and size parameters from the UI so users can navigate large download histories efficiently.

### Description
- Replace usage of `getReportRequests()` with a new `getReportDownloads(params)` service call and add a `ReportDownloadsParams` interface in `TicketService.ts` that builds `page`/`size` query params for `GET /reports/downloads`.
- Update `Downloads.tsx` to manage pagination state (`page`, `pageSize`, `totalPages`) and to call `getReportDownloads` with those params on load and polling.
- Parse multiple possible response shapes (`content`, `items`, `data`, or raw array`) and compute `totalPages` from `totalPages`, `pages`, or `totalElements` fallback, then populate `rows` state and reset row expansion when rows change.
- Disable the table's internal pagination (`pagination={false}`) and add the `PaginationControls` component wired to `page`/`pageSize` state and handlers, and keep the existing manual refresh and polling every 10s.

### Testing
- Ran a TypeScript build to validate typings and compilation, which succeeded.
- Executed the frontend test suite with `yarn test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15ddf9e9d88332a57030d834825f44)