### PR TITLE
Refactor download report DTOs and apply policy-scoped request parameters

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/controller/ReportsController.java
+++ b/api/src/main/java/com/ticketingSystem/api/controller/ReportsController.java
@@ -1,6 +1,7 @@
 package com.ticketingSystem.api.controller;
 
-import com.ticketingSystem.api.dto.DownloadRequestDto;
+import com.ticketingSystem.api.dto.DownloadReportRequestDto;
+import com.ticketingSystem.api.dto.DownloadReportResponseDto;
 import com.ticketingSystem.api.dto.LoginPayload;
 import com.ticketingSystem.api.dto.PaginationResponse;
 import com.ticketingSystem.api.dto.reports.CustomerSatisfactionReportDto;
@@ -255,28 +256,23 @@ public class ReportsController {
     }
 
     @GetMapping("/downloads")
-    public ResponseEntity<PaginationResponse<DownloadRequestDto>> getReportRequests(
+    public ResponseEntity<PaginationResponse<DownloadReportResponseDto>> getReportRequests(
             @AuthenticationPrincipal LoginPayload authenticatedUser,
 
-            @RequestParam(defaultValue = "0", name = "") int page,
-            @RequestParam(defaultValue = "10") int size,
-            @RequestParam(required = false) String requestedBy,
-            @RequestParam(required = false) String reportCode,
-            @RequestParam(required = false) String format,
-            @RequestParam(required = false) String requestedAt,
-
+            DownloadReportRequestDto requestDto,
             @RequestParam Map<String, String>allParams
     ) {
         List<PolicyRule> policyRules = policyEvaluationService.resolveScopedParams(authenticatedUser, allParams);
         Set<String> policyRulesParams = policyRules.stream().map(PolicyRule::getConditionKey).collect(Collectors.toSet());
-        Set<String> keys = allParams.keySet();
-        Pageable pageable = PageRequest.of(page, size);
+        requestDto.applyPolicyRuleParams(policyRulesParams, authenticatedUser);
 
-        PaginationResponse<DownloadRequestDto> response = reportService.getDownloadRequests(
-                requestedBy,
-                reportCode,
-                format,
-                requestedAt,
+        Pageable pageable = PageRequest.of(requestDto.getPage(), requestDto.getSize());
+
+        PaginationResponse<DownloadReportResponseDto> response = reportService.getDownloadRequests(
+                requestDto.getRequestedBy(),
+                requestDto.getReportCode(),
+                requestDto.getFormat(),
+                requestDto.getRequestedAt(),
                 pageable
         );
 

--- a/api/src/main/java/com/ticketingSystem/api/dto/DownloadReportRequestDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/DownloadReportRequestDto.java
@@ -1,0 +1,33 @@
+package com.ticketingSystem.api.dto;
+
+import com.ticketingSystem.api.dto.LoginPayload;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+
+import java.util.Set;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DownloadReportRequestDto {
+    private int page = 0;
+    private int size = 10;
+    private String requestedBy;
+    private String reportCode;
+    private String format;
+    private String requestedAt;
+
+    public void applyPolicyRuleParams(Set<String> policyRulesParams, LoginPayload authenticatedUser) {
+        if (policyRulesParams == null || policyRulesParams.isEmpty()) {
+            return;
+        }
+
+        if (policyRulesParams.contains("requestedBy")
+                && authenticatedUser != null
+                && StringUtils.hasText(authenticatedUser.getUserId())) {
+            this.requestedBy = authenticatedUser.getUserId();
+        }
+    }
+}

--- a/api/src/main/java/com/ticketingSystem/api/dto/DownloadReportResponseDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/DownloadReportResponseDto.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class DownloadRequestDto {
+public class DownloadReportResponseDto {
     private String requestId;
     private String reportCode;
     private String format;

--- a/api/src/main/java/com/ticketingSystem/api/service/ReportService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/ReportService.java
@@ -106,7 +106,7 @@ public class ReportService {
         };
     }
 
-    public PaginationResponse<DownloadRequestDto> getDownloadRequests(String requestedBy, String reportCode, String format, String requestedAt, Pageable pageable) {
+    public PaginationResponse<DownloadReportResponseDto> getDownloadRequests(String requestedBy, String reportCode, String format, String requestedAt, Pageable pageable) {
         LocalDateTime requestedFrom = null;
         LocalDateTime requestedTo = null;
         if (StringUtils.hasText(requestedAt)) {
@@ -115,10 +115,10 @@ public class ReportService {
             requestedTo = requestedFrom.plusDays(1);
         }
 
-        Page<DownloadRequestDto> p = reportRequestHistoryRepository
+        Page<DownloadReportResponseDto> p = reportRequestHistoryRepository
                 .findDownloadRequests(requestedBy, reportCode, format, requestedFrom, requestedTo, pageable)
                 .map(req -> {
-                    DownloadRequestDto dto = new DownloadRequestDto();
+                    DownloadReportResponseDto dto = new DownloadReportResponseDto();
                     dto.setRequestId(req.getRequestId());
                     dto.setReportCode(req.getReport() != null ? req.getReport().getReportCode() : null);
                     dto.setFormat(req.getOutputFormat());
@@ -131,7 +131,7 @@ public class ReportService {
                     dto.setStatus(req.getStatus());
                     if (StringUtils.hasText(req.getRequestedBy())) {
                         userService.getUserDetails(req.getRequestedBy()).ifPresent(user -> dto.setRequestedByDetails(
-                                new DownloadRequestDto.RequestedByDetails(user.getUserId(), user.getUsername(), user.getName())
+                                new DownloadReportResponseDto.RequestedByDetails(user.getUserId(), user.getUsername(), user.getName())
                         ));
                     }
 


### PR DESCRIPTION
### Motivation
- Centralize and clarify handling of `/reports/downloads` query parameters and apply policy-driven overrides to request filters before service invocation.
- Make response DTO name more explicit by renaming it to better reflect it is a response for report downloads.

### Description
- Renamed `DownloadRequestDto` to `DownloadReportResponseDto` and updated all usages in the controller and service to return `PaginationResponse<DownloadReportResponseDto>` from the downloads endpoint.
- Added a new request model `DownloadReportRequestDto` to bind query parameters `page`, `size`, `requestedBy`, `reportCode`, `format`, and `requestedAt` with defaults for `page` and `size`.
- Implemented `DownloadReportRequestDto.applyPolicyRuleParams(Set<String>, LoginPayload)` which applies policy-scoped condition keys (currently maps `requestedBy` to the authenticated user when `requestedBy` is policy-scoped).
- Updated `ReportsController#getReportRequests` to accept `DownloadReportRequestDto`, resolve policy rules via `policyEvaluationService`, call `requestDto.applyPolicyRuleParams(...)`, build `Pageable` from the DTO, and pass request fields into `reportService.getDownloadRequests(...)`.

### Testing
- Ran `./gradlew compileJava -q` in `api` to validate compilation and it failed due to local toolchain incompatibility with Java class file version (`Unsupported class file major version 69`), which is an environment issue and not source-level diagnostics caused by these changes.
- No additional automated tests were executed in this environment after the change due to the compile failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16e93b103c8332bb8e114183206e50)