### PR TITLE
Mark tickets as assignedBackFromFci when moving to ASSIGNED including historical PENDING_WITH_FCI

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/service/TicketService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/TicketService.java
@@ -750,8 +750,23 @@ public class TicketService {
         if (updatedStatus == TicketStatus.CLOSED) {
             applyClosedStatus(existing);
         }
-        if (previousStatus == TicketStatus.PENDING_WITH_FCI) {
-            existing.setAssignedBackFromFci(true);
+        boolean movingToAssigned = updatedStatus == TicketStatus.ASSIGNED;
+        if (!movingToAssigned && updatedStatusId != null) {
+            String updatedStatusCode = workflowService.getStatusCodeById(updatedStatusId);
+            movingToAssigned = TicketStatus.ASSIGNED.name().equalsIgnoreCase(updatedStatusCode);
+        }
+        if (movingToAssigned) {
+            String pendingWithFciStatusId = workflowService.getStatusIdByCode(TicketStatus.PENDING_WITH_FCI.name());
+            boolean wasEverPendingWithFci = previousStatus == TicketStatus.PENDING_WITH_FCI;
+            if (!wasEverPendingWithFci) {
+                List<StatusHistory> statusHistories = statusHistoryRepository.findByTicketOrderByTimestampAsc(existing);
+                wasEverPendingWithFci = statusHistories.stream().anyMatch(history ->
+                        Objects.equals(history.getCurrentStatus(), pendingWithFciStatusId)
+                                || TicketStatus.PENDING_WITH_FCI.name().equalsIgnoreCase(history.getCurrentStatus()));
+            }
+            if (wasEverPendingWithFci) {
+                existing.setAssignedBackFromFci(true);
+            }
         }
         if (updated.getSubCategory() != null) {
             existing.setSubCategory(updated.getSubCategory());


### PR DESCRIPTION
### Motivation
- Ensure `assignedBackFromFci` is set when a ticket transitions to `ASSIGNED` even if the immediate previous status is not `PENDING_WITH_FCI` by checking status history and status codes/ids.
- Make status detection robust when updates provide status ids instead of enum values so transitions are recognized correctly.

### Description
- Replace the previous single-check `previousStatus == TicketStatus.PENDING_WITH_FCI` with logic that determines whether the ticket is moving to `ASSIGNED` by inspecting `updatedStatus`, `updatedStatusId`, and the status code for the `updatedStatusId`.
- When moving to `ASSIGNED`, determine if the ticket was ever in `PENDING_WITH_FCI` by checking `previousStatus` first and then falling back to `statusHistoryRepository.findByTicketOrderByTimestampAsc(...)` to inspect historical status entries.
- If the ticket was ever `PENDING_WITH_FCI`, set `existing.setAssignedBackFromFci(true)`.

### Testing
- Ran the project's automated test suite with `mvn test` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16a1a7c424833295503dbb6fdcef50)