### PR TITLE
Set assignedBackFromFci when moving to ASSIGNED by checking historical PENDING_WITH_FCI status

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/service/TicketService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/TicketService.java
@@ -750,8 +750,21 @@ public class TicketService {
         if (updatedStatus == TicketStatus.CLOSED) {
             applyClosedStatus(existing);
         }
-        if (previousStatus == TicketStatus.PENDING_WITH_FCI) {
-            existing.setAssignedBackFromFci(true);
+        boolean movingToAssigned = updatedStatus == TicketStatus.ASSIGNED;
+        if (!movingToAssigned && updatedStatusId != null) {
+            String updatedStatusCode = workflowService.getStatusCodeById(updatedStatusId);
+            movingToAssigned = TicketStatus.ASSIGNED.name().equalsIgnoreCase(updatedStatusCode);
+        }
+        if (movingToAssigned) {
+            String pendingWithFciStatusId = workflowService.getStatusIdByCode(TicketStatus.PENDING_WITH_FCI.name());
+            boolean wasEverPendingWithFci = previousStatus == TicketStatus.PENDING_WITH_FCI;
+            if (!wasEverPendingWithFci) {
+                List<StatusHistory> statusHistories = statusHistoryRepository.findByTicketOrderByTimestampAsc(existing);
+                wasEverPendingWithFci = statusHistories.stream().anyMatch(history ->
+                        Objects.equals(history.getCurrentStatus(), pendingWithFciStatusId)
+                                || TicketStatus.PENDING_WITH_FCI.name().equalsIgnoreCase(history.getCurrentStatus()));
+            }
+            existing.setAssignedBackFromFci(wasEverPendingWithFci);
         }
         if (updated.getSubCategory() != null) {
             existing.setSubCategory(updated.getSubCategory());


### PR DESCRIPTION
### Motivation

- Ensure the `assignedBackFromFci` flag is preserved when a ticket transitions to `ASSIGNED` even if it was not immediately previously `PENDING_WITH_FCI`, by detecting historical `PENDING_WITH_FCI` state using status ids or history entries.

### Description

- Determine `movingToAssigned` from `updatedStatus` or by resolving `updatedStatusId` via `workflowService.getStatusCodeById`.
- When moving to `ASSIGNED`, compute `wasEverPendingWithFci` by checking `previousStatus` or scanning `statusHistoryRepository.findByTicketOrderByTimestampAsc(existing)` for a history entry matching the `PENDING_WITH_FCI` status id or code obtained from `workflowService.getStatusIdByCode`.
- Set `existing.setAssignedBackFromFci(wasEverPendingWithFci)` only when transitioning to `ASSIGNED`, replacing the previous simple `previousStatus == TicketStatus.PENDING_WITH_FCI` check.
- All other update logic (status id mapping, resolved/closed handling, category/subcategory/severity updates) remains unchanged.

### Testing

- Ran the project unit test suite with `mvn test` and the tests completed successfully.
- Verified the affected logic path by exercising transitions that resolve `updatedStatusId` and by checking status history lookups via existing tests, and no regressions were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16a1a7c424833295503dbb6fdcef50)