### PR TITLE
Add permission-aware filters to Downloads (frontend + backend)

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/controller/ReportsController.java
+++ b/api/src/main/java/com/ticketingSystem/api/controller/ReportsController.java
@@ -272,6 +272,7 @@ public class ReportsController {
                 requestDto.getRequestedBy(),
                 requestDto.getReportCode(),
                 requestDto.getFormat(),
+                requestDto.getStatus(),
                 requestDto.getRequestedAt(),
                 pageable
         );

--- a/api/src/main/java/com/ticketingSystem/api/dto/DownloadReportRequestDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/DownloadReportRequestDto.java
@@ -17,6 +17,7 @@ public class DownloadReportRequestDto {
     private String requestedBy;
     private String reportCode;
     private String format;
+    private String status;
     private String requestedAt;
 
     public void applyPolicyRuleParams(Set<String> policyRulesParams, LoginPayload authenticatedUser) {

--- a/api/src/main/java/com/ticketingSystem/api/service/ReportService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/ReportService.java
@@ -106,7 +106,7 @@ public class ReportService {
         };
     }
 
-    public PaginationResponse<DownloadReportResponseDto> getDownloadRequests(String requestedBy, String reportCode, String format, String requestedAt, Pageable pageable) {
+    public PaginationResponse<DownloadReportResponseDto> getDownloadRequests(String requestedBy, String reportCode, String format, String status, String requestedAt, Pageable pageable) {
         LocalDateTime requestedFrom = null;
         LocalDateTime requestedTo = null;
         if (StringUtils.hasText(requestedAt)) {
@@ -116,7 +116,7 @@ public class ReportService {
         }
 
         Page<DownloadReportResponseDto> p = reportRequestHistoryRepository
-                .findDownloadRequests(requestedBy, reportCode, format, requestedFrom, requestedTo, pageable)
+                .findDownloadRequests(requestedBy, reportCode, format, status, requestedFrom, requestedTo, pageable)
                 .map(req -> {
                     DownloadReportResponseDto dto = new DownloadReportResponseDto();
                     dto.setRequestId(req.getRequestId());

--- a/api/src/main/java/com/ticketingSystem/reportGenerator/repository/ReportRequestHistoryRepository.java
+++ b/api/src/main/java/com/ticketingSystem/reportGenerator/repository/ReportRequestHistoryRepository.java
@@ -18,6 +18,7 @@ public interface ReportRequestHistoryRepository extends JpaRepository<ReportRequ
             "WHERE (:requestedById IS NULL OR rrh.requested_by = :requestedById) " +
             "AND (:reportCode IS NULL OR rm.report_code = :reportCode) " +
             "AND (:format IS NULL OR rrh.output_format = :format) " +
+            "AND (:status IS NULL OR rrh.status = :status) " +
             "AND (:requestedFrom IS NULL OR rrh.requested_at >= :requestedFrom) " +
             "AND (:requestedTo IS NULL OR rrh.requested_at < :requestedTo) " +
             "ORDER BY rrh.requested_at DESC ",
@@ -26,12 +27,14 @@ public interface ReportRequestHistoryRepository extends JpaRepository<ReportRequ
                     "WHERE (:requestedById IS NULL OR rrh.requested_by = :requestedById) " +
                     "AND (:reportCode IS NULL OR rm.report_code = :reportCode) " +
                     "AND (:format IS NULL OR rrh.output_format = :format) " +
+                    "AND (:status IS NULL OR rrh.status = :status) " +
                     "AND (:requestedFrom IS NULL OR rrh.requested_at >= :requestedFrom) " +
                     "AND (:requestedTo IS NULL OR rrh.requested_at < :requestedTo)",
             nativeQuery = true)
     Page<ReportRequestHistory> findDownloadRequests(@Param("requestedById") String requestedBy,
                                                     @Param("reportCode") String reportCode,
                                                     @Param("format") String format,
+                                                    @Param("status") String status,
                                                     @Param("requestedFrom") LocalDateTime requestedFrom,
                                                     @Param("requestedTo") LocalDateTime requestedTo,
                                                   Pageable pageable);

--- a/ui/src/pages/Downloads.tsx
+++ b/ui/src/pages/Downloads.tsx
@@ -1,13 +1,16 @@
 import React, { useCallback, useEffect, useMemo } from 'react';
-import { Box, Button, Chip, CircularProgress, Stack, Tooltip, Typography } from '@mui/material';
+import { Box, Button, Chip, CircularProgress, SelectChangeEvent, Stack, Tooltip, Typography } from '@mui/material';
 import type { ColumnsType } from 'antd/es/table';
 import GenericTable from '../components/UI/GenericTable';
 import { useApi } from '../hooks/useApi';
 import { getReportDownloadUrl, getReportDownloads } from '../services/TicketService';
+import { fetchReportDefinitions } from '../services/ReportDefinitionService';
 import CustomIconButton from '../components/UI/IconButton/CustomIconButton';
-import { formatDateTimeWithRelative } from '../utils/Utils';
+import { formatDateTimeWithRelative, getDropdownOptions, getStatuses, getUserDetails } from '../utils/Utils';
 import Title from '../components/Title';
 import PaginationControls from '../components/PaginationControls';
+import GenericDropdown, { DropdownOption } from '../components/UI/Dropdown/GenericDropdown';
+import { checkFieldAccess } from '../utils/permissions';
 
 type ReportFilter = {
   key?: string;
@@ -44,15 +47,30 @@ type ReportRequestRow = {
 
 const Downloads: React.FC = () => {
   const { data, pending, apiHandler } = useApi<any>();
+  const { apiHandler: reportDefinitionsApiHandler } = useApi<any[]>();
   const [rows, setRows] = React.useState<ReportRequestRow[]>([]);
   const [page, setPage] = React.useState(1);
   const [pageSize, setPageSize] = React.useState(10);
   const [totalPages, setTotalPages] = React.useState(1);
   const [expandedRows, setExpandedRows] = React.useState<Record<string, boolean>>({});
+  const [reportOptions, setReportOptions] = React.useState<DropdownOption[]>([]);
+  const [statusOptions, setStatusOptions] = React.useState<DropdownOption[]>([]);
+  const [filters, setFilters] = React.useState({ reportCode: '', format: '', status: '', requestedBy: '' });
+  const showReportFilter = checkFieldAccess('downloads', 'report');
+  const showFormatFilter = checkFieldAccess('downloads', 'format');
+  const showStatusFilter = checkFieldAccess('downloads', 'status');
+  const showRequestedByFilter = checkFieldAccess('downloads', 'requestedBy');
 
   const load = useCallback(async () => {
-    await apiHandler(() => getReportDownloads({ page: page - 1, size: pageSize }));
-  }, [apiHandler, page, pageSize]);
+    await apiHandler(() => getReportDownloads({
+      page: page - 1,
+      size: pageSize,
+      reportCode: filters.reportCode || undefined,
+      format: filters.format || undefined,
+      status: filters.status || undefined,
+      requestedBy: filters.requestedBy || undefined,
+    }));
+  }, [apiHandler, filters, page, pageSize]);
 
   useEffect(() => {
     load();
@@ -77,6 +95,19 @@ const Downloads: React.FC = () => {
   useEffect(() => {
     setExpandedRows({});
   }, [rows]);
+  
+  useEffect(() => {
+    reportDefinitionsApiHandler(() => fetchReportDefinitions()).then((reportList) => {
+      setReportOptions([{ label: 'All', value: '' }, ...getDropdownOptions(reportList, 'reportCode', 'reportCode')]);
+    });
+    getStatuses().then((list) => {
+      setStatusOptions([{ label: 'All', value: '' }, ...getDropdownOptions(list, 'statusName', 'statusName')]);
+    });
+    const user = getUserDetails();
+    if (showRequestedByFilter && user?.userId) {
+      setFilters((prev) => ({ ...prev, requestedBy: user.userId }));
+    }
+  }, [showRequestedByFilter]);
 
   const renderDateCell = useCallback((value?: string) => {
     if (!value) return '-';
@@ -261,6 +292,10 @@ const Downloads: React.FC = () => {
     ],
     [expandedRows, getFilterValueByKey, parseFilters, renderDateCell, renderFilterChip],
   );
+  const handleFilterChange = (key: keyof typeof filters) => (event: SelectChangeEvent) => {
+    setPage(1);
+    setFilters((prev) => ({ ...prev, [key]: event.target.value }));
+  };
 
   return (
     <div className='d-flex w-100'>
@@ -269,6 +304,32 @@ const Downloads: React.FC = () => {
         <div className='d-flex justify-content-end'>
           <CustomIconButton icon="replay" onClick={load} disabled={pending} aria-label="Refresh" />
         </div>
+        <Stack direction="row" spacing={2} useFlexGap flexWrap="wrap" sx={{ mb: 2 }}>
+          {showReportFilter && (
+            <GenericDropdown label="Report" value={filters.reportCode} onChange={handleFilterChange('reportCode')} options={reportOptions} style={{ minWidth: 220 }} />
+          )}
+          {showFormatFilter && (
+            <GenericDropdown
+              label="Format"
+              value={filters.format}
+              onChange={handleFilterChange('format')}
+              options={[{ label: 'All', value: '' }, ...getDropdownOptions([{ label: 'PDF', value: 'PDF' }, { label: 'EXCEL', value: 'EXCEL' }], 'label', 'value')]}
+              style={{ minWidth: 180 }}
+            />
+          )}
+          {showStatusFilter && (
+            <GenericDropdown label="Status" value={filters.status} onChange={handleFilterChange('status')} options={statusOptions} style={{ minWidth: 220 }} />
+          )}
+          {showRequestedByFilter && (
+            <GenericDropdown
+              label="Requested By"
+              value={filters.requestedBy}
+              onChange={handleFilterChange('requestedBy')}
+              options={[{ label: 'My Requests', value: getUserDetails()?.userId || '' }, { label: 'All', value: '' }]}
+              style={{ minWidth: 220 }}
+            />
+          )}
+        </Stack>
         <GenericTable
           rowKey="requestId"
           dataSource={rows}

--- a/ui/src/services/ReportDefinitionService.ts
+++ b/ui/src/services/ReportDefinitionService.ts
@@ -1,0 +1,6 @@
+import axios from "axios";
+import { BASE_URL } from "./api";
+
+export function fetchReportDefinitions() {
+    return axios.get(`${BASE_URL}/report-definitions`);
+}

--- a/ui/src/services/TicketService.ts
+++ b/ui/src/services/TicketService.ts
@@ -208,12 +208,20 @@ export function downloadTicketsReport({
 export interface ReportDownloadsParams {
     page?: number;
     size?: number;
+    reportCode?: string;
+    format?: string;
+    status?: string;
+    requestedBy?: string;
 }
 
 export function getReportDownloads(params: ReportDownloadsParams = {}) {
     const searchParams = new URLSearchParams();
     if (typeof params.page === 'number') searchParams.append('page', String(params.page));
     if (typeof params.size === 'number') searchParams.append('size', String(params.size));
+    if (params.reportCode) searchParams.append('reportCode', params.reportCode);
+    if (params.format) searchParams.append('format', params.format);
+    if (params.status) searchParams.append('status', params.status);
+    if (params.requestedBy) searchParams.append('requestedBy', params.requestedBy);
     const query = searchParams.toString();
     return axios.get(`${BASE_URL}/reports/downloads${query ? `?${query}` : ''}`);
 }


### PR DESCRIPTION
### Motivation
- Provide users with permission-driven filters on the Downloads page (Report, Format, Status, Requested By) and apply those filters end-to-end so downloads can be queried from UI to API.

### Description
- Frontend: Added dropdown filter controls to `ui/src/pages/Downloads.tsx` rendered only when `checkFieldAccess('downloads', ...)` allows them, using the existing `GenericDropdown` UI component and `getDropdownOptions` utility to build option lists, and wired the selections into the fetch flow via the `useApi` hook (`useApi` is used for both download list and report-definition fetch). 
- Frontend: Added `ui/src/services/ReportDefinitionService.ts` to fetch report definitions for the Report filter and extended `ui/src/services/TicketService.ts` `getReportDownloads` to accept `reportCode`, `format`, `status`, and `requestedBy` query params.
- Backend: Added `status` to `DownloadReportRequestDto`, threaded `status` through `ReportsController` into `ReportService#getDownloadRequests`, and extended the `ReportRequestHistoryRepository` SQL and count query to filter by `status`.
- Implementation follows the requested patterns: used `GenericDropdown`, `getDropdownOptions` from `utils/Utils`, and `useApi` for API calls.

### Testing
- Ran UI tests for the Downloads target: `cd ui && npm run -s test -- Downloads --watch=false` (no tests matched; command exited successfully). 
- Attempted production frontend build: `cd ui && npm run -s build` failed in this environment due to missing dependency resolution for `react-i18next` (module not available here), so full build verification could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17e66c84bc8332bb24079d0481d53a)