### PR TITLE
Clean up deployment manifest version indexes

### DIFF
--- a/deployment/manifests/dev/dev-1.78.md
+++ b/deployment/manifests/dev/dev-1.78.md
@@ -33,12 +33,24 @@ r2351
 
 ## 2. Version Index
 
-This file is the single manifest for the `1.78` release line in `DEVELOPMENT`. Subversions are captured in this same file so readers can review the base release and follow-up UI/API subversions without opening separate manifest files.
+- **Release line:** `1.78` (DEVELOPMENT)
+- **Manifest purpose:** Single reference for the base release and follow-up UI/API subversions.
 
-| Version Type | Deployment Version | UI Version | API Version | Updated Date | Details Section |
-| --- | --- | --- | --- | --- | --- |
-| Base Version | dev-1.78 | 1.78 | 1.78 | 25-05-2026 | [Base Release Details](#5-changes-included) |
-| UI/API Sub Version | dev-1.78.2 | 1.78.2 | 1.78.2 | 30-05-2026 | [Sub Version Details](#6-sub-version-details) |
+### Version entries
+
+- **Base Version**
+  - Deployment Version: `dev-1.78`
+  - UI Version: `1.78`
+  - API Version: `1.78`
+  - Updated Date: 25-05-2026
+  - Details: [Base Release Details](#5-changes-included)
+
+- **UI/API Sub Version**
+  - Deployment Version: `dev-1.78.2`
+  - UI Version: `1.78.2`
+  - API Version: `1.78.2`
+  - Updated Date: 30-05-2026
+  - Details: [Sub Version Details](#6-sub-version-details)
 
 ---
 

--- a/deployment/manifests/production/prod-1.16.md
+++ b/deployment/manifests/production/prod-1.16.md
@@ -33,12 +33,24 @@ r2351
 
 ## 2. Version Index
 
-This file is the single manifest for the `1.16` release line in `PRODUCTION`. Subversions are captured in this same file so readers can review the base release and follow-up UI/API subversions without opening separate manifest files.
+- **Release line:** `1.16` (PRODUCTION)
+- **Manifest purpose:** Single reference for the base release and follow-up UI/API subversions.
 
-| Version Type | Deployment Version | UI Version | API Version | Updated Date | Details Section |
-| --- | --- | --- | --- | --- | --- |
-| Base Version | prod-1.16 | 1.16 | 1.16.1 | 25-05-2026 | [Base Release Details](#5-changes-included) |
-| UI/API Sub Version | prod-1.16.2 | 1.16.2 | 1.16.3 | 30-05-2026 | [Sub Version Details](#6-sub-version-details) |
+### Version entries
+
+- **Base Version**
+  - Deployment Version: `prod-1.16`
+  - UI Version: `1.16`
+  - API Version: `1.16.1`
+  - Updated Date: 25-05-2026
+  - Details: [Base Release Details](#5-changes-included)
+
+- **UI/API Sub Version**
+  - Deployment Version: `prod-1.16.2`
+  - UI Version: `1.16.2`
+  - API Version: `1.16.3`
+  - Updated Date: 30-05-2026
+  - Details: [Sub Version Details](#6-sub-version-details)
 
 ---
 

--- a/deployment/manifests/staging/stg-1.26.md
+++ b/deployment/manifests/staging/stg-1.26.md
@@ -33,12 +33,24 @@ r2351
 
 ## 2. Version Index
 
-This file is the single manifest for the `1.26` release line in `STAGING`. Subversions are captured in this same file so readers can review the base release and follow-up UI/API subversions without opening separate manifest files.
+- **Release line:** `1.26` (STAGING)
+- **Manifest purpose:** Single reference for the base release and follow-up UI/API subversions.
 
-| Version Type | Deployment Version | UI Version | API Version | Updated Date | Details Section |
-| --- | --- | --- | --- | --- | --- |
-| Base Version | stg-1.26 | 1.26 | 1.26 | 25-05-2026 | [Base Release Details](#5-changes-included) |
-| UI/API Sub Version | stg-1.26.1 | 1.26.1 | 1.26.1 | 30-05-2026 | [Sub Version Details](#6-sub-version-details) |
+### Version entries
+
+- **Base Version**
+  - Deployment Version: `stg-1.26`
+  - UI Version: `1.26`
+  - API Version: `1.26`
+  - Updated Date: 25-05-2026
+  - Details: [Base Release Details](#5-changes-included)
+
+- **UI/API Sub Version**
+  - Deployment Version: `stg-1.26.1`
+  - UI Version: `1.26.1`
+  - API Version: `1.26.1`
+  - Updated Date: 30-05-2026
+  - Details: [Sub Version Details](#6-sub-version-details)
 
 ---
 


### PR DESCRIPTION
### Motivation
- The existing version-index tables in several deployment manifests were dense and displayed version text as line-separated characters, making them hard to read. 
- The goal is to present version metadata clearly and compactly so readers can quickly see base/sub-version details for each environment.

### Description
- Replaced the `## 2. Version Index` tables in `deployment/manifests/dev/dev-1.78.md`, `deployment/manifests/staging/stg-1.26.md`, and `deployment/manifests/production/prod-1.16.md` with a concise bullet-based layout. 
- Each manifest now shows a short release-line summary and explicit `Base Version` and `UI/API Sub Version` entries using inline code for version identifiers and preserved details links. 
- All original metadata (UI/API versions, updated dates, and detail anchors) were retained and no other manifest sections were changed.

### Testing
- Ran `git diff --check` to validate there are no whitespace or formatting problems and it returned no issues. 
- Inspected the updated `## 2. Version Index` blocks in the three manifest files to confirm the new layout and content display correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c67e815e883329b71cf0128dec8ad)