### PR TITLE
Align DEV and PROD manifest UI/API change descriptions with STG

### DIFF
--- a/deployment/manifests/dev/dev-1.78.md
+++ b/deployment/manifests/dev/dev-1.78.md
@@ -179,16 +179,15 @@ Yes
 
 ##### UI Changes
 
-- Updated Downloads page to consume paginated API data from `useApi` state.
-- Updated report download request payload to send `format` instead of `outputFormat`.
+- Added pagination on Downloads page.
 - Added role-based access handling for Downloads page visibility and report requests.
 
 ##### API Changes
 
-- Added paginated download request retrieval using snake_case native query mapping.
+- Added paginated download request retrieval.
 - Added policy-scoped access checks for download report requests.
-- Updated assigned-back-from-FCI flag handling when tickets transition to Assigned.
-- Added v2 master ticket JRXML template with requestor contact filters.
+- Resolved bug for assignedBackFromFci flag handling when tickets transition to Assigned.
+- Added user details related column in the tickets download report.
 
 ##### DB Changes
 

--- a/deployment/manifests/production/prod-1.16.md
+++ b/deployment/manifests/production/prod-1.16.md
@@ -179,16 +179,15 @@ Yes
 
 ##### UI Changes
 
-- Updated Downloads page to consume paginated API data from `useApi` state.
-- Updated report download request payload to send `format` instead of `outputFormat`.
+- Added pagination on Downloads page.
 - Added role-based access handling for Downloads page visibility and report requests.
 
 ##### API Changes
 
-- Added paginated download request retrieval using snake_case native query mapping.
+- Added paginated download request retrieval.
 - Added policy-scoped access checks for download report requests.
-- Updated assigned-back-from-FCI flag handling when tickets transition to Assigned.
-- Added v2 master ticket JRXML template with requestor contact filters.
+- Resolved bug for assignedBackFromFci flag handling when tickets transition to Assigned.
+- Added user details related column in the tickets download report.
 
 ##### DB Changes
 


### PR DESCRIPTION
### Motivation

- Ensure manifest change descriptions are consistent across environments so DEV and PROD reflect the same UI/API/reporting changes documented in STG.

### Description

- Updated the UI and API change blocks in `deployment/manifests/dev/dev-1.78.md` to match the revised staging wording (pagination on Downloads page, role-based access, paginated retrieval, policy-scoped checks, assignedBackFromFci fix, and user-details column in ticket download report).
- Updated the UI and API change blocks in `deployment/manifests/production/prod-1.16.md` with the same wording as above.
- The edits make DEV and PROD subversion change entries consistent with `deployment/manifests/staging/stg-1.26.md`.

### Testing

- Ran `git diff --check` to validate there are no obvious whitespace or diff errors and it passed.
- Ran a Python block-comparison script that extracts and prints the `##### UI Changes` through `##### DB Changes` sections from the staging, dev, and production manifests to verify the blocks match, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c7bce6bdc8332906a55feb04216c8)