### PR TITLE
Add Nagios breached ticket count metrics

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/config/ExternalPathForwardingFilter.java
+++ b/api/src/main/java/com/ticketingSystem/api/config/ExternalPathForwardingFilter.java
@@ -22,7 +22,10 @@ public class ExternalPathForwardingFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getRequestURI().substring(request.getContextPath().length());
-        return !path.startsWith("/ext/") || path.startsWith("/ext/auth") || path.startsWith("/ext/ping");
+        return !path.startsWith("/ext/")
+                || path.startsWith("/ext/auth")
+                || path.startsWith("/ext/nagios")
+                || path.startsWith("/ext/ping");
     }
 
     @Override

--- a/api/src/main/java/com/ticketingSystem/api/config/SecurityConfig.java
+++ b/api/src/main/java/com/ticketingSystem/api/config/SecurityConfig.java
@@ -56,7 +56,8 @@ public class SecurityConfig {
                         "auth/login/sso", "auth/sso", "auth/session",
                         "/m/auth/token", "/helpdesk/m/auth/token",
                         "/ext/auth/token", "/helpdesk/ext/auth/token",
-                        "/ext/nagios/ticket-sla", "/helpdesk/ext/nagios/ticket-sla").permitAll()
+                        "/ext/nagios/ticket-sla", "/helpdesk/ext/nagios/ticket-sla",
+                        "/ext/nagios/ticket-sla/**", "/helpdesk/ext/nagios/ticket-sla/**").permitAll()
                 .requestMatchers("/public/**").permitAll()
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .anyRequest().authenticated()

--- a/api/src/main/java/com/ticketingSystem/api/controller/NagiosMonitoringController.java
+++ b/api/src/main/java/com/ticketingSystem/api/controller/NagiosMonitoringController.java
@@ -1,16 +1,19 @@
 package com.ticketingSystem.api.controller;
 
+import com.ticketingSystem.api.dto.nagios.NagiosBreachedTicketsCountDto;
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaRequestDto;
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaSnapshotDto;
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaSummaryDto;
 import com.ticketingSystem.api.service.NagiosTicketSlaService;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 
 @RestController
-@RequestMapping("/public/nagios")
+@RequestMapping({"/public/nagios", "/ext/nagios"})
 public class NagiosMonitoringController {
     private final NagiosTicketSlaService nagiosTicketSlaService;
 
@@ -28,6 +31,15 @@ public class NagiosMonitoringController {
     public NagiosTicketSlaSnapshotDto getTicketSlaSnapshot() {
 //        Integer limit = request != null ? request.getLimit() : null;
         return nagiosTicketSlaService.fetchSnapshot(50);
+    }
+
+    @GetMapping("/ticket-sla/breached-count")
+    public NagiosBreachedTicketsCountDto getBreachedTicketsCountInLastNDays(
+            @RequestParam("days") Integer days) {
+        if (days == null || days <= 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "days must be greater than 0");
+        }
+        return nagiosTicketSlaService.fetchBreachedTicketsCountInLastNDays(days);
     }
 
     @GetMapping("/ticket-sla/summary")

--- a/api/src/main/java/com/ticketingSystem/api/dto/nagios/NagiosBreachedTicketsCountDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/nagios/NagiosBreachedTicketsCountDto.java
@@ -1,0 +1,9 @@
+package com.ticketingSystem.api.dto.nagios;
+
+import java.time.Instant;
+
+public record NagiosBreachedTicketsCountDto(String service,
+                                            Instant generatedAt,
+                                            int days,
+                                            long breachedTicketsCount) {
+}

--- a/api/src/main/java/com/ticketingSystem/api/dto/nagios/NagiosTicketSlaSummaryDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/nagios/NagiosTicketSlaSummaryDto.java
@@ -16,6 +16,10 @@ public record NagiosTicketSlaSummaryDto(String service,
                                         @JsonProperty("totalTicketsRaisedTillNow")
                                         long totalTickets,
                                         long breachedTickets,
+                                        @JsonProperty("Breached tickets in last 1 day")
+                                        long breachedTicketsInLast1Day,
+                                        @JsonProperty("Breached tickets in last 3 days")
+                                        long breachedTicketsInLast3Days,
                                         long nonBreachedTickets,
                                         BigDecimal breachPercentage,
                                         BigDecimal compliancePercentage,

--- a/api/src/main/java/com/ticketingSystem/api/repository/TicketSlaRepository.java
+++ b/api/src/main/java/com/ticketingSystem/api/repository/TicketSlaRepository.java
@@ -83,4 +83,15 @@ public interface TicketSlaRepository extends JpaRepository<TicketSla, String> {
                                                       @Param("toDateExclusive") LocalDateTime toDateExclusive);
 
     long countByBreachedByMinutesGreaterThan(Long breachedByMinutes);
+
+    @Query("""
+            SELECT COUNT(sla)
+            FROM TicketSla sla
+            JOIN sla.ticket t
+            WHERE COALESCE(sla.breachedByMinutes, 0) > 0
+              AND t.reportedDate >= :fromDate
+              AND t.reportedDate < :toDateExclusive
+            """)
+    long countBreachedTicketsReportedBetween(@Param("fromDate") LocalDateTime fromDate,
+                                             @Param("toDateExclusive") LocalDateTime toDateExclusive);
 }

--- a/api/src/main/java/com/ticketingSystem/api/service/NagiosTicketSlaService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/NagiosTicketSlaService.java
@@ -1,5 +1,6 @@
 package com.ticketingSystem.api.service;
 
+import com.ticketingSystem.api.dto.nagios.NagiosBreachedTicketsCountDto;
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaRecordDto;
 import com.ticketingSystem.api.dto.nagios.NagiosTicketSlaSnapshotDto;
 import com.ticketingSystem.api.dto.nagios.NagiosSeveritySlaAggregateView;
@@ -61,6 +62,8 @@ public class NagiosTicketSlaService {
 
         long totalTickets = aggregate.totalTickets();
         long breachedTickets = aggregate.breachedTickets();
+        long breachedTicketsInLast1Day = getBreachedTicketsCountInLastNDays(1);
+        long breachedTicketsInLast3Days = getBreachedTicketsCountInLastNDays(3);
         long nonBreachedTickets = Math.max(totalTickets - breachedTickets, 0);
 
         BigDecimal breachPercentage = calculatePercentage(breachedTickets, totalTickets);
@@ -78,6 +81,8 @@ public class NagiosTicketSlaService {
                 toDateInclusive,
                 totalTickets,
                 breachedTickets,
+                breachedTicketsInLast1Day,
+                breachedTicketsInLast3Days,
                 nonBreachedTickets,
                 breachPercentage,
                 compliancePercentage,
@@ -89,6 +94,23 @@ public class NagiosTicketSlaService {
         );
     }
 
+    public NagiosBreachedTicketsCountDto fetchBreachedTicketsCountInLastNDays(int days) {
+        return new NagiosBreachedTicketsCountDto(
+                "ticketing-system",
+                Instant.now(),
+                days,
+                getBreachedTicketsCountInLastNDays(days)
+        );
+    }
+
+    public long getBreachedTicketsCountInLastNDays(int days) {
+        if (days <= 0) {
+            throw new IllegalArgumentException("days must be greater than 0");
+        }
+        LocalDateTime toDateExclusive = LocalDateTime.now();
+        LocalDateTime fromDateTime = toDateExclusive.minusDays(days);
+        return ticketSlaRepository.countBreachedTicketsReportedBetween(fromDateTime, toDateExclusive);
+    }
 
     public NagiosTicketSlaSummaryDto fetchSummaryDetailed(LocalDate fromDate, LocalDate toDate) {
         LocalDate effectiveToDate = toDate != null ? toDate : LocalDate.now();
@@ -100,6 +122,8 @@ public class NagiosTicketSlaService {
 
         long totalTickets = aggregate.totalTickets();
         long breachedTickets = aggregate.breachedTickets();
+        long breachedTicketsInLast1Day = getBreachedTicketsCountInLastNDays(1);
+        long breachedTicketsInLast3Days = getBreachedTicketsCountInLastNDays(3);
         long nonBreachedTickets = Math.max(totalTickets - breachedTickets, 0);
 
         BigDecimal breachPercentage = calculatePercentage(breachedTickets, totalTickets);
@@ -117,6 +141,8 @@ public class NagiosTicketSlaService {
                 toDateInclusive,
                 totalTickets,
                 breachedTickets,
+                breachedTicketsInLast1Day,
+                breachedTicketsInLast3Days,
                 nonBreachedTickets,
                 breachPercentage,
                 compliancePercentage,


### PR DESCRIPTION
### Motivation
- Expose breached-ticket counts for recent windows in Nagios monitoring output and provide a reusable API to fetch breached counts for an arbitrary N-day window.

### Description
- Add `NagiosBreachedTicketsCountDto` and a new endpoint `GET /public/nagios/ticket-sla/breached-count?days=N` (also routed under `/ext/nagios`) to return the breached-count for N days.
- Add service methods `fetchBreachedTicketsCountInLastNDays(int)` and `getBreachedTicketsCountInLastNDays(int)`, and wire them into `NagiosTicketSlaService` so the code can reuse the logic.
- Add repository query `countBreachedTicketsReportedBetween(LocalDateTime, LocalDateTime)` to `TicketSlaRepository` and use it to compute N-day breached counts.
- Include two new attributes in the Nagios summary DTO: `"Breached tickets in last 1 day"` and `"Breached tickets in last 3 days"` by updating `NagiosTicketSlaSummaryDto` and populating them from the service.
- Ensure external Nagios endpoints remain public by permitting `/ext/nagios/ticket-sla` and variants in `SecurityConfig`, and prevent forwarding of `/ext/nagios` in `ExternalPathForwardingFilter`; also add `/ext/nagios` mapping to the controller.

### Testing
- Ran `compileJava` successfully with Java 17 using `JAVA_HOME=/root/.local/share/mise/installs/java/17.0.2 PATH=... ./api/gradlew -p api compileJava`, which succeeded.
- Attempted `./api/gradlew -p api test --tests '*Nagios*'` with Java 17, but test compilation failed during `compileTestJava` due to unrelated existing test signature mismatches in `TicketServiceTest` (not introduced by this change); tests therefore did not complete successfully.
- Attempted tests with the default environment Java (Java 25) and Gradle/Groovy failed early with `Unsupported class file major version 69`, so running tests without forcing Java 17 is not supported in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d22bbd268833289897093aafbd8f7)