### PR TITLE
Add division-wise pending tickets dashboard chart

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/dto/reports/SupportDashboardDivisionPendingCountDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/reports/SupportDashboardDivisionPendingCountDto.java
@@ -1,0 +1,15 @@
+package com.ticketingSystem.api.dto.reports;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SupportDashboardDivisionPendingCountDto {
+    private String division;
+    private long count;
+}

--- a/api/src/main/java/com/ticketingSystem/api/dto/reports/SupportDashboardSummaryDto.java
+++ b/api/src/main/java/com/ticketingSystem/api/dto/reports/SupportDashboardSummaryDto.java
@@ -20,5 +20,6 @@ public class SupportDashboardSummaryDto {
     private List<SupportDashboardSlaCompliancePointDto> slaCompliance;
     private List<SupportDashboardTicketVolumePointDto> ticketVolume;
     private List<SupportDashboardAssigneeCountDto> assignedTicketsByAssignee;
+    private List<SupportDashboardDivisionPendingCountDto> pendingTicketsByDivision;
     private Long unresolvedBreachedTickets;
 }

--- a/api/src/main/java/com/ticketingSystem/api/repository/TicketRepository.java
+++ b/api/src/main/java/com/ticketingSystem/api/repository/TicketRepository.java
@@ -108,6 +108,50 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
             @Param("districtCode") String districtCode,
             @Param("issueTypeId") String issueTypeId);
 
+
+    @Query(value = """
+                SELECT
+                    COALESCE(NULLIF(dm.division_name, ''), NULLIF(t.division, ''), 'Unassigned') AS division,
+                    COUNT(*) AS count
+                FROM tickets t
+                LEFT JOIN division_master dm ON dm.division_id = t.division
+                WHERE t.status IN (:statuses)
+                  AND (:assignedTo IS NULL OR LOWER(t.assigned_to) = LOWER(:assignedTo))
+                  AND (:parameterAssignedTo IS NULL OR LOWER(t.assigned_to) = LOWER(:parameterAssignedTo))
+                  AND (:parameterAssignedBy IS NULL OR LOWER(t.assigned_by) = LOWER(:parameterAssignedBy))
+                  AND (:parameterUpdatedBy IS NULL OR LOWER(t.updated_by) = LOWER(:parameterUpdatedBy))
+                  AND (:parameterCreatedBy IS NULL OR LOWER(t.created_by) = LOWER(:parameterCreatedBy))
+                  AND (:parameterRequestedBy IS NULL OR LOWER(t.user_id) = LOWER(:parameterRequestedBy))
+                  AND (:zoneCode IS NULL OR LOWER(t.zone_code) = LOWER(:zoneCode))
+                  AND (:regionCode IS NULL OR LOWER(t.region_code) = LOWER(:regionCode))
+                  AND (:districtCode IS NULL OR LOWER(t.district_code) = LOWER(:districtCode))
+                  AND (:issueTypeId IS NULL OR LOWER(t.issue_type_id) = LOWER(:issueTypeId))
+                  AND (:categoryId IS NULL OR LOWER(t.category) = LOWER(:categoryId))
+                  AND (:subCategoryId IS NULL OR LOWER(t.sub_category) = LOWER(:subCategoryId))
+                  AND (:divisionId IS NULL OR LOWER(t.division) = LOWER(:divisionId))
+                  AND (:fromDate IS NULL OR t.reported_date >= :fromDate)
+                  AND (:toDate IS NULL OR t.reported_date <= :toDate)
+                GROUP BY COALESCE(NULLIF(dm.division_name, ''), NULLIF(t.division, ''), 'Unassigned')
+                ORDER BY count DESC, division ASC
+            """, nativeQuery = true)
+    List<DivisionPendingCountProjection> countPendingTicketsByDivisionWithFilters(
+            @Param("statuses") Collection<String> statuses,
+            @Param("assignedTo") String assignedTo,
+            @Param("fromDate") LocalDateTime fromDate,
+            @Param("toDate") LocalDateTime toDate,
+            @Param("parameterAssignedTo") String parameterAssignedTo,
+            @Param("parameterAssignedBy") String parameterAssignedBy,
+            @Param("parameterUpdatedBy") String parameterUpdatedBy,
+            @Param("parameterCreatedBy") String parameterCreatedBy,
+            @Param("parameterRequestedBy") String userId,
+            @Param("zoneCode") String zoneCode,
+            @Param("regionCode") String regionCode,
+            @Param("districtCode") String districtCode,
+            @Param("issueTypeId") String issueTypeId,
+            @Param("categoryId") String categoryId,
+            @Param("subCategoryId") String subCategoryId,
+            @Param("divisionId") String divisionId);
+
     @Query("SELECT t.mode AS mode, COUNT(t) AS count FROM Ticket t GROUP BY t.mode")
     List<ModeCountProjection> countTicketsByMode();
 
@@ -551,6 +595,12 @@ public interface TicketRepository extends JpaRepository<Ticket, String> {
 
     interface AssignedToCountProjection {
         String getAssignedTo();
+
+        Long getCount();
+    }
+
+    interface DivisionPendingCountProjection {
+        String getDivision();
 
         Long getCount();
     }

--- a/api/src/main/java/com/ticketingSystem/api/service/ReportService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/ReportService.java
@@ -9,6 +9,7 @@ import com.ticketingSystem.api.dto.reports.ResolutionCategoryStatDto;
 import com.ticketingSystem.api.dto.reports.SlaPerformanceReportDto;
 import com.ticketingSystem.api.dto.reports.SupportDashboardCategorySummaryDto;
 import com.ticketingSystem.api.dto.reports.SupportDashboardAssigneeCountDto;
+import com.ticketingSystem.api.dto.reports.SupportDashboardDivisionPendingCountDto;
 import com.ticketingSystem.api.dto.reports.SupportDashboardOpenResolvedDto;
 import com.ticketingSystem.api.dto.reports.SupportDashboardSlaCompliancePointDto;
 import com.ticketingSystem.api.dto.reports.SupportDashboardSummaryDto;
@@ -87,6 +88,13 @@ public class ReportService {
 
     private static final DateTimeFormatter DAY_FORMATTER = DateTimeFormatter.ofPattern("dd MMM");
     private static final DateTimeFormatter MONTH_FORMATTER = DateTimeFormatter.ofPattern("MMM yyyy");
+    private static final List<String> PENDING_TICKET_STATUS_NAMES = List.of(
+            TicketStatus.PENDING.name(),
+            TicketStatus.ON_HOLD.name(),
+            TicketStatus.PENDING_WITH_REQUESTER.name(),
+            TicketStatus.PENDING_WITH_SERVICE_PROVIDER.name(),
+            TicketStatus.PENDING_WITH_FCI.name()
+    );
 
     private ParameterCriteria resolveParameterCriteria(String parameterKey, String parameterValue) {
         if (!StringUtils.hasText(parameterKey) || !StringUtils.hasText(parameterValue)) {
@@ -223,6 +231,7 @@ public class ReportService {
         List<SupportDashboardSlaCompliancePointDto> slaCompliance = buildSlaComplianceTrend(timeSeries);
         List<SupportDashboardTicketVolumePointDto> ticketVolume = buildTicketVolumeTrend(timeSeries);
         List<SupportDashboardAssigneeCountDto> assignedTicketsByAssignee = buildAssignedTicketsByAssignee(dateRange, null);
+        List<SupportDashboardDivisionPendingCountDto> pendingTicketsByDivision = buildPendingTicketsByDivision(dateRange, null, null, null, null);
         long unresolvedBreachedTickets = buildUnresolvedBreachedCount(dateRange, null);
 
         return SupportDashboardSummaryDto.builder()
@@ -234,6 +243,7 @@ public class ReportService {
                 .slaCompliance(slaCompliance)
                 .ticketVolume(ticketVolume)
                 .assignedTicketsByAssignee(assignedTicketsByAssignee)
+                .pendingTicketsByDivision(pendingTicketsByDivision)
                 .unresolvedBreachedTickets(unresolvedBreachedTickets)
                 .build();
     }
@@ -284,6 +294,13 @@ public class ReportService {
         List<SupportDashboardSlaCompliancePointDto> slaCompliance = buildSlaComplianceTrend(timeSeries, parameterCriteria);
         List<SupportDashboardTicketVolumePointDto> ticketVolume = buildTicketVolumeTrend(timeSeries, parameterCriteria);
         List<SupportDashboardAssigneeCountDto> assignedTicketsByAssignee = buildAssignedTicketsByAssignee(dateRange, parameterCriteria);
+        List<SupportDashboardDivisionPendingCountDto> pendingTicketsByDivision = buildPendingTicketsByDivision(
+                dateRange,
+                parameterCriteria,
+                optionalParam(allParams, "categoryId"),
+                optionalParam(allParams, "subCategoryId"),
+                optionalParam(allParams, "divisionId")
+        );
         long unresolvedBreachedTickets = buildUnresolvedBreachedCount(dateRange, parameterCriteria);
 
         return SupportDashboardSummaryDto.builder()
@@ -295,8 +312,51 @@ public class ReportService {
                 .slaCompliance(slaCompliance)
                 .ticketVolume(ticketVolume)
                 .assignedTicketsByAssignee(assignedTicketsByAssignee)
+                .pendingTicketsByDivision(pendingTicketsByDivision)
                 .unresolvedBreachedTickets(unresolvedBreachedTickets)
                 .build();
+    }
+
+    private List<SupportDashboardDivisionPendingCountDto> buildPendingTicketsByDivision(DateRange dateRange,
+                                                                                                  ParameterCriteria parameterCriteria,
+                                                                                                  String categoryId,
+                                                                                                  String subCategoryId,
+                                                                                                  String divisionId) {
+        List<TicketRepository.DivisionPendingCountProjection> projections = ticketRepository.countPendingTicketsByDivisionWithFilters(
+                PENDING_TICKET_STATUS_NAMES,
+                null,
+                dateRange.from(),
+                dateRange.to(),
+                parameterCriteria != null ? parameterCriteria.assignedTo() : null,
+                parameterCriteria != null ? parameterCriteria.assignedBy() : null,
+                parameterCriteria != null ? parameterCriteria.updatedBy() : null,
+                parameterCriteria != null ? parameterCriteria.createdBy() : null,
+                parameterCriteria != null ? parameterCriteria.userId() : null,
+                parameterCriteria != null ? parameterCriteria.zoneCode() : null,
+                parameterCriteria != null ? parameterCriteria.regionCode() : null,
+                parameterCriteria != null ? parameterCriteria.districtCode() : null,
+                parameterCriteria != null ? parameterCriteria.issueTypeId() : null,
+                categoryId,
+                subCategoryId,
+                divisionId
+        );
+
+        return projections.stream()
+                .map(projection -> SupportDashboardDivisionPendingCountDto.builder()
+                        .division(StringUtils.hasText(projection.getDivision()) ? projection.getDivision() : "Unassigned")
+                        .count(Optional.ofNullable(projection.getCount()).orElse(0L))
+                        .build())
+                .sorted(Comparator.comparingLong(SupportDashboardDivisionPendingCountDto::getCount).reversed())
+                .toList();
+    }
+
+    private String optionalParam(MultiValueMap<String, String> allParams, String key) {
+        if (allParams == null || !StringUtils.hasText(key)) {
+            return null;
+        }
+
+        String value = allParams.getFirst(key);
+        return StringUtils.hasText(value) ? value : null;
     }
 
     private List<SupportDashboardAssigneeCountDto> buildAssignedTicketsByAssignee(DateRange dateRange,

--- a/ui/src/pages/SupportDashboard.tsx
+++ b/ui/src/pages/SupportDashboard.tsx
@@ -856,6 +856,11 @@ const SupportDashboard: React.FC<SupportDashboardProps> = ({
           tickets: typeof entry?.tickets === "number" ? entry.tickets : 0,
         }));
 
+        const pendingTicketsByDivision = (dashboardData.pendingTicketsByDivision ?? []).map((entry: any) => ({
+          division: typeof entry?.division === "string" && entry.division.trim().length > 0 ? entry.division : "Unassigned",
+          count: typeof entry?.count === "number" ? entry.count : 0,
+        }));
+
         const formatDisplayDate = (value: string | Date) =>
           new Date(value).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
 
@@ -909,6 +914,10 @@ const SupportDashboard: React.FC<SupportDashboardProps> = ({
           ["Ticket Volume"],
           ["Period", "Tickets"],
           ...(ticketVolume.length ? ticketVolume.map((row) => [row.label, row.tickets]) : [["No data", 0]]),
+          [],
+          ["Division-wise Pending Tickets"],
+          ["Division", "Pending Tickets"],
+          ...(pendingTicketsByDivision.length ? pendingTicketsByDivision.map((row) => [row.division, row.count]) : [["No data", 0]]),
         );
 
         const downloadExcel = () => {
@@ -1000,6 +1009,12 @@ const SupportDashboard: React.FC<SupportDashboardProps> = ({
             title: "Ticket Volume",
             head: ["Period", "Tickets"],
             rows: ticketVolume.length ? ticketVolume.map((row) => [row.label, row.tickets]) : [["No data", 0]],
+          });
+
+          sections.push({
+            title: "Division-wise Pending Tickets",
+            head: ["Division", "Pending Tickets"],
+            rows: pendingTicketsByDivision.length ? pendingTicketsByDivision.map((row) => [row.division, row.count]) : [["No data", 0]],
           });
 
           let startY = 24;
@@ -1610,6 +1625,40 @@ const SupportDashboard: React.FC<SupportDashboardProps> = ({
     [ticketVolumeSeries, t],
   );
 
+  const divisionPendingTicketsBarOptions = React.useMemo(() => {
+    const data = (summaryData?.pendingTicketsByDivision ?? [])
+      .map((entry: any) => ({
+        division: typeof entry?.division === "string" && entry.division.trim().length > 0 ? entry.division : "Unassigned",
+        count: typeof entry?.count === "number" ? entry.count : 0,
+      }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 15);
+
+    return {
+      tooltip: { trigger: "axis", axisPointer: { type: "shadow" } },
+      grid: { top: 20, bottom: 20, left: 160, right: 40 },
+      xAxis: { type: "value" },
+      yAxis: {
+        type: "category",
+        inverse: true,
+        data: data.map((entry) => entry.division),
+        axisTick: { show: false },
+      },
+      series: [
+        {
+          name: "Pending Tickets",
+          type: "bar",
+          data: data.map((entry) => entry.count),
+          label: {
+            show: true,
+            position: "right",
+          },
+          itemStyle: { color: "#ff9800" },
+        },
+      ],
+    };
+  }, [summaryData?.pendingTicketsByDivision]);
+
   const activeScopeLabel = t(scopeLabels[activeScope]);
 
   const misReportGeneratorComponent = <MISReportGenerator
@@ -1916,6 +1965,18 @@ const SupportDashboard: React.FC<SupportDashboardProps> = ({
                 </Card>
               </div>
             ) : null}
+            <div className="col-12 col-xl-6">
+              <Card className="h-100 border-0 shadow-sm">
+                <CardContent className="h-100" style={{ minHeight: 320 }}>
+                  <Typography variant="h6" className="fw-semibold mb-3" sx={{ fontSize: 18 }}>
+                    Division-wise Pending Tickets
+                  </Typography>
+                  <Box sx={{ height: "90%", minHeight: 260 }}>
+                    <ReactECharts option={divisionPendingTicketsBarOptions} style={{ height: "100%", width: "100%" }} notMerge lazyUpdate />
+                  </Box>
+                </CardContent>
+              </Card>
+            </div>
             {showAssignedTicketsBarRace ? (
               <div className="col-12 col-xl-6">
                 <Card className="h-100 border-0 shadow-sm">

--- a/ui/src/types/reports.ts
+++ b/ui/src/types/reports.ts
@@ -201,6 +201,11 @@ export interface SupportDashboardAssigneeCount {
     count: number;
 }
 
+export interface SupportDashboardDivisionPendingCount {
+    division: string;
+    count: number;
+}
+
 export interface SupportDashboardSummaryResponse {
     allTickets?: SupportDashboardSummarySectionDto | null;
     myWorkload?: SupportDashboardSummarySectionDto | null;
@@ -210,6 +215,7 @@ export interface SupportDashboardSummaryResponse {
     slaCompliance?: SupportDashboardSlaCompliancePoint[];
     ticketVolume?: SupportDashboardTicketVolumePoint[];
     assignedTicketsByAssignee?: SupportDashboardAssigneeCount[];
+    pendingTicketsByDivision?: SupportDashboardDivisionPendingCount[];
     unresolvedBreachedTickets?: number;
 }
 


### PR DESCRIPTION
### Motivation
- Provide a Division-wise view of pending tickets on the Support Dashboard to help stakeholders see which divisions have most pending work. 
- Expose the data from the backend so the UI can render the same graph and include the counts in exports, following the existing dashboard API/UX patterns.

### Description
- Added a new DTO `SupportDashboardDivisionPendingCountDto` and exposed `pendingTicketsByDivision` on the `SupportDashboardSummaryDto` response so the summary API carries division/count pairs.
- Added a native repository query `countPendingTicketsByDivisionWithFilters(...)` in `TicketRepository` that groups pending-like ticket statuses by division, joins `division_master` for display names, and accepts the same filter parameters used by other dashboard endpoints.
- Wired the aggregation into `ReportService` via a new helper `buildPendingTicketsByDivision(...)`, added `PENDING_TICKET_STATUS_NAMES`, and included the result in both unfiltered and filtered `getSupportDashboardSummary*` flows.
- Updated the UI: extended `ui/src/types/reports.ts` with `SupportDashboardDivisionPendingCount`, added a horizontal bar chart (`ReactECharts`) titled "Division-wise Pending Tickets" to `SupportDashboard.tsx`, and included the division counts in Excel/PDF exports.

### Testing
- Frontend unit tests: ran `npm test -- --watchAll=false SupportDashboard` and the `SupportDashboard` test suite passed.
- Backend unit tests: `./gradlew test` could not run in this environment due to a Java/Gradle compatibility issue (`Unsupported class file major version 69`).
- Frontend build: `npm run build` could not complete in this environment because `i18next` was not present in `ui/node_modules`, so a full production build was not verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d399ab2f88332ad4ccc3ffffaa76b)