### PR TITLE
Gate division dashboard graph by permission

### DIFF
--- a/ui/src/pages/SupportDashboard.tsx
+++ b/ui/src/pages/SupportDashboard.tsx
@@ -528,6 +528,7 @@ const SupportDashboard: React.FC<SupportDashboardProps> = ({
   const showLowSeverityCard = React.useMemo(() => checkAccessMaster(["dashboard", "keyMetrics", "lowSeverityCard"]), []);
   const showTicketsCreatedPerMonth = React.useMemo(() => checkAccessMaster(["dashboard", "ticketsCreatedPerMonth"]), []);
   const showAssignedTicketsBarRace = React.useMemo(() => checkAccessMaster(["dashboard", "assignedTicketsCount"]), []);
+  const showDivisionWisePendingTickets = React.useMemo(() => checkAccessMaster(["dashboard", "divisionWisePendingTickets"]), []);
   const showTotalTicketsRaisedCard = React.useMemo(() => checkAccessMaster(["dashboard", "keyMetrics", "totalTicketsRaisedCard"]), []);
 
 
@@ -1965,18 +1966,20 @@ const SupportDashboard: React.FC<SupportDashboardProps> = ({
                 </Card>
               </div>
             ) : null}
-            <div className="col-12 col-xl-6">
-              <Card className="h-100 border-0 shadow-sm">
-                <CardContent className="h-100" style={{ minHeight: 320 }}>
-                  <Typography variant="h6" className="fw-semibold mb-3" sx={{ fontSize: 18 }}>
-                    Division-wise Pending Tickets
-                  </Typography>
-                  <Box sx={{ height: "90%", minHeight: 260 }}>
-                    <ReactECharts option={divisionPendingTicketsBarOptions} style={{ height: "100%", width: "100%" }} notMerge lazyUpdate />
-                  </Box>
-                </CardContent>
-              </Card>
-            </div>
+            {showDivisionWisePendingTickets ? (
+              <div className="col-12 col-xl-6">
+                <Card className="h-100 border-0 shadow-sm">
+                  <CardContent className="h-100" style={{ minHeight: 320 }}>
+                    <Typography variant="h6" className="fw-semibold mb-3" sx={{ fontSize: 18 }}>
+                      Division-wise Pending Tickets
+                    </Typography>
+                    <Box sx={{ height: "90%", minHeight: 260 }}>
+                      <ReactECharts option={divisionPendingTicketsBarOptions} style={{ height: "100%", width: "100%" }} notMerge lazyUpdate />
+                    </Box>
+                  </CardContent>
+                </Card>
+              </div>
+            ) : null}
             {showAssignedTicketsBarRace ? (
               <div className="col-12 col-xl-6">
                 <Card className="h-100 border-0 shadow-sm">

--- a/ui/src/pages/__tests__/SupportDashboard.test.tsx
+++ b/ui/src/pages/__tests__/SupportDashboard.test.tsx
@@ -4,12 +4,14 @@ import { renderWithTheme } from "../../test/testUtils";
 
 import SupportDashboard from "../SupportDashboard";
 import { getDropdownOptions, getUserDetails } from "../../utils/Utils";
+import { checkAccessMaster } from "../../utils/permissions";
 
 const mockSummaryApiHandler = jest.fn((fn: () => Promise<any>) => fn());
 const mockParameterApiHandler = jest.fn((fn: () => Promise<any>) => fn());
 const mockUseApi = jest.fn();
 const mockGetUserDetails = getUserDetails as jest.Mock;
 const mockGetDropdownOptions = getDropdownOptions as jest.Mock;
+const mockCheckAccessMaster = checkAccessMaster as jest.Mock;
 
 jest.mock("../../hooks/useApi", () => ({
   useApi: (...args: unknown[]) => mockUseApi(...args),
@@ -175,6 +177,7 @@ describe("SupportDashboard", () => {
     mockParameterApiHandler.mockImplementation((fn: () => Promise<any>) => fn());
     mockGetUserDetails.mockReturnValue({ role: [] });
     mockGetDropdownOptions.mockReturnValue([]);
+    mockCheckAccessMaster.mockReturnValue(true);
   });
 
   it("requests dashboard data on mount with default filters", async () => {
@@ -308,6 +311,17 @@ describe("SupportDashboard", () => {
 
     await waitFor(() => expect(mockSummaryApiHandler).toHaveBeenCalled());
     expect(screen.getByLabelText("supportDashboard.filters.interval.label")).toBeInTheDocument();
+  });
+
+
+  it("hides the division-wise pending tickets graph when permission is disabled", async () => {
+    mockCheckAccessMaster.mockImplementation((keys: string[]) => keys[1] !== "divisionWisePendingTickets");
+
+    renderWithTheme(<SupportDashboard />);
+
+    await waitFor(() => expect(mockSummaryApiHandler).toHaveBeenCalled());
+    expect(screen.queryByText("Division-wise Pending Tickets")).not.toBeInTheDocument();
+    expect(mockCheckAccessMaster).toHaveBeenCalledWith(["dashboard", "divisionWisePendingTickets"]);
   });
 
   it("shows an error message when custom month range is invalid", async () => {


### PR DESCRIPTION
### Motivation
- Ensure the Division-wise Pending Tickets chart follows the same role/permission gating as other dashboard cards so it can be hidden by the permissions object.

### Description
- Added a permission flag `showDivisionWisePendingTickets` computed with `checkAccessMaster(["dashboard","divisionWisePendingTickets"])` in `ui/src/pages/SupportDashboard.tsx`.
- Wrapped the Division-wise Pending Tickets ECharts card in a conditional render so it only appears when the permission is enabled.
- Added unit test coverage by mocking `checkAccessMaster` and asserting the division-wise chart is hidden when the `divisionWisePendingTickets` permission is disabled in `ui/src/pages/__tests__/SupportDashboard.test.tsx`.

### Testing
- Ran `npm test -- --runInBand --watchAll=false src/pages/__tests__/SupportDashboard.test.tsx` and all tests in the suite passed (7 tests passed). 
- Ran `git diff --check` with no issues reported.
- Attempted `npm run build` but it failed in this environment due to a missing local `node_modules/react-i18next` dependency even though it is declared in `ui/package.json`, so build is environment-blocked rather than failing due to code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ea6b581a883328e80cf4e2714ccb7)