### PR TITLE
Extract transactional email dispatch operations into dedicated service and add unit tests

### DIFF
--- a/api/src/main/java/com/ticketingSystem/notification/service/EmailNotificationDispatchTransactionService.java
+++ b/api/src/main/java/com/ticketingSystem/notification/service/EmailNotificationDispatchTransactionService.java
@@ -1,0 +1,54 @@
+package com.ticketingSystem.notification.service;
+
+import com.ticketingSystem.notification.repository.NotificationRecipientRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class EmailNotificationDispatchTransactionService {
+    private static final String PROCESSING_TIMEOUT_ERROR = "Processing timeout";
+
+    private final NotificationRecipientRepository notificationRecipientRepository;
+
+    @Transactional
+    public List<Long> claimBatch(int limit,
+                                 LocalDateTime now,
+                                 LocalDateTime staleBefore,
+                                 int maxRetries,
+                                 String instanceId) {
+        if (limit <= 0) {
+            return Collections.emptyList();
+        }
+        List<Long> ids = notificationRecipientRepository.findClaimableIds(
+                now,
+                staleBefore,
+                maxRetries,
+                limit
+        );
+        if (ids.isEmpty()) {
+            return ids;
+        }
+        notificationRecipientRepository.markProcessing(ids, instanceId, now);
+        return ids;
+    }
+
+    @Transactional
+    public int recoverStuckProcessing(LocalDateTime staleBefore, LocalDateTime retryAt) {
+        return notificationRecipientRepository.markProcessingAsFailed(
+                staleBefore,
+                retryAt,
+                PROCESSING_TIMEOUT_ERROR
+        );
+    }
+
+    @Transactional
+    public int expireRetries(int maxRetries) {
+        return notificationRecipientRepository.markRetriesExhausted(maxRetries);
+    }
+}

--- a/api/src/main/java/com/ticketingSystem/notification/service/EmailNotificationDispatcher.java
+++ b/api/src/main/java/com/ticketingSystem/notification/service/EmailNotificationDispatcher.java
@@ -17,14 +17,12 @@ import org.springframework.core.task.TaskExecutor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +43,7 @@ public class EmailNotificationDispatcher {
     private final ObjectMapper objectMapper;
     private final NotificationProperties properties;
     private final NotificationRuntimeToggleService notificationRuntimeToggleService;
+    private final EmailNotificationDispatchTransactionService transactionService;
     @Qualifier("emailNotificationExecutor")
     private final TaskExecutor emailNotificationExecutor;
 
@@ -52,7 +51,6 @@ public class EmailNotificationDispatcher {
             fixedDelayString = "${notification.email-dispatcher.fixedDelayMs:5000}",
             initialDelayString = "${notification.email-dispatcher.initialDelayMs:5000}"
     )
-//    @Transactional
     public void dispatchPendingEmails() {
         if (!notificationRuntimeToggleService.isNotificationEnabled()) {
             return;
@@ -64,7 +62,13 @@ public class EmailNotificationDispatcher {
         recoverStuckProcessing(staleBefore, now);
         expireRetries(emailSettings.getMaxRetries());
 
-        List<Long> claimedIds = claimBatch(emailSettings.getBatchSize(), now, staleBefore);
+        List<Long> claimedIds = transactionService.claimBatch(
+                emailSettings.getBatchSize(),
+                now,
+                staleBefore,
+                emailSettings.getMaxRetries(),
+                resolveInstanceId()
+        );
         if (claimedIds.isEmpty()) {
             return;
         }
@@ -289,39 +293,18 @@ public class EmailNotificationDispatcher {
         return Duration.ofSeconds(delay);
     }
 
-    @Transactional
-    protected List<Long> claimBatch(int limit, LocalDateTime now, LocalDateTime staleBefore) {
-        if (limit <= 0) {
-            return Collections.emptyList();
-        }
-        List<Long> ids = notificationRecipientRepository.findClaimableIds(
-                now,
-                staleBefore,
-                properties.getEmailDispatcher().getMaxRetries(),
-                limit
-        );
-        if (ids.isEmpty()) {
-            return ids;
-        }
-        notificationRecipientRepository.markProcessing(ids, resolveInstanceId(), now);
-        return ids;
-    }
-
-    @Transactional
     private void recoverStuckProcessing(LocalDateTime staleBefore, LocalDateTime now) {
-        int updated = notificationRecipientRepository.markProcessingAsFailed(
+        int updated = transactionService.recoverStuckProcessing(
                 staleBefore,
-                now.plusSeconds(properties.getEmailDispatcher().getRetryBaseSeconds()),
-                "Processing timeout"
+                now.plusSeconds(properties.getEmailDispatcher().getRetryBaseSeconds())
         );
         if (updated > 0) {
             log.warn("email.dispatch.recovered count={} staleBefore={}", updated, staleBefore);
         }
     }
 
-    @Transactional
     private void expireRetries(int maxRetries) {
-        int updated = notificationRecipientRepository.markRetriesExhausted(maxRetries);
+        int updated = transactionService.expireRetries(maxRetries);
         if (updated > 0) {
             log.warn("email.dispatch.expired count={} maxRetries={}", updated, maxRetries);
         }

--- a/api/src/test/java/com/ticketingSystem/notification/service/EmailNotificationDispatchTransactionServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/notification/service/EmailNotificationDispatchTransactionServiceTest.java
@@ -1,0 +1,87 @@
+package com.ticketingSystem.notification.service;
+
+import com.ticketingSystem.notification.repository.NotificationRecipientRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class EmailNotificationDispatchTransactionServiceTest {
+
+    private NotificationRecipientRepository notificationRecipientRepository;
+    private EmailNotificationDispatchTransactionService transactionService;
+
+    @BeforeEach
+    void setUp() {
+        notificationRecipientRepository = mock(NotificationRecipientRepository.class);
+        transactionService = new EmailNotificationDispatchTransactionService(notificationRecipientRepository);
+    }
+
+    @Test
+    void claimBatchMarksClaimedIdsAsProcessing() {
+        LocalDateTime now = LocalDateTime.of(2026, 6, 4, 10, 15);
+        LocalDateTime staleBefore = now.minusMinutes(15);
+        List<Long> ids = List.of(10L, 11L);
+        when(notificationRecipientRepository.findClaimableIds(now, staleBefore, 3, 25)).thenReturn(ids);
+        when(notificationRecipientRepository.markProcessing(ids, "dispatcher-1", now)).thenReturn(ids.size());
+
+        List<Long> claimedIds = transactionService.claimBatch(25, now, staleBefore, 3, "dispatcher-1");
+
+        assertThat(claimedIds).isEqualTo(ids);
+        verify(notificationRecipientRepository).findClaimableIds(now, staleBefore, 3, 25);
+        verify(notificationRecipientRepository).markProcessing(ids, "dispatcher-1", now);
+    }
+
+    @Test
+    void claimBatchSkipsRepositoryCallsWhenLimitIsNotPositive() {
+        LocalDateTime now = LocalDateTime.of(2026, 6, 4, 10, 15);
+        LocalDateTime staleBefore = now.minusMinutes(15);
+
+        List<Long> claimedIds = transactionService.claimBatch(0, now, staleBefore, 3, "dispatcher-1");
+
+        assertThat(claimedIds).isEmpty();
+        verify(notificationRecipientRepository, never()).findClaimableIds(now, staleBefore, 3, 0);
+    }
+
+    @Test
+    void claimBatchDoesNotUpdateWhenNoIdsAreClaimable() {
+        LocalDateTime now = LocalDateTime.of(2026, 6, 4, 10, 15);
+        LocalDateTime staleBefore = now.minusMinutes(15);
+        when(notificationRecipientRepository.findClaimableIds(now, staleBefore, 3, 25)).thenReturn(List.of());
+
+        List<Long> claimedIds = transactionService.claimBatch(25, now, staleBefore, 3, "dispatcher-1");
+
+        assertThat(claimedIds).isEmpty();
+        verify(notificationRecipientRepository, never()).markProcessing(List.of(), "dispatcher-1", now);
+    }
+
+    @Test
+    void recoverStuckProcessingUsesProcessingTimeoutError() {
+        LocalDateTime staleBefore = LocalDateTime.of(2026, 6, 4, 10, 0);
+        LocalDateTime retryAt = LocalDateTime.of(2026, 6, 4, 10, 5);
+        when(notificationRecipientRepository.markProcessingAsFailed(staleBefore, retryAt, "Processing timeout"))
+                .thenReturn(2);
+
+        int updated = transactionService.recoverStuckProcessing(staleBefore, retryAt);
+
+        assertThat(updated).isEqualTo(2);
+        verify(notificationRecipientRepository).markProcessingAsFailed(staleBefore, retryAt, "Processing timeout");
+    }
+
+    @Test
+    void expireRetriesDelegatesToRepository() {
+        when(notificationRecipientRepository.markRetriesExhausted(3)).thenReturn(4);
+
+        int updated = transactionService.expireRetries(3);
+
+        assertThat(updated).isEqualTo(4);
+        verify(notificationRecipientRepository).markRetriesExhausted(3);
+    }
+}


### PR DESCRIPTION
### Motivation
- Isolate database mutation logic from the scheduled dispatcher so transactional boundaries are explicit and easier to manage.
- Reduce transaction scope in `EmailNotificationDispatcher` by moving claim/recovery/expiry operations into a dedicated service.
- Improve testability of the claim/recover/expire logic by adding focused unit tests.

### Description
- Added `EmailNotificationDispatchTransactionService` with transactional methods `claimBatch`, `recoverStuckProcessing`, and `expireRetries` that delegate to `NotificationRecipientRepository` and centralize the processing timeout message.
- Updated `EmailNotificationDispatcher` to inject `EmailNotificationDispatchTransactionService` and to call `transactionService.claimBatch(...)`, `transactionService.recoverStuckProcessing(...)`, and `transactionService.expireRetries(...)`, and removed the previous in-class transactional helpers.
- Removed inline `@Transactional` usage from the dispatcher for the moved operations to keep the dispatch loop outside those transactions.
- Added unit tests in `EmailNotificationDispatchTransactionServiceTest` covering claim behavior, no-op when limit is non-positive, handling empty results, recovery using the processing timeout message, and retries expiry delegation.

### Testing
- Executed `EmailNotificationDispatchTransactionServiceTest` (JUnit) which covers `claimBatch`, `recoverStuckProcessing`, and `expireRetries`, and all tests passed.
- Ran the project's unit test(s) that include the new test class and the run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21041a40788332b182de9da53cebab)