### PR TITLE
Propagate generated notification_id and make notification persistence transactional

### DIFF
--- a/api/src/main/java/com/ticketingSystem/notification/service/EmailNotificationPersistenceService.java
+++ b/api/src/main/java/com/ticketingSystem/notification/service/EmailNotificationPersistenceService.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -30,7 +31,7 @@ public class EmailNotificationPersistenceService {
     private final NotificationRecipientResolver recipientResolver;
     private final ObjectMapper objectMapper;
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void queueEmailNotification(NotificationRequest request) {
         if (request == null) {
             return;

--- a/api/src/main/java/com/ticketingSystem/notification/service/EmailNotificationPersistenceService.java
+++ b/api/src/main/java/com/ticketingSystem/notification/service/EmailNotificationPersistenceService.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -29,6 +30,7 @@ public class EmailNotificationPersistenceService {
     private final NotificationRecipientResolver recipientResolver;
     private final ObjectMapper objectMapper;
 
+    @Transactional
     public void queueEmailNotification(NotificationRequest request) {
         if (request == null) {
             return;
@@ -53,7 +55,7 @@ public class EmailNotificationPersistenceService {
         notification.setData(serializeData(request.getDataModel()));
         notification.setTicketId(resolveTicketId(request.getDataModel()));
 
-        Notification savedNotification = notificationRepository.save(notification);
+        Notification savedNotification = notificationRepository.saveAndFlush(notification);
 
         String cc = extractEmailList(request.getDataModel().get("cc"));
         String bcc = extractEmailList(request.getDataModel().get("bcc"));

--- a/api/src/main/java/com/ticketingSystem/notification/service/NotificationPersistenceService.java
+++ b/api/src/main/java/com/ticketingSystem/notification/service/NotificationPersistenceService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -29,7 +30,7 @@ public class NotificationPersistenceService {
     private final InAppNotificationPayloadFactory payloadFactory;
     private final ObjectMapper objectMapper;
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public InAppNotificationPayload persistInAppNotification(NotificationRequest request) {
         if (request == null) {
             return null;

--- a/api/src/main/java/com/ticketingSystem/notification/service/NotificationPersistenceService.java
+++ b/api/src/main/java/com/ticketingSystem/notification/service/NotificationPersistenceService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -28,27 +29,31 @@ public class NotificationPersistenceService {
     private final InAppNotificationPayloadFactory payloadFactory;
     private final ObjectMapper objectMapper;
 
+    @Transactional
     public InAppNotificationPayload persistInAppNotification(NotificationRequest request) {
+        if (request == null) {
+            return null;
+        }
+
         InAppNotificationPayload payload = payloadFactory.buildPayload(request);
-        persistNotification(request, payload);
-        return payload;
+        return persistNotification(request, payload) ? payload : null;
     }
 
-    private void persistNotification(NotificationRequest request, InAppNotificationPayload payload) {
-        if (request == null || payload == null) {
-            return;
+    private boolean persistNotification(NotificationRequest request, InAppNotificationPayload payload) {
+        if (payload == null) {
+            return false;
         }
 
         NotificationMaster master = request.getNotificationMaster();
         if (master == null) {
             log.warn("Unable to persist notification without notification master");
-            return;
+            return false;
         }
 
         List<User> recipients = recipientResolver.resolveRecipients(request.getRecipient());
         if (recipients.isEmpty()) {
             log.warn("Unable to resolve recipients for in-app notification: {}", request.getRecipient());
-            return;
+            return false;
         }
 
         Notification notification = new Notification();
@@ -58,13 +63,17 @@ public class NotificationPersistenceService {
         notification.setData(serializeData(payload.getData()));
         notification.setTicketId(resolveTicketId(payload.getData()));
 
-        Notification savedNotification = notificationRepository.save(notification);
+        Notification savedNotification = notificationRepository.saveAndFlush(notification);
+        payload.getData().put("notificationId", savedNotification.getId());
+        savedNotification.setData(serializeData(payload.getData()));
+        Notification persistedNotification = notificationRepository.saveAndFlush(savedNotification);
 
         List<NotificationRecipient> recipientEntities = recipients.stream()
-                .map(user -> createRecipient(savedNotification, user))
+                .map(user -> createRecipient(persistedNotification, user))
                 .toList();
 
         notificationRecipientRepository.saveAll(recipientEntities);
+        return true;
     }
 
     private NotificationRecipient createRecipient(Notification notification, User recipient) {

--- a/api/src/test/java/com/ticketingSystem/notification/service/NotificationPersistenceServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/notification/service/NotificationPersistenceServiceTest.java
@@ -21,6 +21,9 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -50,8 +53,14 @@ class NotificationPersistenceServiceTest {
                 objectMapper
         );
 
-        when(notificationRepository.save(any(Notification.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
+        lenient().when(notificationRepository.saveAndFlush(any(Notification.class)))
+                .thenAnswer(invocation -> {
+                    Notification notification = invocation.getArgument(0);
+                    if (notification.getId() == null) {
+                        notification.setId(99L);
+                    }
+                    return notification;
+                });
     }
 
     @Test
@@ -79,19 +88,22 @@ class NotificationPersistenceServiceTest {
                 data
         );
 
-        persistenceService.persistInAppNotification(request);
+        InAppNotificationPayload payload = persistenceService.persistInAppNotification(request);
 
         Notification notification = captureNotification();
         assertThat(notification.getTitle()).isEqualTo("Ticket assigned to Alex");
         assertThat(notification.getMessage()).isEqualTo("Ticket T-100 assigned by System");
         assertThat(notification.getTicketId()).isEqualTo("T-100");
+        assertThat(payload).isNotNull();
+        assertThat(payload.getData()).containsEntry("notificationId", 99L);
 
         Map<String, Object> persistedData = objectMapper.readValue(notification.getData(), Map.class);
         assertThat(persistedData)
                 .containsEntry("ticketId", "T-100")
                 .containsEntry("assigneeName", "Alex")
                 .containsEntry("assignedBy", "System")
-                .containsEntry("redirectUrl", "/tickets/T-100");
+                .containsEntry("redirectUrl", "/tickets/T-100")
+                .containsEntry("notificationId", 99);
 
         List<NotificationRecipient> recipients = captureRecipients();
         assertThat(recipients).hasSize(1);
@@ -179,6 +191,31 @@ class NotificationPersistenceServiceTest {
         assertThat(captureRecipients()).hasSize(1);
     }
 
+    @Test
+    void returnsNullAndDoesNotSaveWhenRecipientCannotBeResolved() {
+        NotificationMaster master = buildMaster(
+                "TICKET_ASSIGNED",
+                "Ticket assigned",
+                "Ticket assigned"
+        );
+
+        NotificationRequest request = new NotificationRequest(
+                ChannelType.IN_APP,
+                master,
+                "missing-user",
+                null,
+                Map.of("ticketId", "T-400")
+        );
+
+        when(recipientResolver.resolveRecipients("missing-user")).thenReturn(List.of());
+
+        InAppNotificationPayload payload = persistenceService.persistInAppNotification(request);
+
+        assertThat(payload).isNull();
+        verify(notificationRepository, never()).saveAndFlush(any(Notification.class));
+        verify(notificationRecipientRepository, never()).saveAll(any());
+    }
+
     private NotificationMaster buildMaster(String code, String titleTemplate, String messageTemplate) {
         NotificationMaster master = new NotificationMaster();
         master.setCode(code);
@@ -191,8 +228,8 @@ class NotificationPersistenceServiceTest {
 
     private Notification captureNotification() {
         ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
-        verify(notificationRepository).save(notificationCaptor.capture());
-        return notificationCaptor.getValue();
+        verify(notificationRepository, times(2)).saveAndFlush(notificationCaptor.capture());
+        return notificationCaptor.getAllValues().get(1);
     }
 
     private List<NotificationRecipient> captureRecipients() {


### PR DESCRIPTION
### Motivation
- In-app notification payloads were being built and returned before the DB-generated `notification_id` was persisted, causing published payloads to lack the notification identifier and enabling situations where no DB rows existed while a payload was published. 
- Email queued notifications also needed the notification row flushed so recipients can reference the generated id. 
- If recipients could not be resolved, the code should not create notification/recipient rows or publish a payload.

### Description
- Made in-app persistence transactional and changed `persistInAppNotification` to return `null` when persistence did not succeed, and to flush the inserted notification to obtain the generated id before creating recipients.  The code now injects `notificationId` into the payload data and re-saves the enriched notification JSON prior to creating recipient rows (`saveAndFlush` used). 
- Made email queue persistence transactional and changed the email persistence flow to `saveAndFlush` the notification before creating email recipient rows so recipients reference a persisted notification id. 
- Adjusted the in-app notifier flow to respect `null` payloads (no publish when persistence failed) and ensured recipient resolution short-circuits persistence when empty. 
- Updated unit tests to mock `saveAndFlush`, assert the returned in-app payload contains `notificationId`, and added a test asserting no DB save occurs when recipients cannot be resolved.

### Testing
- Compiled the modified code with Java 17 via `JAVA_HOME=/root/.local/share/mise/installs/java/17.0.2 ./gradlew compileJava`, which succeeded. 
- Attempted to run the notification unit tests (`./gradlew test --tests com.ticketingSystem.notification.service.NotificationPersistenceServiceTest --tests com.ticketingSystem.notification.service.NotificationServiceTest`) but the full test run was blocked by unrelated test compilation failures in `TicketServiceTest` (signature mismatches) when compiling test sources. 
- Running tests under the default Java runtime without toolchain adjustment failed earlier due to a Groovy/Java class-file version incompatibility (`Unsupported class file major version 69`), so end-to-end test execution in the environment was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21546037748332857f75d82d421f81)