### PR TITLE
Add header permissions support and header access checks (backend + frontend)

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/permissions/RolePermission.java
+++ b/api/src/main/java/com/ticketingSystem/api/permissions/RolePermission.java
@@ -20,4 +20,10 @@ public class RolePermission {
      * therefore we use a generic map.
      */
     private Map<String, Object> pages;
+
+    /**
+     * Structure containing header permissions. Header items follow the same
+     * flexible permission-tree shape as sidebar items.
+     */
+    private Map<String, Object> header;
 }

--- a/api/src/main/java/com/ticketingSystem/api/service/PermissionService.java
+++ b/api/src/main/java/com/ticketingSystem/api/service/PermissionService.java
@@ -129,6 +129,7 @@ public class PermissionService {
         RolePermission result = new RolePermission();
         result.setSidebar(syncSection(template.getSidebar(), existing != null ? existing.getSidebar() : null));
         result.setPages(syncSection(template.getPages(), existing != null ? existing.getPages() : null));
+        result.setHeader(syncSection(template.getHeader(), existing != null ? existing.getHeader() : null));
         return result;
     }
 
@@ -214,14 +215,36 @@ public class PermissionService {
         return getRolePermissions(roles).stream()
                 .map(RolePermission::getSidebar)
                 .filter(Objects::nonNull)
-                .map(m -> m.get(key))
-                .anyMatch(obj -> {
-                    if (obj instanceof Map<?, ?> mp) {
-                        Object show = mp.get("show");
-                        return Boolean.TRUE.equals(show);
-                    }
-                    return Boolean.TRUE.equals(obj);
-                });
+                .map(section -> getSectionItem(section, key))
+                .anyMatch(this::isPermissionShown);
+    }
+
+    public boolean hasHeaderAccess(List<Integer> roles, String key) {
+        return getRolePermissions(roles).stream()
+                .map(RolePermission::getHeader)
+                .filter(Objects::nonNull)
+                .map(section -> getSectionItem(section, key))
+                .anyMatch(this::isPermissionShown);
+    }
+
+    private Object getSectionItem(Map<String, Object> section, String key) {
+        Object direct = section.get(key);
+        if (direct != null) {
+            return direct;
+        }
+        Object children = section.get("children");
+        if (children instanceof Map<?, ?> childrenMap) {
+            return childrenMap.get(key);
+        }
+        return null;
+    }
+
+    private boolean isPermissionShown(Object obj) {
+        if (obj instanceof Map<?, ?> mp) {
+            Object show = mp.get("show");
+            return Boolean.TRUE.equals(show);
+        }
+        return Boolean.TRUE.equals(obj);
     }
 
     public boolean hasFormAccess(List<Integer> roles, String form, String action) {
@@ -262,9 +285,11 @@ public class PermissionService {
         RolePermission result = new RolePermission();
         result.setSidebar(new HashMap<>());
         result.setPages(new HashMap<>());
+        result.setHeader(new HashMap<>());
         for (RolePermission rp : getRolePermissions(roles)) {
             mergeOuter(result.getSidebar(), rp.getSidebar());
             mergeOuter(result.getPages(), rp.getPages());
+            mergeOuter(result.getHeader(), rp.getHeader());
         }
         return result;
     }

--- a/api/src/test/java/com/ticketingSystem/api/service/PermissionServiceTest.java
+++ b/api/src/test/java/com/ticketingSystem/api/service/PermissionServiceTest.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link PermissionService}.
@@ -30,6 +31,13 @@ class PermissionServiceTest {
         sidebar1.put("knowledgeBase", kb1);
         sidebar1.put("faq", faq1);
         role1.setSidebar(sidebar1);
+        Map<String, Object> notifications1 = new HashMap<>();
+        notifications1.put("show", false);
+        Map<String, Object> headerChildren1 = new HashMap<>();
+        headerChildren1.put("notifications", notifications1);
+        Map<String, Object> header1 = new HashMap<>();
+        header1.put("children", headerChildren1);
+        role1.setHeader(header1);
 
         // Role 2 grants FAQ but not Knowledge Base
         RolePermission role2 = new RolePermission();
@@ -41,6 +49,13 @@ class PermissionServiceTest {
         sidebar2.put("knowledgeBase", kb2);
         sidebar2.put("faq", faq2);
         role2.setSidebar(sidebar2);
+        Map<String, Object> notifications2 = new HashMap<>();
+        notifications2.put("show", true);
+        Map<String, Object> headerChildren2 = new HashMap<>();
+        headerChildren2.put("notifications", notifications2);
+        Map<String, Object> header2 = new HashMap<>();
+        header2.put("children", headerChildren2);
+        role2.setHeader(header2);
 
         Map<Integer, RolePermission> roles = new HashMap<>();
         roles.put(1, role1);
@@ -58,6 +73,11 @@ class PermissionServiceTest {
         Map<String, Object> sidebar = merged.getSidebar();
         assertEquals(Boolean.TRUE, ((Map<?, ?>) sidebar.get("knowledgeBase")).get("show"));
         assertEquals(Boolean.TRUE, ((Map<?, ?>) sidebar.get("faq")).get("show"));
+
+        Map<String, Object> header = merged.getHeader();
+        Map<?, ?> headerChildren = (Map<?, ?>) header.get("children");
+        assertEquals(Boolean.TRUE, ((Map<?, ?>) headerChildren.get("notifications")).get("show"));
+        assertTrue(service.hasHeaderAccess(Arrays.asList(1, 2), "notifications"));
     }
 }
 

--- a/ui/src/types/auth.ts
+++ b/ui/src/types/auth.ts
@@ -7,6 +7,7 @@ export interface SidebarItemPermission {
 export interface RolePermission {
   sidebar?: { [key: string]: SidebarItemPermission };
   pages?: { [form: string]: { [key: string]: any } };
+  header?: { [key: string]: SidebarItemPermission };
 }
 
 export interface UserDetails {

--- a/ui/src/utils/permissions.ts
+++ b/ui/src/utils/permissions.ts
@@ -17,6 +17,15 @@ export function checkSidebarAccess(key: string): boolean {
   return false;
 }
 
+export function checkHeaderAccess(key: string): boolean {
+  const perms = getUserPermissions() as RolePermission | null;
+  const fromConfig = perms?.header?.children?.[key]?.show;
+  if (typeof fromConfig === "boolean") {
+    return fromConfig;
+  }
+  return false;
+}
+
 export function checkFormAccess(
   section: string,
   type: 'view' | 'create' | 'update',


### PR DESCRIPTION
### Motivation
- Support a new flexible `header` permissions tree alongside existing `sidebar` and `pages` so header items can be configured and merged per-role.
- Provide API-side access checks and merging for header permissions and expose a simple frontend helper to read header permissions.

### Description
- Added a `header` field to `RolePermission` and included it in the template synchronization and merging logic in `PermissionService` via `applyTemplate` and `mergeRolePermissions`.
- Introduced `hasHeaderAccess` and generalized helpers `getSectionItem` and `isPermissionShown` to consolidate logic used by `hasSidebarAccess` and `hasHeaderAccess`.
- Updated frontend type definitions (`RolePermission`) to include `header` and added `checkHeaderAccess` in `ui/src/utils/permissions.ts` to read header permission flags from the stored user permissions.
- Refactored sidebar access lookup to reuse the new section helpers and added corresponding handling for nested `children` items.

### Testing
- Updated `PermissionServiceTest` to include header items and verify merging and access; the unit test `PermissionServiceTest` ran and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26a9b8f5708332809495b2cd8da0e2)