### PR TITLE
Apply header icon permission checks

### DIFF
--- a/ui/src/components/Layout/Header.tsx
+++ b/ui/src/components/Layout/Header.tsx
@@ -9,6 +9,7 @@ import { DevModeContext } from "../../context/DevModeContext";
 import UserMenu from "./UserMenu";
 import NotificationBell from "../Notifications/NotificationBell";
 import { useTranslation } from "react-i18next";
+import { checkHeaderAccess } from "../../utils/permissions";
 
 interface HeaderProps {
   collapsed?: boolean;
@@ -58,6 +59,26 @@ const Header: React.FC<HeaderProps> = ({
     else if (theme.palette.mode === "dark") return "./fciLogo.png"
   }, [theme.palette.mode])
 
+  const showLightDarkModeIcon = checkHeaderAccess("lightDarkModeIcon");
+  const showTranslateIcon = checkHeaderAccess("translateIcon");
+  const showDevModeIcon = checkHeaderAccess("devModeIcon");
+  const showNotificationIcon =
+    showNotifications &&
+    checkHeaderAccess("notifications") &&
+    checkHeaderAccess(["notifications", "icon"]);
+  const showNotificationDropdown =
+    checkHeaderAccess("notifications") &&
+    checkHeaderAccess(["notifications", "dropdown"]);
+  const showUserProfileIcon =
+    showProfile &&
+    Boolean(user) &&
+    checkHeaderAccess("userProfile") &&
+    checkHeaderAccess(["userProfile", "icon"]);
+  const showUserProfileDropdown =
+    showProfile &&
+    checkHeaderAccess("userProfile") &&
+    checkHeaderAccess(["userProfile", "dropdown"]);
+
   return (
     <header
       className="d-flex py-1 px-2 align-items-center"
@@ -97,24 +118,28 @@ const Header: React.FC<HeaderProps> = ({
         {t("Ticketing System")}
       </div>
       <div className="d-flex align-items-center" style={{ marginLeft: "auto", gap: "8px" }}>
-        <CustomIconButton
-          style={{ color: iconColor }}
-          icon={mode === "light" ? "darkmode" : "lightmode"}
-          onClick={toggle}
-        />
-        <CustomIconButton
-          style={{ color: iconColor }}
-          icon="translate"
-          onClick={toggleLanguage}
-        />
-        {envDevMode && (
+        {showLightDarkModeIcon && (
+          <CustomIconButton
+            style={{ color: iconColor }}
+            icon={mode === "light" ? "darkmode" : "lightmode"}
+            onClick={toggle}
+          />
+        )}
+        {showTranslateIcon && (
+          <CustomIconButton
+            style={{ color: iconColor }}
+            icon="translate"
+            onClick={toggleLanguage}
+          />
+        )}
+        {envDevMode && showDevModeIcon && (
           <CustomIconButton
             style={{ color: devMode ? theme.palette.warning.main : iconColor }}
             icon="code"
             onClick={toggleDevMode}
           />
         )}
-        {envDevMode && devMode && (
+        {envDevMode && showDevModeIcon && devMode && (
           <CustomIconButton
             style={{
               color: jwtBypass
@@ -126,14 +151,16 @@ const Header: React.FC<HeaderProps> = ({
             title={jwtBypass ? "JWT bypass enabled" : "JWT protection active"}
           />
         )}
-        {envDevMode && devMode && <CustomIconButton
+        {envDevMode && showDevModeIcon && devMode && <CustomIconButton
           style={{ color: iconColor, fontSize: 14 }}
           icon={layout.toString()}
           // icon="code"
           onClick={toggleLayout}
         />}
-        {showNotifications && <NotificationBell iconColor={iconColor} />}
-        {showProfile && user && (
+        {showNotificationIcon && (
+          <NotificationBell iconColor={iconColor} showDropdown={showNotificationDropdown} />
+        )}
+        {showUserProfileIcon && (
           <Avatar
             sx={{
               bgcolor: "white",
@@ -149,7 +176,7 @@ const Header: React.FC<HeaderProps> = ({
           </Avatar>
         )}
       </div>
-      {showProfile && (
+      {showUserProfileDropdown && (
         <UserMenu anchorEl={menuAnchorEl} open={Boolean(menuAnchorEl)} onClose={handleMenuClose} />
       )}
     </header>

--- a/ui/src/components/Layout/__tests__/Header.test.tsx
+++ b/ui/src/components/Layout/__tests__/Header.test.tsx
@@ -6,13 +6,20 @@ import { LanguageContext } from '../../../context/LanguageContext';
 import { DevModeContext } from '../../../context/DevModeContext';
 import { renderWithTheme, createTestTheme } from '../../../test/testUtils';
 import * as config from '../../../config/config';
+import { setUserPermissions } from '../../../utils/Utils';
 
 jest.mock('../UserMenu', () => ({ open }: { open: boolean }) => (
   <div data-testid="user-menu" data-open={open} />
 ));
 
-jest.mock('../../Notifications/NotificationBell', () => ({ iconColor }: { iconColor: string }) => (
-  <div data-testid="notification-bell" data-icon-color={iconColor} />
+jest.mock('../../Notifications/NotificationBell', () => ({
+  iconColor,
+  showDropdown,
+}: {
+  iconColor: string;
+  showDropdown?: boolean;
+}) => (
+  <div data-testid="notification-bell" data-icon-color={iconColor} data-show-dropdown={showDropdown} />
 ));
 
 import Header from '../Header';
@@ -61,6 +68,30 @@ describe('Header', () => {
   beforeEach(() => {
     jest.restoreAllMocks();
     jest.clearAllMocks();
+    setUserPermissions({
+      header: {
+        show: true,
+        children: {
+          devModeIcon: { show: true },
+          lightDarkModeIcon: { show: true },
+          translateIcon: { show: true },
+          notifications: {
+            show: true,
+            children: {
+              icon: { show: true },
+              dropdown: { show: true },
+            },
+          },
+          userProfile: {
+            show: true,
+            children: {
+              icon: { show: true },
+              dropdown: { show: true },
+            },
+          },
+        },
+      },
+    });
     jest.spyOn(config, 'getCurrentUserDetails').mockReturnValue({
       name: 'John Doe',
       username: 'johnd',
@@ -104,6 +135,62 @@ describe('Header', () => {
     expect(toggleDevMode).toHaveBeenCalledTimes(1);
     expect(toggleJwtBypass).toHaveBeenCalledTimes(1);
     expect(toggleLayout).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides header controls when permission flags are disabled', () => {
+    setUserPermissions({
+      header: {
+        show: true,
+        children: {
+          devModeIcon: { show: false },
+          lightDarkModeIcon: { show: false },
+          translateIcon: { show: false },
+          notifications: {
+            show: true,
+            children: { icon: { show: false }, dropdown: { show: true } },
+          },
+          userProfile: {
+            show: true,
+            children: { icon: { show: false }, dropdown: { show: true } },
+          },
+        },
+      },
+    });
+
+    renderHeader({ devMode: true, jwtBypass: true });
+
+    expect(screen.queryByTestId('DarkModeIcon')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('TranslateIcon')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('CodeIcon')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('LockOpenIcon')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '1' })).not.toBeInTheDocument();
+    expect(screen.queryByTestId('notification-bell')).not.toBeInTheDocument();
+    expect(screen.queryByText('JD')).not.toBeInTheDocument();
+  });
+
+  it('passes the notification dropdown permission to the bell', () => {
+    setUserPermissions({
+      header: {
+        show: true,
+        children: {
+          devModeIcon: { show: true },
+          lightDarkModeIcon: { show: true },
+          translateIcon: { show: true },
+          notifications: {
+            show: true,
+            children: { icon: { show: true }, dropdown: { show: false } },
+          },
+          userProfile: {
+            show: true,
+            children: { icon: { show: true }, dropdown: { show: true } },
+          },
+        },
+      },
+    });
+
+    renderHeader();
+
+    expect(screen.getByTestId('notification-bell')).toHaveAttribute('data-show-dropdown', 'false');
   });
 
   it('renders appropriate logo for light and dark themes', () => {

--- a/ui/src/components/Notifications/NotificationBell.tsx
+++ b/ui/src/components/Notifications/NotificationBell.tsx
@@ -84,9 +84,10 @@ const renderNotification = (
 
 interface NotificationBellProps {
   iconColor: string;
+  showDropdown?: boolean;
 }
 
-const NotificationBell: React.FC<NotificationBellProps> = ({ iconColor }) => {
+const NotificationBell: React.FC<NotificationBellProps> = ({ iconColor, showDropdown = true }) => {
   const theme = useTheme();
   const navigate = useNavigate();
   const {
@@ -104,7 +105,7 @@ const NotificationBell: React.FC<NotificationBellProps> = ({ iconColor }) => {
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [snackbarNotification, setSnackbarNotification] = useState<NotificationItem | null>(null);
 
-  const menuOpen = Boolean(anchorEl);
+  const menuOpen = showDropdown && Boolean(anchorEl);
 
   const sortedNotifications = useMemo(
     () =>
@@ -115,7 +116,9 @@ const NotificationBell: React.FC<NotificationBellProps> = ({ iconColor }) => {
   );
 
   const handleOpen = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
+    if (showDropdown) {
+      setAnchorEl(event.currentTarget);
+    }
   };
 
   const handleClose = () => {
@@ -179,64 +182,66 @@ const NotificationBell: React.FC<NotificationBellProps> = ({ iconColor }) => {
           <NotificationsNoneOutlinedIcon />
         </Badge>
       </IconButton>
-      <Menu
-        anchorEl={anchorEl}
-        open={menuOpen}
-        onClose={handleClose}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-        PaperProps={{
-          sx: {
-            width: 360,
-            maxHeight: 420,
-            mt: 1,
-          },
-        }}
-      >
-        <Box sx={{ px: 2, py: 1.5 }}>
-          <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
-            Notifications
-          </Typography>
-        </Box>
-        <Divider />
-        {sortedNotifications.length === 0 ? (
-          <Box sx={{ px: 2, py: 2 }}>
-            <Typography variant="body2" color="text.secondary">
-              You're all caught up!
+      {showDropdown && (
+        <Menu
+          anchorEl={anchorEl}
+          open={menuOpen}
+          onClose={handleClose}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+          transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+          PaperProps={{
+            sx: {
+              width: 360,
+              maxHeight: 420,
+              mt: 1,
+            },
+          }}
+        >
+          <Box sx={{ px: 2, py: 1.5 }}>
+            <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+              Notifications
             </Typography>
           </Box>
-        ) : (
-          <>
-            <List
-              dense
-              disablePadding
-              sx={{ maxHeight: 56 * 7, overflowY: 'auto' }}
-            >
-              {sortedNotifications.map((notification, index) => (
-                <React.Fragment key={notification.id}>
-                  {renderNotification(notification, theme, handleNotificationClick)}
-                  {index < sortedNotifications.length - 1 && <Divider component="li" />}
-                </React.Fragment>
-              ))}
-            </List>
-            {(hasMore || loading) && (
-              <>
-                <Divider />
-                <Box sx={{ px: 2, py: 1 }}>
-                  <Button
-                    size="small"
-                    onClick={handleShowMore}
-                    disabled={loading}
-                    sx={{ textTransform: 'none' }}
-                  >
-                    {loading ? 'Loading…' : 'Show more'}
-                  </Button>
-                </Box>
-              </>
-            )}
-          </>
-        )}
-      </Menu>
+          <Divider />
+          {sortedNotifications.length === 0 ? (
+            <Box sx={{ px: 2, py: 2 }}>
+              <Typography variant="body2" color="text.secondary">
+                You're all caught up!
+              </Typography>
+            </Box>
+          ) : (
+            <>
+              <List
+                dense
+                disablePadding
+                sx={{ maxHeight: 56 * 7, overflowY: 'auto' }}
+              >
+                {sortedNotifications.map((notification, index) => (
+                  <React.Fragment key={notification.id}>
+                    {renderNotification(notification, theme, handleNotificationClick)}
+                    {index < sortedNotifications.length - 1 && <Divider component="li" />}
+                  </React.Fragment>
+                ))}
+              </List>
+              {(hasMore || loading) && (
+                <>
+                  <Divider />
+                  <Box sx={{ px: 2, py: 1 }}>
+                    <Button
+                      size="small"
+                      onClick={handleShowMore}
+                      disabled={loading}
+                      sx={{ textTransform: 'none' }}
+                    >
+                      {loading ? 'Loading…' : 'Show more'}
+                    </Button>
+                  </Box>
+                </>
+              )}
+            </>
+          )}
+        </Menu>
+      )}
       <Snackbar
         open={snackbarOpen && Boolean(snackbarNotification)}
         autoHideDuration={6000}

--- a/ui/src/utils/__tests__/permissions.test.ts
+++ b/ui/src/utils/__tests__/permissions.test.ts
@@ -5,6 +5,7 @@ import {
   checkMyTicketsAccess,
   checkMyTicketsColumnAccess,
   checkSidebarAccess,
+  checkHeaderAccess,
   getFieldChildren,
   setPermissions,
 } from "../permissions";
@@ -33,6 +34,37 @@ describe("utils/permissions", () => {
     expect(checkSidebarAccess("reports")).toBe(true);
     expect(checkSidebarAccess("fileManagement")).toBe(true);
     expect(checkSidebarAccess("missing")).toBe(false);
+  });
+
+  it("checks header access from top-level and nested permission flags", () => {
+    getUserPermissions.mockReturnValue({
+      header: {
+        show: true,
+        children: {
+          lightDarkModeIcon: { show: true },
+          translateIcon: { show: false },
+          notifications: {
+            show: true,
+            children: { icon: { show: true }, dropdown: { show: false } },
+          },
+        },
+      },
+    });
+
+    expect(checkHeaderAccess("lightDarkModeIcon")).toBe(true);
+    expect(checkHeaderAccess("translateIcon")).toBe(false);
+    expect(checkHeaderAccess(["notifications", "icon"])).toBe(true);
+    expect(checkHeaderAccess("notifications.dropdown")).toBe(false);
+    expect(checkHeaderAccess("missing")).toBe(false);
+
+    getUserPermissions.mockReturnValue({
+      header: {
+        show: false,
+        children: { lightDarkModeIcon: { show: true } },
+      },
+    });
+
+    expect(checkHeaderAccess("lightDarkModeIcon")).toBe(false);
   });
 
   it("checks form/field and nested children access", () => {

--- a/ui/src/utils/permissions.ts
+++ b/ui/src/utils/permissions.ts
@@ -17,13 +17,21 @@ export function checkSidebarAccess(key: string): boolean {
   return false;
 }
 
-export function checkHeaderAccess(key: string): boolean {
+export function checkHeaderAccess(path: string | string[]): boolean {
   const perms = getUserPermissions() as RolePermission | null;
-  const fromConfig = perms?.header?.children?.[key]?.show;
-  if (typeof fromConfig === "boolean") {
-    return fromConfig;
+  const header = perms?.header as SidebarItemPermission | undefined;
+
+  if (header?.show === false) {
+    return false;
   }
-  return false;
+
+  const keys = Array.isArray(path) ? path : path.split('.').filter(Boolean);
+  const current = keys.reduce<SidebarItemPermission | undefined>(
+    (node, key) => node?.children?.[key],
+    header,
+  );
+
+  return current?.show === true;
 }
 
 export function checkFormAccess(


### PR DESCRIPTION
### Motivation
- Make header icon rendering honor the nested `header` permission configuration (top-level `header.show`, per-icon `show`, and nested child flags like `notifications.icon` / `notifications.dropdown`).

### Description
- Changed `checkHeaderAccess` in `ui/src/utils/permissions.ts` to accept a path (`string | string[]`), respect `header.show === false`, and resolve nested children paths before returning a boolean.
- Added permission checks in `ui/src/components/Layout/Header.tsx` to gate rendering of light/dark mode, translate, dev-mode, notifications and user-profile controls using `checkHeaderAccess`.
- Extended `NotificationBell` (`ui/src/components/Notifications/NotificationBell.tsx`) with a `showDropdown` prop so the bell can render while its dropdown menu remains disabled when configured.
- Updated tests in `ui/src/components/Layout/__tests__/Header.test.tsx` and `ui/src/utils/__tests__/permissions.test.ts` to cover top-level and nested header permission behavior.

### Testing
- Ran unit tests with `npm test -- --runInBand --watchAll=false ui/src/utils/__tests__/permissions.test.ts ui/src/components/Layout/__tests__/Header.test.tsx`, and both test suites passed (`2 passed, 2 total`).
- Attempted production build with `npm run build` and `NODE_OPTIONS=--max_old_space_size=4096 npm run build`, but the build failed in this environment due to V8 heap out-of-memory during `react-scripts` / `fork-ts-checker-webpack-plugin` execution.
- Ran `npx tsc --noEmit --skipLibCheck --pretty false` which surfaced type incompatibilities in some `node_modules` `.d.ts` files under the repo TypeScript version (these are environment/dependency issues rather than logic regressions in the change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26d980c0148332ae2657278aaec35e)