### PR TITLE
Add role-notification channel mapping API, service, UI grid and batch update

### DIFF
--- a/api/src/main/java/com/ticketingSystem/api/controller/RoleNotificationChannelMappingController.java
+++ b/api/src/main/java/com/ticketingSystem/api/controller/RoleNotificationChannelMappingController.java
@@ -1,0 +1,35 @@
+package com.ticketingSystem.api.controller;
+
+import com.ticketingSystem.notification.dto.RoleNotificationChannelBatchUpdateRequest;
+import com.ticketingSystem.notification.dto.RoleNotificationChannelBatchUpdateResponse;
+import com.ticketingSystem.notification.dto.RoleNotificationChannelGridResponse;
+import com.ticketingSystem.notification.service.RoleNotificationChannelMappingService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/role-notification-channel-mappings")
+@CrossOrigin(origins = "http://localhost:3000")
+@RequiredArgsConstructor
+public class RoleNotificationChannelMappingController {
+    private final RoleNotificationChannelMappingService service;
+
+    @GetMapping
+    public ResponseEntity<RoleNotificationChannelGridResponse> getGrid() {
+        return ResponseEntity.ok(service.getGrid());
+    }
+
+    @PutMapping("/batch")
+    public ResponseEntity<RoleNotificationChannelBatchUpdateResponse> batchUpdate(
+            @Valid @RequestBody RoleNotificationChannelBatchUpdateRequest request
+    ) {
+        return ResponseEntity.ok(service.batchUpdate(request));
+    }
+}

--- a/api/src/main/java/com/ticketingSystem/notification/dto/RoleNotificationChannelBatchUpdateRequest.java
+++ b/api/src/main/java/com/ticketingSystem/notification/dto/RoleNotificationChannelBatchUpdateRequest.java
@@ -1,0 +1,39 @@
+package com.ticketingSystem.notification.dto;
+
+import com.ticketingSystem.notification.enums.ChannelType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RoleNotificationChannelBatchUpdateRequest {
+    private String updatedBy;
+
+    @Valid
+    @NotEmpty
+    private List<Item> items;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class Item {
+        @NotNull
+        private Integer roleId;
+
+        @NotNull
+        private Integer notificationTypeId;
+
+        @NotNull
+        private ChannelType channelCode;
+
+        @NotNull
+        private Boolean isActive;
+    }
+}

--- a/api/src/main/java/com/ticketingSystem/notification/dto/RoleNotificationChannelBatchUpdateResponse.java
+++ b/api/src/main/java/com/ticketingSystem/notification/dto/RoleNotificationChannelBatchUpdateResponse.java
@@ -1,0 +1,15 @@
+package com.ticketingSystem.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoleNotificationChannelBatchUpdateResponse {
+    private int updated;
+    private int created;
+}

--- a/api/src/main/java/com/ticketingSystem/notification/dto/RoleNotificationChannelGridResponse.java
+++ b/api/src/main/java/com/ticketingSystem/notification/dto/RoleNotificationChannelGridResponse.java
@@ -1,0 +1,50 @@
+package com.ticketingSystem.notification.dto;
+
+import com.ticketingSystem.notification.enums.ChannelType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoleNotificationChannelGridResponse {
+    private List<RoleOption> roles;
+    private List<NotificationOption> notifications;
+    private List<MappingState> mappings;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RoleOption {
+        private Integer roleId;
+        private String role;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class NotificationOption {
+        private Integer notificationTypeId;
+        private String name;
+        private String code;
+        private String description;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MappingState {
+        private Integer roleId;
+        private Integer notificationTypeId;
+        private Map<ChannelType, Boolean> channels;
+    }
+}

--- a/api/src/main/java/com/ticketingSystem/notification/models/RoleNotificationChannelMapping.java
+++ b/api/src/main/java/com/ticketingSystem/notification/models/RoleNotificationChannelMapping.java
@@ -11,7 +11,11 @@ import org.hibernate.annotations.UpdateTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "role_notification_channel_mapping")
+@Table(name = "role_notification_channel_mapping",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_role_notification_channel_mapping",
+                columnNames = {"role_id", "notification_type_id", "channel_code"}
+        ))
 @Getter
 @Setter
 public class RoleNotificationChannelMapping {

--- a/api/src/main/java/com/ticketingSystem/notification/repository/NotificationMasterRepository.java
+++ b/api/src/main/java/com/ticketingSystem/notification/repository/NotificationMasterRepository.java
@@ -3,8 +3,11 @@ package com.ticketingSystem.notification.repository;
 import com.ticketingSystem.notification.models.NotificationMaster;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface NotificationMasterRepository extends JpaRepository<NotificationMaster, Integer> {
     Optional<NotificationMaster> findByCodeAndIsActiveTrue(String code);
+
+    List<NotificationMaster> findByIsActiveTrueOrderByNameAsc();
 }

--- a/api/src/main/java/com/ticketingSystem/notification/repository/RoleNotificationChannelMappingRepository.java
+++ b/api/src/main/java/com/ticketingSystem/notification/repository/RoleNotificationChannelMappingRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface RoleNotificationChannelMappingRepository extends JpaRepository<RoleNotificationChannelMapping, Long> {
     @Query("""
@@ -19,4 +20,20 @@ public interface RoleNotificationChannelMappingRepository extends JpaRepository<
             """)
     List<ChannelType> findActiveChannelsForRoles(@Param("roleIds") Collection<Integer> roleIds,
                                                   @Param("notificationTypeId") Integer notificationTypeId);
+
+    @Query("""
+            SELECT mapping
+            FROM RoleNotificationChannelMapping mapping
+            JOIN FETCH mapping.role role
+            JOIN FETCH mapping.notificationType notificationType
+            WHERE role.isDeleted = false
+              AND notificationType.isActive = true
+            """)
+    List<RoleNotificationChannelMapping> findGridMappings();
+
+    Optional<RoleNotificationChannelMapping> findByRoleRoleIdAndNotificationTypeIdAndChannelCode(
+            Integer roleId,
+            Integer notificationTypeId,
+            ChannelType channelCode
+    );
 }

--- a/api/src/main/java/com/ticketingSystem/notification/service/RoleNotificationChannelMappingService.java
+++ b/api/src/main/java/com/ticketingSystem/notification/service/RoleNotificationChannelMappingService.java
@@ -1,0 +1,141 @@
+package com.ticketingSystem.notification.service;
+
+import com.ticketingSystem.api.exception.ResourceNotFoundException;
+import com.ticketingSystem.api.models.Role;
+import com.ticketingSystem.api.repository.RoleRepository;
+import com.ticketingSystem.notification.dto.RoleNotificationChannelBatchUpdateRequest;
+import com.ticketingSystem.notification.dto.RoleNotificationChannelBatchUpdateResponse;
+import com.ticketingSystem.notification.dto.RoleNotificationChannelGridResponse;
+import com.ticketingSystem.notification.enums.ChannelType;
+import com.ticketingSystem.notification.models.NotificationMaster;
+import com.ticketingSystem.notification.models.RoleNotificationChannelMapping;
+import com.ticketingSystem.notification.repository.NotificationMasterRepository;
+import com.ticketingSystem.notification.repository.RoleNotificationChannelMappingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class RoleNotificationChannelMappingService {
+    private static final String DEFAULT_AUDITOR = "SYSTEM";
+
+    private final RoleRepository roleRepository;
+    private final NotificationMasterRepository notificationMasterRepository;
+    private final RoleNotificationChannelMappingRepository mappingRepository;
+
+    @Transactional(readOnly = true)
+    public RoleNotificationChannelGridResponse getGrid() {
+        List<RoleNotificationChannelGridResponse.RoleOption> roles = roleRepository.findByIsDeletedFalseOrderByRoleAsc()
+                .stream()
+                .map(role -> new RoleNotificationChannelGridResponse.RoleOption(role.getRoleId(), role.getRole()))
+                .toList();
+
+        List<RoleNotificationChannelGridResponse.NotificationOption> notifications = notificationMasterRepository
+                .findByIsActiveTrueOrderByNameAsc()
+                .stream()
+                .map(notification -> new RoleNotificationChannelGridResponse.NotificationOption(
+                        notification.getId(),
+                        notification.getName(),
+                        notification.getCode(),
+                        notification.getDescription()
+                ))
+                .toList();
+
+        Map<String, RoleNotificationChannelGridResponse.MappingState> mappingStates = new LinkedHashMap<>();
+        for (RoleNotificationChannelMapping mapping : mappingRepository.findGridMappings()) {
+            Integer roleId = mapping.getRole().getRoleId();
+            Integer notificationTypeId = mapping.getNotificationType().getId();
+            String key = key(roleId, notificationTypeId);
+            RoleNotificationChannelGridResponse.MappingState state = mappingStates.computeIfAbsent(
+                    key,
+                    ignored -> new RoleNotificationChannelGridResponse.MappingState(
+                            roleId,
+                            notificationTypeId,
+                            emptyChannelMap()
+                    )
+            );
+            state.getChannels().put(mapping.getChannelCode(), Boolean.TRUE.equals(mapping.getIsActive()));
+        }
+
+        List<RoleNotificationChannelGridResponse.MappingState> mappings = new ArrayList<>(mappingStates.values());
+        mappings.sort(Comparator
+                .comparing(RoleNotificationChannelGridResponse.MappingState::getNotificationTypeId)
+                .thenComparing(RoleNotificationChannelGridResponse.MappingState::getRoleId));
+
+        return new RoleNotificationChannelGridResponse(roles, notifications, mappings);
+    }
+
+    @Transactional
+    public RoleNotificationChannelBatchUpdateResponse batchUpdate(RoleNotificationChannelBatchUpdateRequest request) {
+        int updated = 0;
+        int created = 0;
+        String auditor = request.getUpdatedBy() == null || request.getUpdatedBy().isBlank()
+                ? DEFAULT_AUDITOR
+                : request.getUpdatedBy().trim();
+
+        for (RoleNotificationChannelBatchUpdateRequest.Item item : request.getItems()) {
+            RoleNotificationChannelMapping mapping = mappingRepository
+                    .findByRoleRoleIdAndNotificationTypeIdAndChannelCode(
+                            item.getRoleId(),
+                            item.getNotificationTypeId(),
+                            item.getChannelCode()
+                    )
+                    .orElse(null);
+
+            if (mapping == null) {
+                mapping = new RoleNotificationChannelMapping();
+                mapping.setRole(resolveRole(item.getRoleId()));
+                mapping.setNotificationType(resolveNotification(item.getNotificationTypeId()));
+                mapping.setChannelCode(item.getChannelCode());
+                mapping.setCreatedBy(auditor);
+                created++;
+            } else {
+                updated++;
+            }
+
+            mapping.setIsActive(Boolean.TRUE.equals(item.getIsActive()));
+            mapping.setUpdatedBy(auditor);
+            mappingRepository.save(mapping);
+        }
+
+        return new RoleNotificationChannelBatchUpdateResponse(updated, created);
+    }
+
+    private Role resolveRole(Integer roleId) {
+        Role role = roleRepository.findById(roleId)
+                .orElseThrow(() -> new ResourceNotFoundException("Role", roleId));
+        if (role.isDeleted()) {
+            throw new ResourceNotFoundException("Role", roleId);
+        }
+        return role;
+    }
+
+    private NotificationMaster resolveNotification(Integer notificationTypeId) {
+        NotificationMaster notification = notificationMasterRepository.findById(notificationTypeId)
+                .orElseThrow(() -> new ResourceNotFoundException("NotificationMaster", notificationTypeId));
+        if (!Boolean.TRUE.equals(notification.getIsActive())) {
+            throw new ResourceNotFoundException("NotificationMaster", notificationTypeId);
+        }
+        return notification;
+    }
+
+    private Map<ChannelType, Boolean> emptyChannelMap() {
+        Map<ChannelType, Boolean> channels = new EnumMap<>(ChannelType.class);
+        for (ChannelType channelType : ChannelType.values()) {
+            channels.put(channelType, Boolean.FALSE);
+        }
+        return channels;
+    }
+
+    private String key(Integer roleId, Integer notificationTypeId) {
+        return roleId + ":" + notificationTypeId;
+    }
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -17,6 +17,7 @@ const CategoriesMaster = lazy(() => import('./pages/CategoriesMaster'));
 const EscalationMaster = lazy(() => import('./pages/EscalationMaster'));
 const RoleMaster = lazy(() => import('./pages/RoleMaster'));
 const RoleDetails = lazy(() => import('./pages/RoleDetails'));
+const RoleNotification = lazy(() => import('./pages/RoleNotification'));
 const Login = lazy(() => import('./pages/Login'));
 const DevLogin = lazy(() => import('./pages/DevLogin'));
 const Users = lazy(() => import('./pages/Users'));
@@ -109,6 +110,7 @@ function App() {
           <Route path="modules-master" element={<CategoriesMaster />} />
           <Route path="escalation-master" element={<EscalationMaster />} />
           <Route path="role-master" element={<RoleMaster />} />
+          <Route path="role-master/notifications" element={<RoleNotification />} />
           <Route path="role-master/:roleId" element={<RoleDetails />} />
           <Route path="users" element={<Users />} />
           <Route path="users/:type/:userId" element={<UserProfile />} />

--- a/ui/src/hooks/usePageTitle.ts
+++ b/ui/src/hooks/usePageTitle.ts
@@ -26,6 +26,7 @@ const ROUTE_TITLES: RouteTitle[] = [
   { path: '/calendar', title: 'Calendar' },
   { path: '/categories-master', title: 'Categories Master' },
   { path: '/escalation-master', title: 'Escalation Master' },
+  { path: '/role-master/notifications', title: 'Role - Notification' },
   { path: '/role-master/:roleId', title: 'Role Details' },
   { path: '/role-master', title: 'Role Master' },
   { path: '/users/new', title: 'Add New User' },

--- a/ui/src/pages/RoleMaster.tsx
+++ b/ui/src/pages/RoleMaster.tsx
@@ -107,7 +107,10 @@ const RoleMaster: React.FC = () => {
         <div className="">
             <Title textKey="Role Master" />
             <div className="d-flex justify-content-between mb-3">
-                {!creating && <Button variant="contained" onClick={handleCreate}>Create Role</Button>}
+                <div className="d-flex gap-2">
+                    {!creating && <Button variant="contained" onClick={handleCreate}>Create Role</Button>}
+                    {!creating && <Button variant="outlined" onClick={() => navigate('/role-master/notifications')}>Role - Notification</Button>}
+                </div>
                 <ViewToggle value={view} onChange={setView} options={[{ icon: 'grid', value: 'grid' }, { icon: 'table', value: 'table' }]} />
             </div>
             {creating && (

--- a/ui/src/pages/RoleNotification.tsx
+++ b/ui/src/pages/RoleNotification.tsx
@@ -1,0 +1,361 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+    Alert,
+    Box,
+    Button,
+    Chip,
+    CircularProgress,
+    IconButton,
+    Paper,
+    Stack,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    TextField,
+    Tooltip,
+    Typography,
+} from '@mui/material';
+import EmailIcon from '@mui/icons-material/Email';
+import NotificationsIcon from '@mui/icons-material/Notifications';
+import SmsIcon from '@mui/icons-material/Sms';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import Title from '../components/Title';
+import { useApi } from '../hooks/useApi';
+import {
+    getRoleNotificationChannelGrid,
+    NotificationChannel,
+    RoleNotificationGridResponse,
+    RoleNotificationMappingState,
+    RoleNotificationRole,
+    RoleNotificationType,
+    updateRoleNotificationChannels,
+} from '../services/RoleNotificationChannelService';
+import { getUserDetails } from '../utils/Utils';
+import { useSnackbar } from '../context/SnackbarContext';
+import { useNavigate } from 'react-router-dom';
+
+const CHANNELS: NotificationChannel[] = ['EMAIL', 'IN_APP', 'SMS'];
+
+const CHANNEL_LABELS: Record<NotificationChannel, string> = {
+    EMAIL: 'Email',
+    IN_APP: 'In App',
+    SMS: 'SMS',
+};
+
+const channelIcon = (channel: NotificationChannel) => {
+    if (channel === 'EMAIL') return <EmailIcon fontSize="small" />;
+    if (channel === 'IN_APP') return <NotificationsIcon fontSize="small" />;
+    return <SmsIcon fontSize="small" />;
+};
+
+const keyFor = (roleId: number, notificationTypeId: number, channel: NotificationChannel) => (
+    `${roleId}:${notificationTypeId}:${channel}`
+);
+
+
+const buildState = (grid?: RoleNotificationGridResponse | null): Record<string, boolean> => {
+    const state: Record<string, boolean> = {};
+    if (!grid) return state;
+
+    grid.notifications.forEach((notification) => {
+        grid.roles.forEach((role) => {
+            CHANNELS.forEach((channel) => {
+                state[keyFor(role.roleId, notification.notificationTypeId, channel)] = false;
+            });
+        });
+    });
+
+    grid.mappings.forEach((mapping: RoleNotificationMappingState) => {
+        CHANNELS.forEach((channel) => {
+            state[keyFor(mapping.roleId, mapping.notificationTypeId, channel)] = Boolean(mapping.channels?.[channel]);
+        });
+    });
+
+    return state;
+};
+
+const RoleNotification: React.FC = () => {
+    const navigate = useNavigate();
+    const { showMessage } = useSnackbar();
+    const { data: gridData, pending, apiHandler } = useApi<RoleNotificationGridResponse>();
+    const { pending: saving, apiHandler: saveApiHandler } = useApi<any>();
+
+    const [currentState, setCurrentState] = useState<Record<string, boolean>>({});
+    const [originalState, setOriginalState] = useState<Record<string, boolean>>({});
+    const [roleFilter, setRoleFilter] = useState('');
+    const [notificationFilter, setNotificationFilter] = useState('');
+
+    const loadGrid = () => {
+        apiHandler(() => getRoleNotificationChannelGrid());
+    };
+
+    useEffect(() => {
+        loadGrid();
+    }, []);
+
+    useEffect(() => {
+        const initial = buildState(gridData);
+        setOriginalState(initial);
+        setCurrentState(initial);
+    }, [gridData]);
+
+    const dirtyKeys = useMemo(() => (
+        Object.keys(currentState).filter((key) => currentState[key] !== originalState[key])
+    ), [currentState, originalState]);
+
+    const hasUnsavedChanges = dirtyKeys.length > 0;
+
+    useEffect(() => {
+        const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+            if (!hasUnsavedChanges) return;
+            event.preventDefault();
+            event.returnValue = '';
+        };
+
+        window.addEventListener('beforeunload', handleBeforeUnload);
+        return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+    }, [hasUnsavedChanges]);
+
+    const filteredRoles = useMemo(() => {
+        const query = roleFilter.trim().toLowerCase();
+        const roles = gridData?.roles ?? [];
+        if (!query) return roles;
+        return roles.filter((role) => role.role.toLowerCase().includes(query));
+    }, [gridData?.roles, roleFilter]);
+
+    const filteredNotifications = useMemo(() => {
+        const query = notificationFilter.trim().toLowerCase();
+        const notifications = gridData?.notifications ?? [];
+        if (!query) return notifications;
+        return notifications.filter((notification) => (
+            notification.name.toLowerCase().includes(query)
+            || notification.code?.toLowerCase().includes(query)
+            || notification.description?.toLowerCase().includes(query)
+        ));
+    }, [gridData?.notifications, notificationFilter]);
+
+    const toggleChannel = (roleId: number, notificationTypeId: number, channel: NotificationChannel) => {
+        const key = keyFor(roleId, notificationTypeId, channel);
+        setCurrentState((prev) => ({ ...prev, [key]: !prev[key] }));
+    };
+
+    const setVisibleChannels = (active: boolean) => {
+        setCurrentState((prev) => {
+            const next = { ...prev };
+            filteredNotifications.forEach((notification) => {
+                filteredRoles.forEach((role) => {
+                    CHANNELS.forEach((channel) => {
+                        next[keyFor(role.roleId, notification.notificationTypeId, channel)] = active;
+                    });
+                });
+            });
+            return next;
+        });
+    };
+
+    const resetChanges = () => {
+        setCurrentState(originalState);
+    };
+
+    const saveChanges = async () => {
+        if (!gridData || dirtyKeys.length === 0) {
+            showMessage('No notification channel changes to save.', 'info');
+            return;
+        }
+
+        const items = dirtyKeys.map((key) => {
+            const [roleId, notificationTypeId, channelCode] = key.split(':');
+            return {
+                roleId: Number(roleId),
+                notificationTypeId: Number(notificationTypeId),
+                channelCode: channelCode as NotificationChannel,
+                isActive: currentState[key],
+            };
+        });
+
+        const result = await saveApiHandler(() => updateRoleNotificationChannels({
+            updatedBy: getUserDetails()?.username || getUserDetails()?.userId || 'SYSTEM',
+            items,
+        }));
+        if (!result) return;
+        showMessage('Role notification channels saved successfully.', 'success');
+        setOriginalState(currentState);
+        loadGrid();
+    };
+
+    const handleBack = () => {
+        if (hasUnsavedChanges && !window.confirm('You have unsaved changes. Leave without saving?')) {
+            return;
+        }
+        navigate('/role-master');
+    };
+
+    const renderCell = (role: RoleNotificationRole, notification: RoleNotificationType) => (
+        <Stack direction="row" spacing={0.5} justifyContent="center" sx={{ minWidth: 120 }}>
+            {CHANNELS.map((channel) => {
+                const stateKey = keyFor(role.roleId, notification.notificationTypeId, channel);
+                const active = Boolean(currentState[stateKey]);
+                const changed = currentState[stateKey] !== originalState[stateKey];
+                return (
+                    <Tooltip
+                        key={channel}
+                        title={`${CHANNEL_LABELS[channel]} ${active ? 'active' : 'inactive'}${changed ? ' (unsaved)' : ''}`}
+                    >
+                        <IconButton
+                            aria-label={`${role.role} ${notification.name} ${CHANNEL_LABELS[channel]} ${active ? 'active' : 'inactive'}`}
+                            size="small"
+                            color={active ? 'primary' : 'default'}
+                            onClick={() => toggleChannel(role.roleId, notification.notificationTypeId, channel)}
+                            sx={{
+                                border: '1px solid',
+                                borderColor: changed ? 'warning.main' : active ? 'primary.main' : 'divider',
+                                backgroundColor: active ? 'primary.50' : 'transparent',
+                                opacity: active ? 1 : 0.55,
+                                '&:hover': {
+                                    backgroundColor: active ? 'primary.100' : 'action.hover',
+                                },
+                            }}
+                        >
+                            {channelIcon(channel)}
+                        </IconButton>
+                    </Tooltip>
+                );
+            })}
+        </Stack>
+    );
+
+    return (
+        <div>
+            <Title
+                text="Role - Notification"
+                rightContent={(
+                    <Button startIcon={<ArrowBackIcon />} variant="outlined" onClick={handleBack}>
+                        Back to Role Master
+                    </Button>
+                )}
+            />
+
+            <Paper sx={{ p: 2, mb: 2 }}>
+                <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} alignItems={{ xs: 'stretch', md: 'center' }}>
+                    <TextField
+                        label="Search roles"
+                        value={roleFilter}
+                        onChange={(event) => setRoleFilter(event.target.value)}
+                        size="small"
+                    />
+                    <TextField
+                        label="Search notifications"
+                        value={notificationFilter}
+                        onChange={(event) => setNotificationFilter(event.target.value)}
+                        size="small"
+                    />
+                    <Box sx={{ flex: 1 }} />
+                    <Button variant="outlined" onClick={() => setVisibleChannels(true)} disabled={!filteredRoles.length || !filteredNotifications.length}>
+                        Enable visible
+                    </Button>
+                    <Button variant="outlined" color="warning" onClick={() => setVisibleChannels(false)} disabled={!filteredRoles.length || !filteredNotifications.length}>
+                        Disable visible
+                    </Button>
+                    <Button variant="outlined" onClick={resetChanges} disabled={!hasUnsavedChanges}>
+                        Reset Changes
+                    </Button>
+                </Stack>
+                <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 2, flexWrap: 'wrap', gap: 1 }}>
+                    <Chip label={`${gridData?.roles?.length ?? 0} roles`} size="small" />
+                    <Chip label={`${gridData?.notifications?.length ?? 0} notifications`} size="small" />
+                    <Chip
+                        label={`${dirtyKeys.length} unsaved changes`}
+                        size="small"
+                        color={hasUnsavedChanges ? 'warning' : 'default'}
+                    />
+                    <Typography variant="body2" color="text.secondary">
+                        Icon clicks are local only. Click Save to persist changed EMAIL, IN_APP, and SMS mappings.
+                    </Typography>
+                </Stack>
+            </Paper>
+
+            {pending && (
+                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', py: 5 }}>
+                    <CircularProgress size={28} />
+                    <Typography sx={{ ml: 2 }}>Loading role notification mappings...</Typography>
+                </Box>
+            )}
+
+            {!pending && (!gridData?.roles?.length || !gridData?.notifications?.length) && (
+                <Alert severity="info">
+                    Roles or active notification types are not available. Please add roles and notification master entries first.
+                </Alert>
+            )}
+
+            {!pending && Boolean(gridData?.roles?.length) && Boolean(gridData?.notifications?.length) && (
+                <TableContainer component={Paper} sx={{ maxHeight: '65vh', overflow: 'auto' }}>
+                    <Table stickyHeader size="small" aria-label="Role notification channel mapping grid">
+                        <TableHead>
+                            <TableRow>
+                                <TableCell
+                                    sx={{
+                                        position: 'sticky',
+                                        left: 0,
+                                        zIndex: 4,
+                                        minWidth: 260,
+                                        backgroundColor: 'background.paper',
+                                        fontWeight: 700,
+                                    }}
+                                >
+                                    Notification Type
+                                </TableCell>
+                                {filteredRoles.map((role) => (
+                                    <TableCell key={role.roleId} align="center" sx={{ minWidth: 150, fontWeight: 700 }}>
+                                        {role.role}
+                                    </TableCell>
+                                ))}
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {filteredNotifications.map((notification) => (
+                                <TableRow key={notification.notificationTypeId} hover>
+                                    <TableCell
+                                        component="th"
+                                        scope="row"
+                                        sx={{
+                                            position: 'sticky',
+                                            left: 0,
+                                            zIndex: 2,
+                                            backgroundColor: 'background.paper',
+                                            minWidth: 260,
+                                            boxShadow: '2px 0 4px rgba(0,0,0,0.04)',
+                                        }}
+                                    >
+                                        <Typography variant="body2" fontWeight={600}>{notification.name}</Typography>
+                                        {notification.code && <Typography variant="caption" color="text.secondary">{notification.code}</Typography>}
+                                    </TableCell>
+                                    {filteredRoles.map((role) => (
+                                        <TableCell key={`${notification.notificationTypeId}-${role.roleId}`} align="center">
+                                            {renderCell(role, notification)}
+                                        </TableCell>
+                                    ))}
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+            )}
+
+            <Stack direction="row" justifyContent="flex-end" spacing={2} sx={{ mt: 2 }}>
+                <Button variant="outlined" onClick={handleBack}>Cancel</Button>
+                <Button
+                    variant="contained"
+                    onClick={saveChanges}
+                    disabled={saving || !hasUnsavedChanges}
+                >
+                    {saving ? 'Saving...' : 'Save'}
+                </Button>
+            </Stack>
+        </div>
+    );
+};
+
+export default RoleNotification;

--- a/ui/src/pages/__tests__/RoleMaster.test.tsx
+++ b/ui/src/pages/__tests__/RoleMaster.test.tsx
@@ -76,13 +76,11 @@ jest.mock('../CreateRole', () => ({
   ),
 }));
 
-jest.mock('react-router-dom', () => ({
-  useNavigate: jest.fn(),
-}));
+const mockNavigate = jest.fn();
 
-const navigateMock = jest.fn();
-const useNavigateMock = jest.requireMock('react-router-dom').useNavigate as jest.Mock;
-useNavigateMock.mockReturnValue(navigateMock);
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
 
 import RoleMaster from '../RoleMaster';
 
@@ -99,7 +97,7 @@ describe('RoleMaster', () => {
     mockGetStatusActions.mockClear();
     mockGetParameters.mockClear();
     capturedTableProps = null;
-    navigateMock.mockClear();
+    mockNavigate.mockClear();
     window.confirm = jest.fn(() => true);
     mockUseApi.mockReset();
 
@@ -154,6 +152,17 @@ describe('RoleMaster', () => {
       expect(mockAddRole).toHaveBeenCalledWith({ role: 'NewRole' });
       expect(mockGetAllRoles).toHaveBeenCalledTimes(2);
     });
+  });
+
+
+  it('opens role notification mapping page from the toolbar', async () => {
+    const { getByText } = renderWithTheme(<RoleMaster />);
+
+    await act(async () => {
+      fireEvent.click(getByText('Role - Notification'));
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('/role-master/notifications');
   });
 
   it('deletes selected roles', async () => {

--- a/ui/src/pages/__tests__/RoleNotification.test.tsx
+++ b/ui/src/pages/__tests__/RoleNotification.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { renderWithTheme } from '../../test/testUtils';
+
+const mockGetGrid = jest.fn();
+const mockUpdateChannels = jest.fn();
+const mockNavigate = jest.fn();
+const mockShowMessage = jest.fn();
+
+jest.mock('../../services/RoleNotificationChannelService', () => ({
+  getRoleNotificationChannelGrid: () => mockGetGrid(),
+  updateRoleNotificationChannels: (...args: unknown[]) => mockUpdateChannels(...args),
+}));
+
+jest.mock('../../context/SnackbarContext', () => ({
+  useSnackbar: () => ({ showMessage: mockShowMessage }),
+}));
+
+jest.mock('../../utils/Utils', () => ({
+  getUserDetails: () => ({ username: 'tester', userId: 'tester-id' }),
+}));
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+import RoleNotification from '../RoleNotification';
+
+const gridResponse = {
+  roles: [{ roleId: 1, role: 'Admin' }],
+  notifications: [{ notificationTypeId: 10, name: 'Ticket Assigned', code: 'TICKET_ASSIGNED' }],
+  mappings: [
+    {
+      roleId: 1,
+      notificationTypeId: 10,
+      channels: { EMAIL: true, IN_APP: false, SMS: false },
+    },
+  ],
+};
+
+describe('RoleNotification', () => {
+  beforeEach(() => {
+    mockGetGrid.mockReset();
+    mockUpdateChannels.mockReset();
+    mockNavigate.mockClear();
+    mockShowMessage.mockClear();
+    mockGetGrid.mockResolvedValue({ data: { success: true, data: gridResponse } });
+    mockUpdateChannels.mockResolvedValue({ data: { success: true, data: { updated: 1, created: 0 } } });
+  });
+
+  it('renders role-notification grid and saves only changed channel toggles', async () => {
+    renderWithTheme(<RoleNotification />);
+
+    expect(await screen.findByText('Ticket Assigned')).toBeInTheDocument();
+    expect(screen.getByText('Admin')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Admin Ticket Assigned Email active'));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(mockUpdateChannels).toHaveBeenCalledWith({
+        updatedBy: 'tester',
+        items: [
+          {
+            roleId: 1,
+            notificationTypeId: 10,
+            channelCode: 'EMAIL',
+            isActive: false,
+          },
+        ],
+      });
+    });
+  });
+});

--- a/ui/src/services/RoleNotificationChannelService.ts
+++ b/ui/src/services/RoleNotificationChannelService.ts
@@ -1,0 +1,48 @@
+import axios from "axios";
+import { BASE_URL } from "./api";
+
+export type NotificationChannel = 'EMAIL' | 'IN_APP' | 'SMS';
+
+export interface RoleNotificationRole {
+    roleId: number;
+    role: string;
+}
+
+export interface RoleNotificationType {
+    notificationTypeId: number;
+    name: string;
+    code?: string;
+    description?: string;
+}
+
+export interface RoleNotificationMappingState {
+    roleId: number;
+    notificationTypeId: number;
+    channels: Record<NotificationChannel, boolean>;
+}
+
+export interface RoleNotificationGridResponse {
+    roles: RoleNotificationRole[];
+    notifications: RoleNotificationType[];
+    mappings: RoleNotificationMappingState[];
+}
+
+export interface RoleNotificationBatchUpdateItem {
+    roleId: number;
+    notificationTypeId: number;
+    channelCode: NotificationChannel;
+    isActive: boolean;
+}
+
+export interface RoleNotificationBatchUpdateRequest {
+    updatedBy?: string;
+    items: RoleNotificationBatchUpdateItem[];
+}
+
+export function getRoleNotificationChannelGrid() {
+    return axios.get(`${BASE_URL}/role-notification-channel-mappings`);
+}
+
+export function updateRoleNotificationChannels(body: RoleNotificationBatchUpdateRequest) {
+    return axios.put(`${BASE_URL}/role-notification-channel-mappings/batch`, body);
+}


### PR DESCRIPTION
### Motivation
- Provide administrators the ability to view and manage notification channel mappings per role and notification type in a grid and persist bulk changes.
- Expose API endpoints to retrieve the grid and perform batch upserts for channel mappings.
- Integrate the feature into the UI with a dedicated page and navigation from `RoleMaster` to allow interactive toggling and saving of channels.

### Description
- Added backend controller `RoleNotificationChannelMappingController` and DTOs `RoleNotificationChannelGridResponse`, `RoleNotificationChannelBatchUpdateRequest`, and `RoleNotificationChannelBatchUpdateResponse` to expose the new endpoints at `/role-notification-channel-mappings` and `/role-notification-channel-mappings/batch`.
- Implemented `RoleNotificationChannelMappingService` which provides `getGrid()` to assemble roles, notification types and mapping states, and `batchUpdate()` to upsert mapping rows (with role/notification resolution and auditing); extended repositories with `findGridMappings()`, `findByRoleRoleIdAndNotificationTypeIdAndChannelCode()` and `findByIsActiveTrueOrderByNameAsc()`; added a unique constraint to the `RoleNotificationChannelMapping` entity.
- Frontend changes include a new `RoleNotification` page, client service `RoleNotificationChannelService` (`getRoleNotificationChannelGrid` and `updateRoleNotificationChannels`), a route and page title entry (`/role-master/notifications`), and a navigation button in `RoleMaster` to open the page.
- Added and updated unit tests: new `RoleNotification.test.tsx` to validate grid rendering and save behavior and adjustments to `RoleMaster.test.tsx` to assert navigation to the notifications page.

### Testing
- Ran frontend unit tests with Jest (`npm test`) including `RoleMaster.test.tsx` and `RoleNotification.test.tsx`, and they passed.
- Built the UI (`npm run build`) to ensure TypeScript/React compilation succeeded with the new page and service code.
- Compiled the backend to verify new Java sources and JPA mappings compile cleanly with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2948601e94833287e3c2f766792a23)